### PR TITLE
fix set load time

### DIFF
--- a/src/adapters/http/views/cardPrintings.hbs
+++ b/src/adapters/http/views/cardPrintings.hbs
@@ -19,7 +19,7 @@
 </div>
 <table id="all-printings-card-listing">
     <tbody>
-    {{#each this.cards}}
+        {{#each this.cards}}
         <tr>
             <td class="card-printing-owned">
                 {{>cardsOwned}}
@@ -37,6 +37,7 @@
                 <p>{{this.price}}</p>
             </td>
         </tr>
-    {{/each}}
+        {{/each}}
     </tbody>
-</table>    
+</table>
+<script src="/public/js/updateInventory.js" defer></script>

--- a/src/adapters/http/views/inventory.hbs
+++ b/src/adapters/http/views/inventory.hbs
@@ -5,7 +5,7 @@
             <p class="user-inventory-metadata-heading">Value</p>
             <p class="user-inventory-metadata-data">{{this.value}}</p>
         </div>
-   </section>
+    </section>
 
     <table id="user-inventory-cards">
         <thead>
@@ -17,7 +17,7 @@
             </tr>
         </thead>
         <tbody>
-        {{#each cards}}
+            {{#each cards}}
             <tr>
                 <td>{{>cardsOwned card=this}}</td>
                 <td>
@@ -30,7 +30,8 @@
                 </td>
                 <td>{{#if this.price}}{{this.price}}{{else}}0{{/if}}</td>
             </tr>
-        {{/each}}
+            {{/each}}
         </tbody>
     </table>
 </div>
+<script src="/public/js/updateInventory.js" defer></script>

--- a/src/adapters/http/views/partials/cardInfo.hbs
+++ b/src/adapters/http/views/partials/cardInfo.hbs
@@ -1,5 +1,5 @@
 <div id="card-image">
-    <img src="{{card.imgSrc}}" alt="{{card.name}} - ({{card.setCode}})"/>
+    <img src="{{card.imgSrc}}" alt="{{card.name}} - ({{card.setCode}})" />
 </div>
 
 <div id="card-identity">
@@ -22,10 +22,10 @@
     <p class="card-number">{{card.number}}</p>
     <table class="card-legalities">
         <tbody>
-        {{!-- TODO: hard code each format? I.e.: 
+            {{!-- TODO: hard code each format? I.e.:
             <td>Standard</td>
             <td>{{card.standard}}</td>
-        etc --}}
+            etc --}}
             {{#each card.legalities}}
             <tr>
                 <td>{{card.key}}</td>
@@ -46,19 +46,20 @@
         <h4 id="card-other-printings-title">Other Printings</h4>
         <table>
             <tbody>
-            {{#each card.otherPrintings}}
+                {{#each card.otherPrintings}}
                 <tr>
                     <td class="set-icon"><i class="ss ss-{{card.setCode}}"></i></td>
                     <td class="other-printing-url"><a href="{{card.url}}">{{card.set.name}}</a></td>
                     <td class="other-differentiators">
-                    {{#each card.differentiators}}
+                        {{#each card.differentiators}}
                         <span class="differentiators-description">{{card.description}}</span>
-                    {{/each}}
+                        {{/each}}
                     </td>
                     <td class="other-printing-price">{{card.price}}</td>
                 </tr>
-            {{/each}}
+                {{/each}}
             </tbody>
         </table>
     </div>
 </div>
+<script src="/public/js/updateInventory.js" defer></script>

--- a/src/adapters/http/views/partials/cardsOwned.hbs
+++ b/src/adapters/http/views/partials/cardsOwned.hbs
@@ -7,4 +7,3 @@
         data-id="{{card.id}}" />
     <button type="button" class="decrement-quantity">-</button>
 </form>
-<script src="/public/js/updateInventory.js" defer></script>

--- a/src/adapters/http/views/partials/setCards.hbs
+++ b/src/adapters/http/views/partials/setCards.hbs
@@ -8,7 +8,7 @@
         <th>Price</th>
     </thead>
     <tbody>
-    {{#each set.cards}}
+        {{#each set.cards}}
         <tr class="card-set-card">
             <td class="card-set-card-owned">
                 {{>cardsOwned card=this}}
@@ -23,6 +23,7 @@
             <td class="card-set-card-rarity">{{this.rarity}}</td>
             <td class="card-set-card-price">${{#if this.price}}{{this.price}}{{else}}0.00{{/if}}</td>
         </tr>
-    {{/each}}
+        {{/each}}
     </tbody>
 </table>
+<script src="/public/js/updateInventory.js" defer></script>

--- a/test/http/views/cardPrintings.hbs
+++ b/test/http/views/cardPrintings.hbs
@@ -19,7 +19,7 @@
 </div>
 <table id="all-printings-card-listing">
     <tbody>
-    {{#each this.cards}}
+        {{#each this.cards}}
         <tr>
             <td class="card-printing-owned">
                 {{>cardsOwned}}
@@ -37,6 +37,7 @@
                 <p>{{this.price}}</p>
             </td>
         </tr>
-    {{/each}}
+        {{/each}}
     </tbody>
-</table>    
+</table>
+<script src="/public/js/updateInventory.js" defer></script>

--- a/test/http/views/inventory.hbs
+++ b/test/http/views/inventory.hbs
@@ -5,7 +5,7 @@
             <p class="user-inventory-metadata-heading">Value</p>
             <p class="user-inventory-metadata-data">{{this.value}}</p>
         </div>
-   </section>
+    </section>
 
     <table id="user-inventory-cards">
         <thead>
@@ -17,7 +17,7 @@
             </tr>
         </thead>
         <tbody>
-        {{#each cards}}
+            {{#each cards}}
             <tr>
                 <td>{{>cardsOwned card=this}}</td>
                 <td>
@@ -30,7 +30,8 @@
                 </td>
                 <td>{{#if this.price}}{{this.price}}{{else}}0{{/if}}</td>
             </tr>
-        {{/each}}
+            {{/each}}
         </tbody>
     </table>
 </div>
+<script src="/public/js/updateInventory.js" defer></script>

--- a/test/http/views/partials/cardInfo.hbs
+++ b/test/http/views/partials/cardInfo.hbs
@@ -1,5 +1,5 @@
 <div id="card-image">
-    <img src="{{card.imgSrc}}" alt="{{card.name}} - ({{card.setCode}})"/>
+    <img src="{{card.imgSrc}}" alt="{{card.name}} - ({{card.setCode}})" />
 </div>
 
 <div id="card-identity">
@@ -22,10 +22,10 @@
     <p class="card-number">{{card.number}}</p>
     <table class="card-legalities">
         <tbody>
-        {{!-- TODO: hard code each format? I.e.: 
+            {{!-- TODO: hard code each format? I.e.:
             <td>Standard</td>
             <td>{{card.standard}}</td>
-        etc --}}
+            etc --}}
             {{#each card.legalities}}
             <tr>
                 <td>{{card.key}}</td>
@@ -46,19 +46,20 @@
         <h4 id="card-other-printings-title">Other Printings</h4>
         <table>
             <tbody>
-            {{#each card.otherPrintings}}
+                {{#each card.otherPrintings}}
                 <tr>
                     <td class="set-icon"><i class="ss ss-{{card.setCode}}"></i></td>
                     <td class="other-printing-url"><a href="{{card.url}}">{{card.set.name}}</a></td>
                     <td class="other-differentiators">
-                    {{#each card.differentiators}}
+                        {{#each card.differentiators}}
                         <span class="differentiators-description">{{card.description}}</span>
-                    {{/each}}
+                        {{/each}}
                     </td>
                     <td class="other-printing-price">{{card.price}}</td>
                 </tr>
-            {{/each}}
+                {{/each}}
             </tbody>
         </table>
     </div>
 </div>
+<script src="/public/js/updateInventory.js" defer></script>

--- a/test/http/views/partials/cardsOwned.hbs
+++ b/test/http/views/partials/cardsOwned.hbs
@@ -7,4 +7,3 @@
         data-id="{{card.id}}" />
     <button type="button" class="decrement-quantity">-</button>
 </form>
-<script src="/public/js/updateInventory.js" defer></script>

--- a/test/http/views/partials/setCards.hbs
+++ b/test/http/views/partials/setCards.hbs
@@ -8,7 +8,7 @@
         <th>Price</th>
     </thead>
     <tbody>
-    {{#each set.cards}}
+        {{#each set.cards}}
         <tr class="card-set-card">
             <td class="card-set-card-owned">
                 {{>cardsOwned card=this}}
@@ -23,6 +23,7 @@
             <td class="card-set-card-rarity">{{this.rarity}}</td>
             <td class="card-set-card-price">${{#if this.price}}{{this.price}}{{else}}0.00{{/if}}</td>
         </tr>
-    {{/each}}
+        {{/each}}
     </tbody>
 </table>
+<script src="/public/js/updateInventory.js" defer></script>


### PR DESCRIPTION
updateInventory.js was getting loaded for every card loaded on page due to inclusion in partial hbs template, cardsOwned. Move outside to container of cardsOwned decreased total load time by a factor of approximately 10.