### PR TITLE
Update ROADMAP and MCP handoff for 0.1.0 + 0.2.0 milestones

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -718,8 +718,8 @@ Server lives in a separate repo at [`iwantmymtg-mcp`](https://github.com/matthew
 - [x] Surface rate-limit responses: `ApiError` captures `X-RateLimit-Limit/Remaining/Reset` headers and surfaces them in tool error responses
 - [x] `IWMM_BASE_URL` env var (default `https://iwantmymtg.net`) for self-hosters / local dev
 - [ ] Generate typed API client from `/api/openapi.json` at build time (e.g. `openapi-typescript` + `openapi-fetch`) so tool schemas stay in lockstep with the API — currently zod schemas are hand-maintained per tool, which works but will drift
-- [ ] Surface premium-gating cleanly: when API returns 402/403 with upgrade message, return that message verbatim to the model so it can relay to the user (today the body is surfaced raw via `ApiError`; verify it reads cleanly to a model and isn't swallowed as a generic error)
-- [ ] Unit tests for each tool (mock fetch); integration test that boots the server against a recorded API fixture — `test/` dir exists but is empty
+- [x] Surface premium-gating cleanly: `formatApiError` (in `src/error-formatter.ts`) parses JSON error bodies, returns a clean upgrade prompt with `/pricing` link for 402/403, an API-key setup hint for 401, and reset-time info for 429
+- [x] Unit tests for each tool (45 tests on `node:test` covering `apiFetch` auth/query/error handling and one happy-path test per registered tool)
 
 #### Web app prereqs (this repo)
 
@@ -731,10 +731,10 @@ Server lives in a separate repo at [`iwantmymtg-mcp`](https://github.com/matthew
 #### Distribution
 
 - [x] README with: install, Claude Desktop config snippet, Claude Code `.mcp.json` snippet, example prompts
-- [ ] Publish to npm as `iwantmymtg-mcp` — runnable via `npx iwantmymtg-mcp` (name confirmed available on registry; not yet published)
-- [ ] Add `examples/` dir with screenshots/transcripts of common flows
-- [ ] CI: build + test + publish on tag (mirror Scry's release workflow) — no `.github/workflows` yet
-- [ ] Cursor config snippet in README (currently only Claude Desktop + Claude Code documented)
+- [x] Publish to npm as `iwantmymtg-mcp` — runnable via `npx iwantmymtg-mcp` (v0.1.0 published via Trusted Publishing/OIDC)
+- [x] Add `examples/` dir with prompt walkthroughs of common flows (card lookup, inventory, transactions, portfolio, price alerts, sealed products); screenshots/transcripts to be added as captured
+- [x] CI: build + test on push/PR; publish on tag via Trusted Publishing (`.github/workflows/ci.yml` + `publish.yml`, gated to tags reachable from main)
+- [x] Cursor config snippet in README
 
 #### Discovery
 

--- a/docs/mcp-rollout-handoff.md
+++ b/docs/mcp-rollout-handoff.md
@@ -54,26 +54,43 @@ Branch is pushed; PR not opened yet.
 
 Branch pushed; PR not opened yet.
 
+## Done (continued)
+
+### npm publish - `iwantmymtg-mcp@0.1.0`
+
+- Published via Trusted Publishing (OIDC) - no long-lived `NPM_TOKEN` secret;
+  GitHub Actions identity is configured as a trusted publisher on the npm
+  package.
+- Workflow bumped to Node 24 (npm 11 ships natively, required by trusted
+  publishing).
+- Publish workflow gated to tags reachable from `main` - feature-branch
+  tags fail fast with an actionable message instead of publishing.
+- `dist-tags.latest = 0.1.0`; published by `npm-oidc-no-reply@github.com`.
+
+### `0.2.0` UX pass - branch `mcp-examples-and-gating-ux` in `iwantmymtg-mcp`
+
+- `src/error-formatter.ts` parses NestJS-style JSON error bodies and
+  surfaces clean LLM-facing messages: API-key setup hint for 401, upgrade
+  prompt with `/pricing` link for 402/403, reset-time note for 429.
+- Cursor config snippet added to README.
+- `examples/` dir scaffolded: README index plus per-flow walkthroughs
+  (card lookup, inventory, transactions, portfolio, price alerts, sealed
+  products). Screenshots/real transcripts still to be captured.
+- 13 new tests for the error formatter; 58 tests total, all passing.
+- Bumped to `0.2.0` (User-Agent + package + MCP server version).
+
+PR not opened yet; merge -> tag `v0.2.0` -> publish workflow handles npm.
+
 ## Next up (in order)
 
-1. **Review + merge** `mcp-web-prereqs` (this repo) and `mcp-tests-ci` (mcp
-   repo). Each is a small, self-contained PR.
-2. **npm publish** as `iwantmymtg-mcp@0.1.0`. Name is free on the registry.
-   Add `NPM_TOKEN` to the repo secrets, bump `package.json` version, tag
-   `v0.1.0`, push the tag - the publish workflow handles the rest.
-3. **examples/ dir** - screenshots/transcripts of common flows for the
-   README.
-4. **Cursor config snippet** in README (only Claude Desktop + Claude Code
-   documented today).
-5. **Premium-gating UX check** - verify 402/403 API responses surface
-   cleanly through `ApiError.message` so the LLM relays the upgrade prompt
-   verbatim. May need a thin wrapper in `api-client.ts`.
-6. **Typed API client from OpenAPI** - currently hand-rolled zod schemas;
+1. **Capture real screenshots/transcripts** in `examples/` once you've
+   exercised the flows in Claude Desktop / Cursor / Claude Code.
+2. **Typed API client from OpenAPI** - currently hand-rolled zod schemas;
    will drift. Generate at build time with `openapi-typescript` +
    `openapi-fetch`.
-7. **Discovery** - PR to `modelcontextprotocol/servers`, list on Smithery
+3. **Discovery** - PR to `modelcontextprotocol/servers`, list on Smithery
    and Glama, post on r/ClaudeAI + r/mtgfinance.
-8. **Content** - tutorial blog post, demo GIF.
+4. **Content** - tutorial blog post, demo GIF.
 
 ## Deferred
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.23.1",
+    "version": "1.23.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "i-want-my-mtg",
-            "version": "1.23.1",
+            "version": "1.23.2",
             "license": "UNLICENSED",
             "dependencies": {
                 "@nestjs/common": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.23.1",
+    "version": "1.23.2",
     "description": "MTG Collection Tracker",
     "author": "Matthew Towles",
     "private": true,


### PR DESCRIPTION
## Summary
- ROADMAP §4.3: mark npm publish, CI/publish workflows, tool unit tests, premium-gating UX, Cursor snippet, and examples/ scaffold as complete.
- \`docs/mcp-rollout-handoff.md\`: add entries for the 0.1.0 trusted-publishing rollout and the 0.2.0 error-formatter / examples / Cursor work (in flight on \`mcp-examples-and-gating-ux\` in the mcp repo, PR #3).

## Test plan
- [x] Docs only; no code paths affected