### PR TITLE
Add JSON-API inventory import/export endpoints (Roadmap 5.1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -409,7 +409,7 @@ Done: Moxfield, Archidekt, Deckbox, and TCGPlayer (app + seller) CSV exports are
 - [x] Build Deckbox import integration (longest-running tool, most legacy data)
 - [x] Parse common CSV formats (TCGPlayer app export, TCGPlayer seller export, Deckbox export, native IWMM)
 - [x] Highlight import capability in app copy — inventory empty-state, getting-started guide, import/export guide, and pricing page now mention the four supported sources
-- [ ] Refactor follow-up: extract a JSON-API import/export endpoint (`POST /api/v1/inventory/import/cards` multipart + `GET /api/v1/inventory/export`) for API consumers and MCP, reusing the existing parsers and services (deferred from the 5.1 PR audit)
+- [x] Refactor follow-up: extract a JSON-API import/export endpoint (`POST /api/v1/inventory/import/cards` multipart + `GET /api/v1/inventory/export`) for API consumers and MCP, reusing the existing parsers and services. Shared `csvUploadInterceptor` lifted to `src/http/base/`; `InventoryImportResponseDto` returns `saved`/`deleted`/`skipped`/`errorCount`/`errors`/`detectedFormat`. Auth via `JwtOrApiKeyGuard`; counts toward tier quota.
 
 ### 5.2 Content & SEO Marketing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.26.0",
+    "version": "1.27.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "i-want-my-mtg",
-            "version": "1.26.0",
+            "version": "1.27.0",
             "license": "UNLICENSED",
             "dependencies": {
                 "@nestjs/common": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.26.0",
+    "version": "1.27.0",
     "description": "MTG Collection Tracker",
     "author": "Matthew Towles",
     "private": true,

--- a/src/http/api/inventory/dto/inventory-import-response.dto.ts
+++ b/src/http/api/inventory/dto/inventory-import-response.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ImportError, ImportFormat } from 'src/core/import/import.types';
+
+export class InventoryImportResponseDto {
+    @ApiProperty({ description: 'Number of inventory rows saved (created or updated to exact qty)' })
+    readonly saved: number;
+
+    @ApiProperty({ description: 'Number of inventory rows deleted (qty=0 in input)' })
+    readonly deleted: number;
+
+    @ApiProperty({ description: 'Number of rows skipped because a record already existed (no-qty input)' })
+    readonly skipped: number;
+
+    @ApiProperty({ description: 'Total number of row errors' })
+    readonly errorCount: number;
+
+    @ApiProperty({
+        description: 'Per-row errors. Each entry includes the 1-indexed CSV row and a message.',
+        isArray: true,
+    })
+    readonly errors: ImportError[];
+
+    @ApiPropertyOptional({
+        description: 'Auto-detected source format of the uploaded CSV',
+        enum: ['native', 'archidekt', 'moxfield', 'deckbox', 'tcgplayer'],
+    })
+    readonly detectedFormat?: ImportFormat;
+
+    constructor(init: {
+        saved: number;
+        deleted: number;
+        skipped: number;
+        errors: ImportError[];
+        detectedFormat?: ImportFormat;
+    }) {
+        this.saved = init.saved;
+        this.deleted = init.deleted;
+        this.skipped = init.skipped;
+        this.errors = init.errors;
+        this.errorCount = init.errors.length;
+        this.detectedFormat = init.detectedFormat;
+    }
+}

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -4,6 +4,7 @@ import {
     Controller,
     Delete,
     Get,
+    Header,
     HttpCode,
     HttpStatus,
     Inject,
@@ -11,17 +12,35 @@ import {
     Post,
     Query,
     Req,
+    Res,
+    UploadedFile,
     UseGuards,
+    UseInterceptors,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+    ApiBearerAuth,
+    ApiBody,
+    ApiConsumes,
+    ApiOperation,
+    ApiProduces,
+    ApiQuery,
+    ApiResponse,
+    ApiTags,
+} from '@nestjs/swagger';
+import { Response } from 'express';
+import { InventoryExportService } from 'src/core/inventory/export/inventory-export.service';
+import { InventoryImportService } from 'src/core/inventory/import/inventory-import.service';
 import { Inventory } from 'src/core/inventory/inventory.entity';
 import { InventoryService } from 'src/core/inventory/inventory.service';
+import { parseCardImport } from 'src/core/import/parsers/card-import-dispatch';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { JwtOrApiKeyGuard } from 'src/http/api/shared/jwt-or-api-key.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { csvUploadInterceptor } from 'src/http/base/csv-upload.interceptor';
 import { InventoryRequestApiDto } from './dto/inventory-request-api.dto';
 import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
 import { InventoryItemApiDto } from './dto/inventory-response.dto';
+import { InventoryImportResponseDto } from './dto/inventory-import-response.dto';
 import { InventoryQuantityApiDto } from './dto/inventory-quantity.dto';
 import { InventoryApiPresenter } from './inventory-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
@@ -31,7 +50,11 @@ import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 @Controller('api/v1/inventory')
 @UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
 export class InventoryApiController {
-    constructor(@Inject(InventoryService) private readonly inventoryService: InventoryService) {}
+    constructor(
+        @Inject(InventoryService) private readonly inventoryService: InventoryService,
+        @Inject(InventoryImportService) private readonly importService: InventoryImportService,
+        @Inject(InventoryExportService) private readonly exportService: InventoryExportService
+    ) {}
 
     @Get()
     @ApiOperation({ summary: 'List inventory items' })
@@ -125,6 +148,70 @@ export class InventoryApiController {
         );
         const saved = await this.inventoryService.save(items);
         return ApiResponseDto.ok(saved.map((item) => InventoryApiPresenter.toInventoryItem(item)));
+    }
+
+    @Post('import/cards')
+    @HttpCode(HttpStatus.OK)
+    @UseInterceptors(csvUploadInterceptor)
+    @ApiOperation({
+        operationId: 'importInventoryCards',
+        summary: 'Import inventory cards from CSV',
+        description:
+            'Upload a CSV of inventory rows. Auto-detects native IWMM, Moxfield, ' +
+            'Archidekt, Deckbox, or TCGPlayer (app + seller) formats. ' +
+            'Returns counts of saved/deleted/skipped rows and per-row errors.',
+    })
+    @ApiConsumes('multipart/form-data')
+    @ApiBody({
+        schema: {
+            type: 'object',
+            properties: {
+                file: { type: 'string', format: 'binary', description: 'CSV file (max 2 MB)' },
+            },
+            required: ['file'],
+        },
+    })
+    @ApiResponse({ status: 200, description: 'Import result', type: InventoryImportResponseDto })
+    @ApiResponse({ status: 400, description: 'Missing or invalid CSV file' })
+    async importCards(
+        @UploadedFile() file: Express.Multer.File,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<InventoryImportResponseDto>> {
+        if (!file) {
+            throw new BadRequestException('No CSV file provided or file type not accepted');
+        }
+        const { format, rows } = parseCardImport(file.buffer);
+        const result = await this.importService.importCards(rows, req.user.id);
+        return ApiResponseDto.ok(
+            new InventoryImportResponseDto({
+                saved: result.saved,
+                deleted: result.deleted,
+                skipped: result.skipped,
+                errors: result.errors,
+                detectedFormat: format,
+            })
+        );
+    }
+
+    @Get('export')
+    @ApiOperation({
+        operationId: 'exportInventory',
+        summary: 'Export inventory as CSV',
+        description:
+            'Returns the authenticated user\'s full inventory as CSV ' +
+            '(columns: id, name, set_code, number, quantity, foil). ' +
+            'Reimport-compatible with POST /api/v1/inventory/import/cards.',
+    })
+    @ApiProduces('text/csv')
+    @ApiResponse({ status: 200, description: 'CSV body' })
+    @Header('Content-Type', 'text/csv')
+    @Header('Content-Disposition', 'attachment; filename="inventory.csv"')
+    async exportInventory(
+        @Req() req: AuthenticatedRequest,
+        @Res() res: Response
+    ): Promise<void> {
+        const csv = await this.exportService.exportToCsv(req.user.id);
+        res.send(csv);
     }
 
     @Delete()

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -180,7 +180,15 @@ export class InventoryApiController {
         if (!file) {
             throw new BadRequestException('No CSV file provided or file type not accepted');
         }
-        const { format, rows } = parseCardImport(file.buffer);
+        let format: ReturnType<typeof parseCardImport>['format'];
+        let rows: ReturnType<typeof parseCardImport>['rows'];
+        try {
+            ({ format, rows } = parseCardImport(file.buffer));
+        } catch (err) {
+            throw new BadRequestException(
+                err instanceof Error ? err.message : 'Invalid CSV file'
+            );
+        }
         const result = await this.importService.importCards(rows, req.user.id);
         return ApiResponseDto.ok(
             new InventoryImportResponseDto({

--- a/src/http/base/csv-upload.interceptor.ts
+++ b/src/http/base/csv-upload.interceptor.ts
@@ -1,0 +1,24 @@
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+
+// `application/octet-stream` is a pragmatic allowance: Safari (and some Windows
+// configurations) send that MIME for .csv uploads. The `.csv` extension check
+// below is the load-bearing defense against renamed-binary uploads.
+const CSV_MIME_TYPES = new Set([
+    'text/csv',
+    'text/plain',
+    'application/csv',
+    'application/octet-stream',
+]);
+
+export const CSV_UPLOAD_MAX_BYTES = 2 * 1024 * 1024;
+
+export const csvUploadInterceptor = FileInterceptor('file', {
+    storage: memoryStorage(),
+    limits: { fileSize: CSV_UPLOAD_MAX_BYTES, files: 1 },
+    fileFilter: (_req, file, cb) => {
+        const validExtension = file.originalname.toLowerCase().endsWith('.csv');
+        const validMime = CSV_MIME_TYPES.has(file.mimetype);
+        cb(null, validExtension && validMime);
+    },
+});

--- a/src/http/hbs/inventory/inventory.controller.ts
+++ b/src/http/hbs/inventory/inventory.controller.ts
@@ -18,8 +18,6 @@ import {
     UseGuards,
     UseInterceptors,
 } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { memoryStorage } from 'multer';
 import { MAX_IMPORT_ROWS } from 'src/core/import/import.constants';
 import { parseCardImport } from 'src/core/import/parsers/card-import-dispatch';
 import { SetCsvParser } from 'src/core/import/parsers/set-csv.parser';
@@ -27,6 +25,7 @@ import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
 import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { csvUploadInterceptor } from 'src/http/base/csv-upload.interceptor';
 import { UploadRateLimitGuard } from './guards/upload-rate-limit.guard';
 import { InventoryRequestDto } from './dto/inventory.request.dto';
 import { ImportExportGuideViewDto } from './dto/import-export-guide.view.dto';
@@ -34,26 +33,6 @@ import { InventoryBinderViewDto } from './dto/inventory-binder.view.dto';
 import { InventoryViewDto } from './dto/inventory.view.dto';
 import { InventoryOrchestrator } from './inventory.orchestrator';
 import { Response } from 'express';
-
-// `application/octet-stream` is a pragmatic allowance: Safari (and some Windows
-// configurations) send that MIME for .csv uploads. The `.csv` extension check
-// below is the load-bearing defense against renamed-binary uploads.
-const CSV_MIME_TYPES = new Set([
-    'text/csv',
-    'text/plain',
-    'application/csv',
-    'application/octet-stream',
-]);
-
-const csvUploadInterceptor = FileInterceptor('file', {
-    storage: memoryStorage(),
-    limits: { fileSize: 2 * 1024 * 1024, files: 1 },
-    fileFilter: (_req, file, cb) => {
-        const validExtension = file.originalname.toLowerCase().endsWith('.csv');
-        const validMime = CSV_MIME_TYPES.has(file.mimetype);
-        cb(null, validExtension && validMime);
-    },
-});
 
 @Controller('inventory')
 export class InventoryController {

--- a/test/http/api/inventory/inventory-api.controller.spec.ts
+++ b/test/http/api/inventory/inventory-api.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { InventoryService } from 'src/core/inventory/inventory.service';
+import { InventoryImportService } from 'src/core/inventory/import/inventory-import.service';
+import { InventoryExportService } from 'src/core/inventory/export/inventory-export.service';
 import { InventoryApiController } from 'src/http/api/inventory/inventory-api.controller';
 import { ApiSubscriptionService } from 'src/core/api-tier/api-subscription.service';
 import { ApiUsageService } from 'src/core/api-tier/api-usage.service';
@@ -35,6 +37,14 @@ describe('InventoryApiController', () => {
                 },
                 { provide: ApiSubscriptionService, useValue: {} },
                 { provide: ApiUsageService, useValue: {} },
+                {
+                    provide: InventoryImportService,
+                    useValue: { importCards: jest.fn() },
+                },
+                {
+                    provide: InventoryExportService,
+                    useValue: { exportToCsv: jest.fn() },
+                },
             ],
         }).compile();
 

--- a/test/integration/api-inventory-import-export.e2e-spec.ts
+++ b/test/integration/api-inventory-import-export.e2e-spec.ts
@@ -1,0 +1,212 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import {
+    createTestApp,
+    closeTestApp,
+    loginTestUserApi,
+    getTestUserId,
+    TEST_CARD_ID,
+    TEST_CARD_ID_2,
+    TEST_SET_CODE,
+} from './setup';
+
+function buildCsv(headers: string, ...rows: string[]): Buffer {
+    return Buffer.from([headers, ...rows].join('\n'));
+}
+
+const NATIVE_HEADER = 'id,name,set_code,number,quantity,foil';
+const MOXFIELD_HEADER =
+    '"Count","Tradelist Count","Name","Edition","Condition","Language","Foil","Tags","Last Modified","Collector Number","Alter","Proxy","Purchase Price"';
+
+describe('Inventory Import/Export API (e2e)', () => {
+    let app: INestApplication;
+    let bearerToken: string;
+    let ds: DataSource;
+    let userId: number;
+
+    beforeAll(async () => {
+        app = await createTestApp();
+        bearerToken = await loginTestUserApi(app);
+        ds = app.get(DataSource);
+        userId = await getTestUserId(app);
+    }, 30000);
+
+    beforeEach(async () => {
+        await ds.query(`DELETE FROM inventory WHERE user_id = $1`, [userId]);
+    });
+
+    afterAll(async () => {
+        try {
+            if (ds?.isInitialized) {
+                await ds.query(`DELETE FROM inventory WHERE user_id = $1`, [userId]);
+            }
+        } catch {
+            // best-effort cleanup
+        }
+        await closeTestApp(app);
+    });
+
+    describe('Auth guard enforcement', () => {
+        it('POST /api/v1/inventory/import/cards without auth returns 401', async () => {
+            const csv = buildCsv(NATIVE_HEADER, `,Test Angel,${TEST_SET_CODE},1,3,false`);
+            const res = await request(app.getHttpServer())
+                .post('/api/v1/inventory/import/cards')
+                .attach('file', csv, 'inventory.csv')
+                .expect(401);
+            expect(res.body.success).toBe(false);
+        });
+
+        it('GET /api/v1/inventory/export without auth returns 401', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/inventory/export')
+                .expect(401);
+            expect(res.body.success).toBe(false);
+        });
+    });
+
+    describe('POST /api/v1/inventory/import/cards', () => {
+        it('imports a native IWMM CSV and returns JSON result', async () => {
+            const csv = buildCsv(
+                NATIVE_HEADER,
+                `,Test Angel,${TEST_SET_CODE},1,3,false`,
+                `,Test Sphinx,${TEST_SET_CODE},2,1,true`
+            );
+            const res = await request(app.getHttpServer())
+                .post('/api/v1/inventory/import/cards')
+                .set('Authorization', bearerToken)
+                .attach('file', csv, 'inventory.csv')
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data).toMatchObject({
+                saved: 2,
+                deleted: 0,
+                skipped: 0,
+                errorCount: 0,
+                detectedFormat: 'native',
+            });
+            expect(res.body.data.errors).toEqual([]);
+
+            const rows = await ds.query(
+                `SELECT card_id, quantity, foil FROM inventory WHERE user_id = $1 ORDER BY card_id`,
+                [userId]
+            );
+            expect(rows).toHaveLength(2);
+            expect(rows).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ card_id: TEST_CARD_ID, quantity: 3, foil: false }),
+                    expect.objectContaining({ card_id: TEST_CARD_ID_2, quantity: 1, foil: true }),
+                ])
+            );
+        });
+
+        it('auto-detects Moxfield format', async () => {
+            const csv = buildCsv(
+                MOXFIELD_HEADER,
+                `"4","0","Test Angel","${TEST_SET_CODE}","NM","en","","","2026-01-01","1","False","False","0"`
+            );
+            const res = await request(app.getHttpServer())
+                .post('/api/v1/inventory/import/cards')
+                .set('Authorization', bearerToken)
+                .attach('file', csv, 'moxfield.csv')
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data.detectedFormat).toBe('moxfield');
+            expect(res.body.data.saved).toBe(1);
+        });
+
+        it('returns 400 when no file is attached', async () => {
+            const res = await request(app.getHttpServer())
+                .post('/api/v1/inventory/import/cards')
+                .set('Authorization', bearerToken)
+                .expect(400);
+            expect(res.body.success).toBe(false);
+        });
+
+        it('surfaces per-row errors for unresolved cards', async () => {
+            const csv = buildCsv(NATIVE_HEADER, `,Bogus Card,zzz,99,1,false`);
+            const res = await request(app.getHttpServer())
+                .post('/api/v1/inventory/import/cards')
+                .set('Authorization', bearerToken)
+                .attach('file', csv, 'inventory.csv')
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data.saved).toBe(0);
+            expect(res.body.data.errorCount).toBe(1);
+            expect(res.body.data.errors[0]).toMatchObject({ row: 2 });
+        });
+    });
+
+    describe('GET /api/v1/inventory/export', () => {
+        it('returns CSV with the expected columns and rows', async () => {
+            await ds.query(
+                `INSERT INTO inventory (user_id, card_id, foil, quantity) VALUES ($1, $2, false, 4), ($1, $3, true, 1)`,
+                [userId, TEST_CARD_ID, TEST_CARD_ID_2]
+            );
+
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/inventory/export')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.headers['content-type']).toMatch(/text\/csv/);
+            expect(res.headers['content-disposition']).toMatch(/attachment; filename="inventory\.csv"/);
+
+            const lines = res.text.trim().split('\n');
+            expect(lines[0]).toBe('id,name,set_code,number,quantity,foil');
+            expect(lines).toHaveLength(3);
+            expect(res.text).toContain(`${TEST_CARD_ID},`);
+            expect(res.text).toContain(`${TEST_CARD_ID_2},`);
+            expect(res.text).toContain(',4,false');
+            expect(res.text).toContain(',1,true');
+        });
+
+        it('returns only headers when inventory is empty', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/inventory/export')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.text.trim()).toBe('id,name,set_code,number,quantity,foil');
+        });
+    });
+
+    describe('Round-trip', () => {
+        it('export output can be re-imported losslessly', async () => {
+            await ds.query(
+                `INSERT INTO inventory (user_id, card_id, foil, quantity) VALUES ($1, $2, false, 2), ($1, $3, true, 5)`,
+                [userId, TEST_CARD_ID, TEST_CARD_ID_2]
+            );
+
+            const exportRes = await request(app.getHttpServer())
+                .get('/api/v1/inventory/export')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            await ds.query(`DELETE FROM inventory WHERE user_id = $1`, [userId]);
+
+            const importRes = await request(app.getHttpServer())
+                .post('/api/v1/inventory/import/cards')
+                .set('Authorization', bearerToken)
+                .attach('file', Buffer.from(exportRes.text), 'inventory.csv')
+                .expect(200);
+
+            expect(importRes.body.data.saved).toBe(2);
+            expect(importRes.body.data.errorCount).toBe(0);
+
+            const rows = await ds.query(
+                `SELECT card_id, quantity, foil FROM inventory WHERE user_id = $1 ORDER BY card_id`,
+                [userId]
+            );
+            expect(rows).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({ card_id: TEST_CARD_ID, quantity: 2, foil: false }),
+                    expect.objectContaining({ card_id: TEST_CARD_ID_2, quantity: 5, foil: true }),
+                ])
+            );
+        });
+    });
+});

--- a/test/integration/api-inventory-import-export.e2e-spec.ts
+++ b/test/integration/api-inventory-import-export.e2e-spec.ts
@@ -125,6 +125,19 @@ describe('Inventory Import/Export API (e2e)', () => {
             expect(res.body.success).toBe(false);
         });
 
+        it('returns 400 when CSV has an unknown column', async () => {
+            const csv = buildCsv(
+                'id,name,set_code,number,quantity,foil,bogus',
+                `,Test Angel,${TEST_SET_CODE},1,3,false,oops`
+            );
+            const res = await request(app.getHttpServer())
+                .post('/api/v1/inventory/import/cards')
+                .set('Authorization', bearerToken)
+                .attach('file', csv, 'inventory.csv')
+                .expect(400);
+            expect(res.body.success).toBe(false);
+        });
+
         it('surfaces per-row errors for unresolved cards', async () => {
             const csv = buildCsv(NATIVE_HEADER, `,Bogus Card,zzz,99,1,false`);
             const res = await request(app.getHttpServer())


### PR DESCRIPTION
POST /api/v1/inventory/import/cards (multipart) and GET /api/v1/inventory/export let API and MCP clients use the same shared parsers and services as the HBS upload flow. Shared csvUploadInterceptor lifted to src/http/base/ to avoid duplicating the 2 MB limit and MIME validation across controllers.