### PR TITLE
feat(api): strict query-param validation on JSON API (Roadmap 4.4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,6 +81,7 @@ Surfaced by Copilot on PR #497 (transaction `type`); deferred from that PR becau
 - [x] Apply consistently across cards, set-cards, set-list, inventory, and transactions. (The sealed-product list endpoints read only `page`/`limit` - no enumerated filter to validate.)
 - [x] Align the MCP tools: `format` is now an enum in `search_cards`/`list_set_cards` and `list_transactions` `sort` is an enum, so typos are rejected rather than silently dropped (the `type` enum already did).
 - [x] Contract settled: 400 body is `{ success: false, error, param, allowedValues }` (`allowedValues` omitted for `setCode`), documented via `QueryValidationErrorDto` + `@ApiResponse(400)` on each endpoint.
+- [x] PR #507 review follow-ups: `sort` is validated against each endpoint's honorable set (per-context constants in `sort-options.enum.ts`) rather than the global enum - an endpoint-inapplicable sort (e.g. `?sort=card.name` on `/transactions`) now 400s instead of 500ing. The ordering paths (`QueryBuilderHelper`, set `addSetOrdering`) fall back to the context default via `resolveSort()`, so HBS/internal callers can't hit the SQL error either. `legality` without `format` now 400s (mirrored in the MCP card tools).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,6 +83,14 @@ Surfaced by Copilot on PR #497 (transaction `type`); deferred from that PR becau
 - [x] Contract settled: 400 body is `{ success: false, error, param, allowedValues }` (`allowedValues` omitted for `setCode`), documented via `QueryValidationErrorDto` + `@ApiResponse(400)` on each endpoint.
 - [x] PR #507 review follow-ups: `sort` is validated against each endpoint's honorable set (per-context constants in `sort-options.enum.ts`) rather than the global enum - an endpoint-inapplicable sort (e.g. `?sort=card.name` on `/transactions`) now 400s instead of 500ing. The ordering paths (`QueryBuilderHelper`, set `addSetOrdering`) fall back to the context default via `resolveSort()`, so HBS/internal callers can't hit the SQL error either. `legality` without `format` now 400s (mirrored in the MCP card tools).
 
+### 4.5 Unify HBS sortable headers with the honorable sort sets
+
+Follow-up from 4.4 (PR #507). The per-context honorable sort sets (`SET_CARD_SORTS`/`SET_SORTS`/`INVENTORY_SORTS`/`TRANSACTION_SORTS` in `sort-options.enum.ts`) are the single source of truth for "what a query can sort by", consumed by the repositories (`QueryBuilderHelper.allowedSorts` / set `addSetOrdering`) and the API validator. But each HBS orchestrator still lists its clickable `SortableHeaderView` columns independently. They agree today and a mismatch can't 500 (the `resolveSort` fallback degrades an inapplicable sort to the context default), but nothing *enforces* that every offered header is honorable - so a future header edit could quietly become a dead sort (UI says sortable, click falls back to default; the API would 400 the same value).
+
+- [ ] Decide the mechanism: derive each orchestrator's sortable headers from the honorable set (headers carry labels via `SortOptionLabels` + per-column CSS, so a small per-context header-config table is likely cleaner than a raw list), or keep the lists but add a guardrail test that asserts every `SortableHeaderView` sort key is a member of the matching `*_SORTS` set.
+- [ ] Implement the chosen approach so "offered ⊆ honorable" is enforced, not just currently-true.
+- [ ] Re-verify the browse/inventory/transaction/set pages with Playwright (sort links still work, default ordering unchanged) since this touches the view layer.
+
 ---
 
 ## Phase 6: Buylist Pricing & Vendor Selling Tools

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,11 +76,11 @@ The constraint is that `SafeQueryOptions` is one shared sanitizer used by ~20 ca
 
 Surfaced by Copilot on PR #497 (transaction `type`); deferred from that PR because 400-ing `type` alone would be inconsistent with every other filter.
 
-- [ ] Add a strict validation path for the JSON API that returns 400 on invalid filter values (unknown `rarity`/`format`/`legality`/`sort`, malformed `setCode`, invalid transaction `type`) instead of silent fallback. Layer it in front of `SafeQueryOptions`; do not change the sanitizer's behavior.
-- [ ] Keep `SafeQueryOptions` lenient for the HBS browse/search pages and the internal service callers - no 400s there.
-- [ ] Apply consistently across every list endpoint (cards, sets, inventory, transactions, sealed-products) so one filter does not 400 while the rest silently ignore.
-- [ ] Align the MCP tools that pass raw filters through `SafeQueryOptions` (the `list_transactions` `type` enum already rejects typos; bring the others in line).
-- [ ] Settle the contract (400 body shape: `error` + offending param + allowed values) and document it in the OpenAPI spec.
+- [x] Add a strict validation path for the JSON API that returns 400 on invalid filter values (unknown `rarity`/`format`/`legality`/`sort`, malformed `setCode`, invalid transaction `type`) instead of silent fallback. `validateApiQuery()` (`src/http/api/shared/query-validation.ts`) runs in front of `SafeQueryOptions` on the API controllers; the sanitizer is unchanged.
+- [x] Keep `SafeQueryOptions` lenient for the HBS browse/search pages and the internal service callers - no 400s there.
+- [x] Apply consistently across cards, set-cards, set-list, inventory, and transactions. (The sealed-product list endpoints read only `page`/`limit` - no enumerated filter to validate.)
+- [x] Align the MCP tools: `format` is now an enum in `search_cards`/`list_set_cards` and `list_transactions` `sort` is an enum, so typos are rejected rather than silently dropped (the `type` enum already did).
+- [x] Contract settled: 400 body is `{ success: false, error, param, allowedValues }` (`allowedValues` omitted for `setCode`), documented via `QueryValidationErrorDto` + `@ApiResponse(400)` on each endpoint.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.29.0",
+    "version": "1.30.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "i-want-my-mtg",
-            "version": "1.29.0",
+            "version": "1.30.0",
             "license": "UNLICENSED",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.29.0",
+    "version": "1.30.0",
     "description": "MTG Collection Tracker",
     "author": "Matthew Towles",
     "private": true,

--- a/src/core/query/query.util.ts
+++ b/src/core/query/query.util.ts
@@ -26,6 +26,19 @@ export function safeSort(value: string | SortOptions | undefined): SortOptions |
     return validSorts.includes(value as SortOptions) ? (value as SortOptions) : undefined;
 }
 
+/**
+ * Narrows a requested sort to the set a query can actually honor. Returns the
+ * sort if it is in `allowedSorts`, otherwise `undefined` so the caller falls back
+ * to its default sort. Keeps an endpoint-inapplicable (but globally valid) sort
+ * from reaching `ORDER BY` and producing a SQL error on an unjoined alias.
+ */
+export function resolveSort(
+    sort: SortOptions | undefined,
+    allowedSorts: readonly SortOptions[]
+): SortOptions | undefined {
+    return sort && allowedSorts.includes(sort) ? sort : undefined;
+}
+
 export function safeBoolean(
     value: string | boolean | undefined,
     defaultValue: boolean = true

--- a/src/core/query/query.util.ts
+++ b/src/core/query/query.util.ts
@@ -1,29 +1,34 @@
 import { RawQueryOptions } from './safe-query-options.dto';
 import { SortOptions } from './sort-options.enum';
 
-export function sanitizeInt(value: string | number | undefined, defaultValue: number): number {
-    if (value === undefined || value === null) return defaultValue;
+// All sanitizers accept `unknown`: Express/qs can parse a repeated query param
+// (`?x=a&x=b`) as an array, so a value typed `string` at the call site may be a
+// `string[]` at runtime. Each returns its default rather than calling a string
+// method on a non-string (which would throw and surface as a 500).
+
+export function sanitizeInt(value: unknown, defaultValue: number): number {
     if (typeof value === 'number') return value < 1 ? defaultValue : value;
+    if (typeof value !== 'string') return defaultValue;
     const parsed = parseInt(value, 10);
     return isNaN(parsed) || parsed < 1 ? defaultValue : parsed;
 }
 
-export function safeAlphaNumeric(value: string | undefined): string | undefined {
-    if (!value) return undefined;
+export function safeAlphaNumeric(value: unknown): string | undefined {
+    if (typeof value !== 'string') return undefined;
     const sanitized = value.replace(/[^a-zA-Z0-9\s-]/g, '').trim();
     return sanitized.length > 0 ? sanitized : undefined;
 }
 
-export function safeSearchTerm(value: string | undefined): string | undefined {
-    if (!value) return undefined;
+export function safeSearchTerm(value: unknown): string | undefined {
+    if (typeof value !== 'string') return undefined;
     const sanitized = value.replace(/[^a-zA-Z0-9\s\-',.;:/]/g, '').trim();
     return sanitized.length > 0 ? sanitized : undefined;
 }
 
-export function safeSort(value: string | SortOptions | undefined): SortOptions | undefined {
-    if (!value) return undefined;
-    const validSorts = Object.values(SortOptions);
-    return validSorts.includes(value as SortOptions) ? (value as SortOptions) : undefined;
+export function safeSort(value: unknown): SortOptions | undefined {
+    if (typeof value !== 'string') return undefined;
+    const validSorts: readonly string[] = Object.values(SortOptions);
+    return validSorts.includes(value) ? (value as SortOptions) : undefined;
 }
 
 /**
@@ -39,11 +44,7 @@ export function resolveSort(
     return sort && allowedSorts.includes(sort) ? sort : undefined;
 }
 
-export function safeBoolean(
-    value: string | boolean | undefined,
-    defaultValue: boolean = true
-): boolean {
-    if (value === undefined || value === null) return defaultValue;
+export function safeBoolean(value: unknown, defaultValue: boolean = true): boolean {
     if (typeof value === 'boolean') return value;
     if (typeof value !== 'string') return defaultValue;
     const lower = value.toLowerCase();

--- a/src/core/query/safe-query-options.dto.ts
+++ b/src/core/query/safe-query-options.dto.ts
@@ -4,7 +4,7 @@ import { LegalityStatus } from 'src/core/card/legality.status.enum';
 import { safeAlphaNumeric, safeBoolean, safeSort, sanitizeInt } from './query.util';
 import { SortOptions } from './sort-options.enum';
 
-const PUBLIC_RARITIES: ReadonlySet<CardRarity> = new Set([
+export const PUBLIC_RARITIES: ReadonlySet<CardRarity> = new Set([
     CardRarity.Common,
     CardRarity.Uncommon,
     CardRarity.Rare,

--- a/src/core/query/safe-query-options.dto.ts
+++ b/src/core/query/safe-query-options.dto.ts
@@ -13,30 +13,31 @@ export const PUBLIC_RARITIES: ReadonlySet<CardRarity> = new Set([
 
 // Set codes are stored lowercase (matches keyrune CSS class convention used in views).
 // Lowercasing input lets callers pass either case in the API.
-function safeSetCode(value: string | undefined): string | undefined {
-    if (!value) return undefined;
+// All helpers accept `unknown` because a repeated query param can arrive as an
+// array at runtime; a non-string returns the lenient default rather than throwing.
+function safeSetCode(value: unknown): string | undefined {
+    if (typeof value !== 'string') return undefined;
     const cleaned = value.replace(/[^a-zA-Z0-9]/g, '');
     return cleaned.length > 0 ? cleaned.toLowerCase() : undefined;
 }
 
-function safeRarity(value: string | undefined): CardRarity | undefined {
-    if (!value) return undefined;
+// Exported so the strict API validator decides "is this a valid rarity/format"
+// with the exact same logic, instead of re-deriving it and risking divergence.
+export function safeRarity(value: unknown): CardRarity | undefined {
+    if (typeof value !== 'string') return undefined;
     const lower = value.toLowerCase() as CardRarity;
     return PUBLIC_RARITIES.has(lower) ? lower : undefined;
 }
 
-function safeFormat(value: string | undefined): Format | undefined {
-    if (!value) return undefined;
+export function safeFormat(value: unknown): Format | undefined {
+    if (typeof value !== 'string') return undefined;
     const lower = value.toLowerCase() as Format;
     return Object.values(Format).includes(lower) ? lower : undefined;
 }
 
-function safeLegality(
-    value: string | undefined,
-    format: Format | undefined
-): LegalityStatus | undefined {
+function safeLegality(value: unknown, format: Format | undefined): LegalityStatus | undefined {
     if (!format) return undefined;
-    if (!value) return LegalityStatus.Legal;
+    if (typeof value !== 'string' || value === '') return LegalityStatus.Legal;
     const lower = value.toLowerCase() as LegalityStatus;
     return Object.values(LegalityStatus).includes(lower) ? lower : LegalityStatus.Legal;
 }

--- a/src/core/query/sort-options.enum.ts
+++ b/src/core/query/sort-options.enum.ts
@@ -31,3 +31,54 @@ export const SortOptionLabels: Record<SortOptions, string> = {
     [SortOptions.TX_CARD]: 'Card',
     [SortOptions.TX_PRICE]: 'Price',
 };
+
+/**
+ * Sort keys each list query can actually honor, grouped by the table aliases the
+ * query joins. A sort key outside its context's set references an alias the query
+ * never joined, which is a SQL error (e.g. `ORDER BY card.name` on the transaction
+ * query, which only joins `transaction_card`).
+ *
+ * Single source of truth shared by two consumers:
+ *   - the ordering paths (`QueryBuilderHelper.applyOrdering`, set `addSetOrdering`)
+ *     fall back to the context default when a requested sort is not in the set, so
+ *     no caller (HBS, API, internal) can trigger the SQL error;
+ *   - the JSON API validator (`validateApiQuery`) 400s a sort outside the set
+ *     instead of letting it silently fall back.
+ *
+ * Card search (`searchByName`) is intentionally absent: it has a fixed name order
+ * and ignores `sort` entirely, matching the `search_cards` MCP tool which exposes
+ * no sort param.
+ */
+export const SET_CARD_SORTS: readonly SortOptions[] = [
+    SortOptions.CARD,
+    SortOptions.CARD_SET,
+    SortOptions.NUMBER,
+    SortOptions.PRICE,
+    SortOptions.PRICE_FOIL,
+];
+
+export const SET_SORTS: readonly SortOptions[] = [
+    SortOptions.SET,
+    SortOptions.SET_CODE,
+    SortOptions.RELEASE_DATE,
+    SortOptions.SET_BASE_PRICE,
+];
+
+export const INVENTORY_SORTS: readonly SortOptions[] = [
+    SortOptions.OWNED_QUANTITY,
+    SortOptions.CARD,
+    SortOptions.CARD_SET,
+    SortOptions.NUMBER,
+    SortOptions.PRICE,
+    SortOptions.PRICE_FOIL,
+    SortOptions.SET,
+    SortOptions.SET_CODE,
+    SortOptions.RELEASE_DATE,
+];
+
+export const TRANSACTION_SORTS: readonly SortOptions[] = [
+    SortOptions.TX_DATE,
+    SortOptions.TX_TYPE,
+    SortOptions.TX_CARD,
+    SortOptions.TX_PRICE,
+];

--- a/src/core/transaction/transaction.entity.ts
+++ b/src/core/transaction/transaction.entity.ts
@@ -1,11 +1,20 @@
 import { validateInit } from 'src/core/validation.util';
 
-export type TransactionType = 'BUY' | 'SELL';
+/** The only valid transaction types. Single source for parsing and validation. */
+export const TRANSACTION_TYPES = ['BUY', 'SELL'] as const;
+export type TransactionType = (typeof TRANSACTION_TYPES)[number];
 
-/** Parse an untrusted string into a TransactionType, or undefined if it isn't one. */
-export function parseTransactionType(value?: string): TransactionType | undefined {
-    const upper = value?.toUpperCase();
-    return upper === 'BUY' || upper === 'SELL' ? upper : undefined;
+/**
+ * Parse an untrusted value into a TransactionType, or undefined if it isn't one.
+ * Trims and upper-cases so ` sell ` and `BUY` both resolve; anything else (typos,
+ * non-strings) is undefined. The single gate used by the controllers, the MCP
+ * tools, and the strict API validator so they can't disagree.
+ */
+export function parseTransactionType(value?: unknown): TransactionType | undefined {
+    const upper = typeof value === 'string' ? value.trim().toUpperCase() : undefined;
+    return TRANSACTION_TYPES.includes(upper as TransactionType)
+        ? (upper as TransactionType)
+        : undefined;
 }
 
 export class Transaction {

--- a/src/database/card/card.repository.ts
+++ b/src/database/card/card.repository.ts
@@ -5,7 +5,7 @@ import { CardRepositoryPort } from 'src/core/card/ports/card.repository.port';
 import { Format } from 'src/core/card/format.enum';
 import { PriceCalculationPolicy } from 'src/core/pricing/price-calculation.policy';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
-import { SortOptions } from 'src/core/query/sort-options.enum';
+import { SET_CARD_SORTS, SortOptions } from 'src/core/query/sort-options.enum';
 import { BaseRepository } from 'src/database/base.repository';
 import { QueryBuilderHelper } from 'src/database/query/query-builder.helper';
 import { getLogger } from 'src/logger/global-app-logger';
@@ -23,12 +23,14 @@ export class CardRepository extends BaseRepository<CardOrmEntity> implements Car
     private readonly queryHelper = new QueryBuilderHelper<CardOrmEntity>({
         table: this.TABLE,
         defaultSort: SortOptions.NUMBER,
+        allowedSorts: SET_CARD_SORTS,
     });
 
     private readonly queryHelperPriceDesc = new QueryBuilderHelper<CardOrmEntity>({
         table: this.TABLE,
         defaultSort: SortOptions.PRICE,
         defaultSortDesc: true,
+        allowedSorts: SET_CARD_SORTS,
     });
 
     constructor(

--- a/src/database/inventory/inventory.repository.ts
+++ b/src/database/inventory/inventory.repository.ts
@@ -4,7 +4,7 @@ import { Inventory } from 'src/core/inventory/inventory.entity';
 import { InventoryRepositoryPort } from 'src/core/inventory/ports/inventory.repository.port';
 import { PriceCalculationPolicy } from 'src/core/pricing/price-calculation.policy';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
-import { SortOptions } from 'src/core/query/sort-options.enum';
+import { INVENTORY_SORTS, SortOptions } from 'src/core/query/sort-options.enum';
 import { BaseRepository } from 'src/database/base.repository';
 import { QueryBuilderHelper } from 'src/database/query/query-builder.helper';
 import { getLogger } from 'src/logger/global-app-logger';
@@ -24,6 +24,7 @@ export class InventoryRepository
         table: this.TABLE,
         filterColumn: 'card.name', // Inventory filters by card name
         defaultSort: SortOptions.NUMBER,
+        allowedSorts: INVENTORY_SORTS,
     });
 
     constructor(

--- a/src/database/query/query-builder.helper.ts
+++ b/src/database/query/query-builder.helper.ts
@@ -26,7 +26,15 @@ export class QueryBuilderHelper<T> {
     private static readonly DESC = 'DESC';
     private static readonly NULLS_LAST = 'NULLS LAST';
 
-    constructor(private readonly config: QueryBuilderConfig) {}
+    constructor(private readonly config: QueryBuilderConfig) {
+        // The fallback default must itself be honorable, otherwise a dropped sort
+        // would fall back to an unjoined alias and 500. Fail fast at startup.
+        if (config.allowedSorts && !config.allowedSorts.includes(config.defaultSort)) {
+            throw new Error(
+                `QueryBuilderHelper(${config.table}): defaultSort '${config.defaultSort}' is not in allowedSorts`
+            );
+        }
+    }
 
     /**
      * Applies all standard query options in a consistent order.

--- a/src/database/query/query-builder.helper.ts
+++ b/src/database/query/query-builder.helper.ts
@@ -1,5 +1,6 @@
 import { SelectQueryBuilder } from 'typeorm';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
+import { resolveSort } from 'src/core/query/query.util';
 import { SortOptions } from 'src/core/query/sort-options.enum';
 
 export interface QueryBuilderConfig {
@@ -7,6 +8,13 @@ export interface QueryBuilderConfig {
     filterColumn?: string; // defaults to `${table}.name`
     defaultSort: SortOptions;
     defaultSortDesc?: boolean;
+    /**
+     * Sort keys this query can honor (see the sort-set constants in
+     * sort-options.enum). When set, a requested sort outside it falls back to
+     * `defaultSort` instead of ordering by an unjoined alias (SQL error). Should
+     * be set on any query that exposes user-controlled sort.
+     */
+    allowedSorts?: readonly SortOptions[];
     customSortHandlers?: Map<
         SortOptions,
         (qb: SelectQueryBuilder<any>, direction: 'ASC' | 'DESC') => void
@@ -50,10 +58,16 @@ export class QueryBuilderHelper<T> {
     }
 
     applyOrdering(qb: SelectQueryBuilder<T>, options: SafeQueryOptions): void {
-        const sort = options.sort ?? this.config.defaultSort;
+        // A sort the query can't honor (not in allowedSorts) is treated as "no
+        // sort given" so it falls back to the default instead of ordering by an
+        // unjoined alias. No allowedSorts configured = accept any sort (legacy).
+        const requestedSort = this.config.allowedSorts
+            ? resolveSort(options.sort, this.config.allowedSorts)
+            : options.sort;
+        const sort = requestedSort ?? this.config.defaultSort;
         const direction = options.ascend
             ? QueryBuilderHelper.ASC
-            : options.sort
+            : requestedSort
               ? QueryBuilderHelper.DESC
               : this.config.defaultSortDesc
                 ? QueryBuilderHelper.DESC

--- a/src/database/set/set.repository.ts
+++ b/src/database/set/set.repository.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PriceCalculationPolicy } from 'src/core/pricing/price-calculation.policy';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
-import { SortOptions } from 'src/core/query/sort-options.enum';
+import { resolveSort } from 'src/core/query/query.util';
+import { SET_SORTS, SortOptions } from 'src/core/query/sort-options.enum';
 import { Set } from 'src/core/set/set.entity';
 import { SetRepositoryPort } from 'src/core/set/ports/set.repository.port';
 import { BaseRepository } from 'src/database/base.repository';
@@ -22,6 +23,7 @@ export class SetRepository extends BaseRepository<SetOrmEntity> implements SetRe
         table: this.TABLE,
         defaultSort: SortOptions.RELEASE_DATE,
         defaultSortDesc: true,
+        allowedSorts: SET_SORTS,
     });
 
     constructor(
@@ -218,10 +220,7 @@ export class SetRepository extends BaseRepository<SetOrmEntity> implements SetRe
      * empty array, return no rows (the user has explicitly cleared all
      * types).
      */
-    private applyBaseFilter(
-        qb: SelectQueryBuilder<SetOrmEntity>,
-        options: SafeQueryOptions
-    ): void {
+    private applyBaseFilter(qb: SelectQueryBuilder<SetOrmEntity>, options: SafeQueryOptions): void {
         if (!options.baseOnly) return;
         const types = options.includedSetTypes;
         if (types === undefined || types === null) {
@@ -255,7 +254,10 @@ export class SetRepository extends BaseRepository<SetOrmEntity> implements SetRe
     }
 
     private addSetOrdering(qb: SelectQueryBuilder<SetOrmEntity>, options: SafeQueryOptions): void {
-        if (!options.sort) {
+        // Drop a sort this query can't honor (only `set` + `setPrice` are joined)
+        // back to the default so it can't order by an unjoined alias (SQL error).
+        const sort = resolveSort(options.sort, SET_SORTS);
+        if (!sort) {
             // Default: release date desc, then name asc
             qb.orderBy(`${this.TABLE}.releaseDate`, this.DESC, this.NULLS_LAST);
             qb.addOrderBy(`${this.TABLE}.name`, this.ASC, this.NULLS_LAST);
@@ -264,13 +266,13 @@ export class SetRepository extends BaseRepository<SetOrmEntity> implements SetRe
 
         const direction = options.ascend ? this.ASC : this.DESC;
 
-        if (options.sort === SortOptions.SET_BASE_PRICE) {
+        if (sort === SortOptions.SET_BASE_PRICE) {
             qb.addSelect(
                 PriceCalculationPolicy.effectiveSetPriceExpression('setPrice'),
                 'effective_price'
             ).orderBy('effective_price', direction, this.NULLS_LAST);
         } else {
-            qb.orderBy(options.sort, direction, this.NULLS_LAST);
+            qb.orderBy(sort, direction, this.NULLS_LAST);
         }
     }
 }

--- a/src/database/transaction/transaction.repository.ts
+++ b/src/database/transaction/transaction.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
-import { SortOptions } from 'src/core/query/sort-options.enum';
+import { SortOptions, TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
 import { Transaction, TransactionType } from 'src/core/transaction/transaction.entity';
 import {
     CashFlowPeriod,
@@ -21,6 +21,7 @@ export class TransactionRepository implements TransactionRepositoryPort {
         filterColumn: 'transaction_card.name',
         defaultSort: SortOptions.TX_DATE,
         defaultSortDesc: true,
+        allowedSorts: TRANSACTION_SORTS,
     });
 
     constructor(

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -18,7 +18,12 @@ import { CardApiPresenter } from './card-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { OptionalAuthOrApiKeyGuard } from '../shared/optional-auth-or-api-key.guard';
 import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
-import { validateApiQuery } from '../shared/query-validation';
+import {
+    FORMAT_VALUES,
+    LEGALITY_VALUES,
+    RARITY_VALUES,
+    validateApiQuery,
+} from '../shared/query-validation';
 
 @ApiTags('Cards')
 @Controller('api/v1/cards')
@@ -41,7 +46,7 @@ export class CardApiController {
         name: 'rarity',
         required: false,
         description: 'Filter by rarity',
-        enum: ['common', 'uncommon', 'rare', 'mythic'],
+        enum: [...RARITY_VALUES],
     })
     @ApiQuery({
         name: 'type',
@@ -52,25 +57,13 @@ export class CardApiController {
         name: 'format',
         required: false,
         description: 'Filter by format legality (joins legality table; defaults legality=legal)',
-        enum: [
-            'standard',
-            'commander',
-            'modern',
-            'legacy',
-            'vintage',
-            'brawl',
-            'explorer',
-            'historic',
-            'oathbreaker',
-            'pauper',
-            'pioneer',
-        ],
+        enum: [...FORMAT_VALUES],
     })
     @ApiQuery({
         name: 'legality',
         required: false,
         description: 'Legality status; only meaningful with format. Defaults to "legal".',
-        enum: ['legal', 'banned', 'restricted'],
+        enum: [...LEGALITY_VALUES],
     })
     @ApiQuery({ name: 'page', required: false })
     @ApiQuery({ name: 'limit', required: false })

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -27,21 +27,44 @@ export class CardApiController {
     constructor(@Inject(CardService) private readonly cardService: CardService) {}
 
     @Get()
-    @ApiOperation({ operationId: 'searchCards', summary: 'Search cards by name with optional filters' })
+    @ApiOperation({
+        operationId: 'searchCards',
+        summary: 'Search cards by name with optional filters',
+    })
     @ApiQuery({ name: 'q', required: false, description: 'Search query (matches card name)' })
-    @ApiQuery({ name: 'setCode', required: false, description: 'Restrict to a single set (e.g. LEA, MH3)' })
+    @ApiQuery({
+        name: 'setCode',
+        required: false,
+        description: 'Restrict to a single set (e.g. LEA, MH3)',
+    })
     @ApiQuery({
         name: 'rarity',
         required: false,
         description: 'Filter by rarity',
         enum: ['common', 'uncommon', 'rare', 'mythic'],
     })
-    @ApiQuery({ name: 'type', required: false, description: 'Substring match on card type line (e.g. "creature", "instant")' })
+    @ApiQuery({
+        name: 'type',
+        required: false,
+        description: 'Substring match on card type line (e.g. "creature", "instant")',
+    })
     @ApiQuery({
         name: 'format',
         required: false,
         description: 'Filter by format legality (joins legality table; defaults legality=legal)',
-        enum: ['standard', 'commander', 'modern', 'legacy', 'vintage', 'brawl', 'explorer', 'historic', 'oathbreaker', 'pauper', 'pioneer'],
+        enum: [
+            'standard',
+            'commander',
+            'modern',
+            'legacy',
+            'vintage',
+            'brawl',
+            'explorer',
+            'historic',
+            'oathbreaker',
+            'pauper',
+            'pioneer',
+        ],
     })
     @ApiQuery({
         name: 'legality',
@@ -51,19 +74,19 @@ export class CardApiController {
     })
     @ApiQuery({ name: 'page', required: false })
     @ApiQuery({ name: 'limit', required: false })
-    @ApiQuery({ name: 'sort', required: false })
-    @ApiQuery({ name: 'ascend', required: false })
-    @ApiResponse({ status: 200, description: 'Search results' })
+    @ApiResponse({ status: 200, description: 'Search results (ordered by card name)' })
     @ApiResponse({
         status: 400,
-        description: 'Invalid filter value (unknown rarity/format/legality/sort or malformed setCode)',
+        description:
+            'Invalid filter value (unknown rarity/format/legality, malformed setCode, or legality without format)',
         type: QueryValidationErrorDto,
     })
     async search(
         @Query() query: Record<string, string>
     ): Promise<ApiResponseDto<CardApiResponseDto[]>> {
+        // Card search has a fixed name order (searchByName ignores `sort`), so no
+        // sort set is passed - only the catalog filters are validated.
         validateApiQuery(query, {
-            sort: true,
             rarity: true,
             format: true,
             legality: true,
@@ -99,7 +122,10 @@ export class CardApiController {
     }
 
     @Get(':cardId/price-history')
-    @ApiOperation({ operationId: 'getCardPriceHistory', summary: 'Get price history for a card by ID' })
+    @ApiOperation({
+        operationId: 'getCardPriceHistory',
+        summary: 'Get price history for a card by ID',
+    })
     @ApiQuery({ name: 'days', required: false, description: 'Number of days of history' })
     @ApiResponse({ status: 200, description: 'Price history data' })
     async getPriceHistoryById(
@@ -110,7 +136,10 @@ export class CardApiController {
     }
 
     @Get(':setCode/:setNumber/prices')
-    @ApiOperation({ operationId: 'getCardPricesBySetAndNumber', summary: 'Get current prices for a card by set code and number' })
+    @ApiOperation({
+        operationId: 'getCardPricesBySetAndNumber',
+        summary: 'Get current prices for a card by set code and number',
+    })
     @ApiResponse({ status: 200, description: 'Card prices' })
     @ApiResponse({ status: 404, description: 'Card not found' })
     async getPricesBySetCodeAndNumber(
@@ -129,7 +158,10 @@ export class CardApiController {
     }
 
     @Get(':setCode/:setNumber/price-history')
-    @ApiOperation({ operationId: 'getCardPriceHistoryBySetAndNumber', summary: 'Get price history for a card by set code and number' })
+    @ApiOperation({
+        operationId: 'getCardPriceHistoryBySetAndNumber',
+        summary: 'Get price history for a card by set code and number',
+    })
     @ApiQuery({ name: 'days', required: false, description: 'Number of days of history' })
     @ApiResponse({ status: 200, description: 'Price history data' })
     @ApiResponse({ status: 404, description: 'Card not found' })
@@ -146,7 +178,10 @@ export class CardApiController {
     }
 
     @Get(':setCode/:setNumber')
-    @ApiOperation({ operationId: 'getCardBySetAndNumber', summary: 'Get card by set code and collector number' })
+    @ApiOperation({
+        operationId: 'getCardBySetAndNumber',
+        summary: 'Get card by set code and collector number',
+    })
     @ApiResponse({ status: 200, description: 'Card detail' })
     @ApiResponse({ status: 404, description: 'Card not found' })
     async findBySetCodeAndNumber(

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -17,6 +17,8 @@ import { CardApiResponseDto, PriceHistoryPointDto } from './dto/card-response.dt
 import { CardApiPresenter } from './card-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { OptionalAuthOrApiKeyGuard } from '../shared/optional-auth-or-api-key.guard';
+import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
+import { validateApiQuery } from '../shared/query-validation';
 
 @ApiTags('Cards')
 @Controller('api/v1/cards')
@@ -52,9 +54,21 @@ export class CardApiController {
     @ApiQuery({ name: 'sort', required: false })
     @ApiQuery({ name: 'ascend', required: false })
     @ApiResponse({ status: 200, description: 'Search results' })
+    @ApiResponse({
+        status: 400,
+        description: 'Invalid filter value (unknown rarity/format/legality/sort or malformed setCode)',
+        type: QueryValidationErrorDto,
+    })
     async search(
         @Query() query: Record<string, string>
     ): Promise<ApiResponseDto<CardApiResponseDto[]>> {
+        validateApiQuery(query, {
+            sort: true,
+            rarity: true,
+            format: true,
+            legality: true,
+            setCode: true,
+        });
         const options = new SearchQueryOptions(query);
         if (!options.q) {
             return ApiResponseDto.ok([], new PaginationMeta(1, options.limit, 0));

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -44,6 +44,8 @@ import { InventoryImportResponseDto } from './dto/inventory-import-response.dto'
 import { InventoryQuantityApiDto } from './dto/inventory-quantity.dto';
 import { InventoryApiPresenter } from './inventory-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
+import { validateApiQuery } from '../shared/query-validation';
 
 @ApiTags('Inventory')
 @ApiBearerAuth()
@@ -64,10 +66,16 @@ export class InventoryApiController {
     @ApiQuery({ name: 'ascend', required: false })
     @ApiQuery({ name: 'filter', required: false })
     @ApiResponse({ status: 200, description: 'Inventory list' })
+    @ApiResponse({
+        status: 400,
+        description: 'Invalid sort value',
+        type: QueryValidationErrorDto,
+    })
     async findAll(
         @Query() query: Record<string, string>,
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<InventoryItemApiDto[]>> {
+        validateApiQuery(query, { sort: true });
         const options = new SafeQueryOptions(query);
         const [items, total] = await Promise.all([
             this.inventoryService.findAllForUser(req.user.id, options),

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -34,6 +34,7 @@ import { Inventory } from 'src/core/inventory/inventory.entity';
 import { InventoryService } from 'src/core/inventory/inventory.service';
 import { parseCardImport } from 'src/core/import/parsers/card-import-dispatch';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
+import { INVENTORY_SORTS } from 'src/core/query/sort-options.enum';
 import { JwtOrApiKeyGuard } from 'src/http/api/shared/jwt-or-api-key.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { csvUploadInterceptor } from 'src/http/base/csv-upload.interceptor';
@@ -75,7 +76,7 @@ export class InventoryApiController {
         @Query() query: Record<string, string>,
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<InventoryItemApiDto[]>> {
-        validateApiQuery(query, { sort: true });
+        validateApiQuery(query, { sort: INVENTORY_SORTS });
         const options = new SafeQueryOptions(query);
         const [items, total] = await Promise.all([
             this.inventoryService.findAllForUser(req.user.id, options),
@@ -193,9 +194,7 @@ export class InventoryApiController {
         try {
             ({ format, rows } = parseCardImport(file.buffer));
         } catch (err) {
-            throw new BadRequestException(
-                err instanceof Error ? err.message : 'Invalid CSV file'
-            );
+            throw new BadRequestException(err instanceof Error ? err.message : 'Invalid CSV file');
         }
         const result = await this.importService.importCards(rows, req.user.id);
         return ApiResponseDto.ok(
@@ -214,7 +213,7 @@ export class InventoryApiController {
         operationId: 'exportInventory',
         summary: 'Export inventory as CSV',
         description:
-            'Returns the authenticated user\'s full inventory as CSV ' +
+            "Returns the authenticated user's full inventory as CSV " +
             '(columns: id, name, set_code, number, quantity, foil). ' +
             'Reimport-compatible with POST /api/v1/inventory/import/cards.',
     })
@@ -222,10 +221,7 @@ export class InventoryApiController {
     @ApiResponse({ status: 200, description: 'CSV body' })
     @Header('Content-Type', 'text/csv')
     @Header('Content-Disposition', 'attachment; filename="inventory.csv"')
-    async exportInventory(
-        @Req() req: AuthenticatedRequest,
-        @Res() res: Response
-    ): Promise<void> {
+    async exportInventory(@Req() req: AuthenticatedRequest, @Res() res: Response): Promise<void> {
         const csv = await this.exportService.exportToCsv(req.user.id);
         res.send(csv);
     }

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -30,7 +30,12 @@ import { CardApiPresenter } from '../card/card-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { OptionalAuthOrApiKeyGuard } from 'src/http/api/shared/optional-auth-or-api-key.guard';
 import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
-import { validateApiQuery } from '../shared/query-validation';
+import {
+    FORMAT_VALUES,
+    LEGALITY_VALUES,
+    RARITY_VALUES,
+    validateApiQuery,
+} from '../shared/query-validation';
 import { formatUtcDate } from 'src/http/base/date.util';
 import { parseDaysParam } from 'src/http/base/query.util';
 
@@ -167,32 +172,20 @@ export class SetApiController {
         name: 'rarity',
         required: false,
         description: 'Filter by rarity',
-        enum: ['common', 'uncommon', 'rare', 'mythic'],
+        enum: [...RARITY_VALUES],
     })
     @ApiQuery({ name: 'type', required: false, description: 'Substring match on card type line' })
     @ApiQuery({
         name: 'format',
         required: false,
         description: 'Filter by format legality (defaults legality=legal)',
-        enum: [
-            'standard',
-            'commander',
-            'modern',
-            'legacy',
-            'vintage',
-            'brawl',
-            'explorer',
-            'historic',
-            'oathbreaker',
-            'pauper',
-            'pioneer',
-        ],
+        enum: [...FORMAT_VALUES],
     })
     @ApiQuery({
         name: 'legality',
         required: false,
         description: 'Legality status; only meaningful with format. Defaults to "legal".',
-        enum: ['legal', 'banned', 'restricted'],
+        enum: [...LEGALITY_VALUES],
     })
     @ApiResponse({ status: 200, description: 'Cards in set' })
     @ApiResponse({

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -24,6 +24,8 @@ import { CardApiResponseDto } from '../card/dto/card-response.dto';
 import { CardApiPresenter } from '../card/card-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { OptionalAuthOrApiKeyGuard } from 'src/http/api/shared/optional-auth-or-api-key.guard';
+import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
+import { validateApiQuery } from '../shared/query-validation';
 import { formatUtcDate } from 'src/http/base/date.util';
 import { parseDaysParam } from 'src/http/base/query.util';
 
@@ -53,10 +55,16 @@ export class SetApiController {
         description: 'Grouping mode: "block" for block-level pagination',
     })
     @ApiResponse({ status: 200, description: 'List of sets' })
+    @ApiResponse({
+        status: 400,
+        description: 'Invalid sort value',
+        type: QueryValidationErrorDto,
+    })
     async findAll(
         @Req() req: AuthenticatedRequest,
         @Query() query: Record<string, string>
     ): Promise<ApiResponseDto<SetApiResponseDto[]>> {
+        validateApiQuery(query, { sort: true });
         const options = new SafeQueryOptions(query).withSetTypes(
             req.user?.includedSetTypes ?? null
         );
@@ -172,10 +180,16 @@ export class SetApiController {
         enum: ['legal', 'banned', 'restricted'],
     })
     @ApiResponse({ status: 200, description: 'Cards in set' })
+    @ApiResponse({
+        status: 400,
+        description: 'Invalid filter value (unknown rarity/format/legality/sort)',
+        type: QueryValidationErrorDto,
+    })
     async findCardsInSet(
         @Param('code') code: string,
         @Query() query: Record<string, string>
     ): Promise<ApiResponseDto<CardApiResponseDto[]>> {
+        validateApiQuery(query, { sort: true, rarity: true, format: true, legality: true });
         const options = new SafeQueryOptions(query);
 
         const set = await this.setService.findByCode(code);

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -13,9 +13,14 @@ import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
 import { InventoryService } from 'src/core/inventory/inventory.service';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
+import { SET_CARD_SORTS, SET_SORTS } from 'src/core/query/sort-options.enum';
 import { SetService } from 'src/core/set/set.service';
 import { Set } from 'src/core/set/set.entity';
-import { ApiResponseDto, BlockPaginationMeta, PaginationMeta } from 'src/http/base/api-response.dto';
+import {
+    ApiResponseDto,
+    BlockPaginationMeta,
+    PaginationMeta,
+} from 'src/http/base/api-response.dto';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { completionRate } from 'src/http/base/http.util';
 import { SetApiResponseDto, SetPriceHistoryPointDto } from './dto/set-response.dto';
@@ -64,7 +69,7 @@ export class SetApiController {
         @Req() req: AuthenticatedRequest,
         @Query() query: Record<string, string>
     ): Promise<ApiResponseDto<SetApiResponseDto[]>> {
-        validateApiQuery(query, { sort: true });
+        validateApiQuery(query, { sort: SET_SORTS });
         const options = new SafeQueryOptions(query).withSetTypes(
             req.user?.includedSetTypes ?? null
         );
@@ -91,12 +96,7 @@ export class SetApiController {
                 this.setService.findMultiSetBlockKeys(blockKeys),
             ]);
             sets = blockSets;
-            meta = new BlockPaginationMeta(
-                options.page,
-                options.limit,
-                totalGroups,
-                multiSetKeys
-            );
+            meta = new BlockPaginationMeta(options.page, options.limit, totalGroups, multiSetKeys);
         } else {
             let total: number;
             [sets, total] = await Promise.all([
@@ -153,7 +153,10 @@ export class SetApiController {
     }
 
     @Get(':code/cards')
-    @ApiOperation({ operationId: 'getSetCards', summary: 'Get cards in a set with optional filters' })
+    @ApiOperation({
+        operationId: 'getSetCards',
+        summary: 'Get cards in a set with optional filters',
+    })
     @ApiQuery({ name: 'page', required: false })
     @ApiQuery({ name: 'limit', required: false })
     @ApiQuery({ name: 'sort', required: false })
@@ -171,7 +174,19 @@ export class SetApiController {
         name: 'format',
         required: false,
         description: 'Filter by format legality (defaults legality=legal)',
-        enum: ['standard', 'commander', 'modern', 'legacy', 'vintage', 'brawl', 'explorer', 'historic', 'oathbreaker', 'pauper', 'pioneer'],
+        enum: [
+            'standard',
+            'commander',
+            'modern',
+            'legacy',
+            'vintage',
+            'brawl',
+            'explorer',
+            'historic',
+            'oathbreaker',
+            'pauper',
+            'pioneer',
+        ],
     })
     @ApiQuery({
         name: 'legality',
@@ -189,7 +204,12 @@ export class SetApiController {
         @Param('code') code: string,
         @Query() query: Record<string, string>
     ): Promise<ApiResponseDto<CardApiResponseDto[]>> {
-        validateApiQuery(query, { sort: true, rarity: true, format: true, legality: true });
+        validateApiQuery(query, {
+            sort: SET_CARD_SORTS,
+            rarity: true,
+            format: true,
+            legality: true,
+        });
         const options = new SafeQueryOptions(query);
 
         const set = await this.setService.findByCode(code);

--- a/src/http/api/shared/dto/query-validation-error.dto.ts
+++ b/src/http/api/shared/dto/query-validation-error.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * 400 response body returned when a list endpoint receives an invalid filter
+ * value (unknown rarity/format/legality/sort, malformed setCode, or invalid
+ * transaction type). Shapes the contract documented in the OpenAPI spec.
+ */
+export class QueryValidationErrorDto {
+    @ApiProperty({ example: false })
+    readonly success: boolean;
+
+    @ApiProperty({
+        example:
+            "Invalid value 'foobar' for query parameter 'rarity'. Allowed values: common, uncommon, rare, mythic.",
+    })
+    readonly error: string;
+
+    @ApiProperty({ example: 'rarity', description: 'The offending query parameter.' })
+    readonly param: string;
+
+    @ApiPropertyOptional({
+        type: [String],
+        example: ['common', 'uncommon', 'rare', 'mythic'],
+        description: 'Accepted values, present when the parameter is an enumerated filter.',
+    })
+    readonly allowedValues?: string[];
+}

--- a/src/http/api/shared/query-validation.ts
+++ b/src/http/api/shared/query-validation.ts
@@ -1,0 +1,120 @@
+import { BadRequestException } from '@nestjs/common';
+import { Format } from 'src/core/card/format.enum';
+import { LegalityStatus } from 'src/core/card/legality.status.enum';
+import { PUBLIC_RARITIES } from 'src/core/query/safe-query-options.dto';
+import { SortOptions } from 'src/core/query/sort-options.enum';
+
+/**
+ * Strict query-param validation for the JSON API.
+ *
+ * The shared `SafeQueryOptions` sanitizer silently drops invalid filter values
+ * (unknown rarity/format/legality/sort, malformed setCode) so that stale
+ * browser bookmarks still render an HBS page. For programmatic API consumers a
+ * silently-ignored filter is a footgun: they get unfiltered results and assume
+ * the filter worked. This validator runs in front of `SafeQueryOptions` on the
+ * API controllers only and returns 400 instead of falling back.
+ *
+ * Each check mirrors the matching sanitizer (same casing rules) so a value the
+ * API accepts is exactly a value `SafeQueryOptions` would keep, and vice versa.
+ */
+
+const ALLOWED_RARITIES: readonly string[] = [...PUBLIC_RARITIES];
+const ALLOWED_FORMATS: readonly string[] = Object.values(Format);
+const ALLOWED_LEGALITIES: readonly string[] = Object.values(LegalityStatus);
+const ALLOWED_SORTS: readonly string[] = Object.values(SortOptions);
+const ALLOWED_TRANSACTION_TYPES: readonly string[] = ['BUY', 'SELL'];
+
+const SET_CODE_PATTERN = /^[a-zA-Z0-9]+$/;
+
+/**
+ * 400 raised when an API filter value is present but invalid. Carries the
+ * offending param and (for enumerated filters) the accepted values so the
+ * exception filter can surface them in the response body.
+ */
+export class InvalidQueryParamException extends BadRequestException {
+    readonly param: string;
+    readonly allowedValues?: readonly string[];
+
+    constructor(param: string, message: string, allowedValues?: readonly string[]) {
+        super(message);
+        this.param = param;
+        this.allowedValues = allowedValues;
+    }
+}
+
+/** Which filters an endpoint actually consumes, and so should strictly validate. */
+export interface StrictQueryFlags {
+    sort?: boolean;
+    rarity?: boolean;
+    format?: boolean;
+    legality?: boolean;
+    setCode?: boolean;
+    transactionType?: boolean;
+}
+
+function isAbsent(value: string | undefined): boolean {
+    return value === undefined || value === null || value.trim() === '';
+}
+
+function enumError(
+    param: string,
+    value: string,
+    allowed: readonly string[]
+): InvalidQueryParamException {
+    return new InvalidQueryParamException(
+        param,
+        `Invalid value '${value}' for query parameter '${param}'. Allowed values: ${allowed.join(', ')}.`,
+        allowed
+    );
+}
+
+/**
+ * Throws `InvalidQueryParamException` on the first invalid filter value among
+ * the enabled flags. Absent or empty values are treated as "not provided" and
+ * skipped, matching the lenient sanitizer.
+ */
+export function validateApiQuery(
+    query: Record<string, string | undefined>,
+    flags: StrictQueryFlags
+): void {
+    if (flags.setCode && !isAbsent(query.setCode)) {
+        const value = query.setCode.trim();
+        if (!SET_CODE_PATTERN.test(value)) {
+            throw new InvalidQueryParamException(
+                'setCode',
+                `Invalid value '${value}' for query parameter 'setCode'. Must contain only letters and digits.`
+            );
+        }
+    }
+    if (flags.sort && !isAbsent(query.sort) && !ALLOWED_SORTS.includes(query.sort)) {
+        throw enumError('sort', query.sort, ALLOWED_SORTS);
+    }
+    if (
+        flags.rarity &&
+        !isAbsent(query.rarity) &&
+        !ALLOWED_RARITIES.includes(query.rarity.toLowerCase())
+    ) {
+        throw enumError('rarity', query.rarity, ALLOWED_RARITIES);
+    }
+    if (
+        flags.format &&
+        !isAbsent(query.format) &&
+        !ALLOWED_FORMATS.includes(query.format.toLowerCase())
+    ) {
+        throw enumError('format', query.format, ALLOWED_FORMATS);
+    }
+    if (
+        flags.legality &&
+        !isAbsent(query.legality) &&
+        !ALLOWED_LEGALITIES.includes(query.legality.toLowerCase())
+    ) {
+        throw enumError('legality', query.legality, ALLOWED_LEGALITIES);
+    }
+    if (
+        flags.transactionType &&
+        !isAbsent(query.type) &&
+        !ALLOWED_TRANSACTION_TYPES.includes(query.type.toUpperCase())
+    ) {
+        throw enumError('type', query.type, ALLOWED_TRANSACTION_TYPES);
+    }
+}

--- a/src/http/api/shared/query-validation.ts
+++ b/src/http/api/shared/query-validation.ts
@@ -1,8 +1,9 @@
 import { BadRequestException } from '@nestjs/common';
 import { Format } from 'src/core/card/format.enum';
 import { LegalityStatus } from 'src/core/card/legality.status.enum';
-import { PUBLIC_RARITIES } from 'src/core/query/safe-query-options.dto';
+import { PUBLIC_RARITIES, safeFormat, safeRarity } from 'src/core/query/safe-query-options.dto';
 import { SortOptions } from 'src/core/query/sort-options.enum';
+import { TRANSACTION_TYPES, parseTransactionType } from 'src/core/transaction/transaction.entity';
 
 /**
  * Strict query-param validation for the JSON API.
@@ -14,23 +15,28 @@ import { SortOptions } from 'src/core/query/sort-options.enum';
  * the filter worked. This validator runs in front of `SafeQueryOptions` on the
  * API controllers only and returns 400 instead of falling back.
  *
- * The rarity/format/type enum checks mirror the matching sanitizer's casing
- * rules, so a value the API rejects is one `SafeQueryOptions` would have dropped
- * anyway. Three checks are deliberately stricter than the sanitizer, because the
- * sanitizer's lenient fallback is itself the footgun for an API consumer:
- *   - `setCode`: 400s a non-alphanumeric code the sanitizer would silently coerce
- *     to its alphanumeric remainder;
+ * To stay consistent with what the endpoint actually does, each check delegates
+ * to the same canonical function the controller/sanitizer use rather than
+ * re-deriving the rule: `safeRarity`/`safeFormat` for those filters and
+ * `parseTransactionType` for `type` (so casing/trimming can't diverge). The
+ * accepted-value lists come from the same source enums. Four checks are
+ * deliberately stricter than the sanitizer, because the sanitizer's lenient
+ * fallback is itself the footgun for an API consumer:
+ *   - `setCode`: 400s a non-alphanumeric code the sanitizer would silently coerce;
  *   - `sort`: validated against the endpoint's honorable set (see StrictQueryFlags)
  *     rather than the global enum, so a sort the endpoint can't apply 400s instead
  *     of silently falling back to the default;
  *   - `legality`: 400s when `format` is absent, since legality is only applied
- *     within a format join and would otherwise be silently ignored.
+ *     within a format join and would otherwise be silently ignored;
+ *   - a repeated param parsed as an array (`?x=a&x=b`) 400s instead of throwing.
  */
 
-const ALLOWED_RARITIES: readonly string[] = [...PUBLIC_RARITIES];
-const ALLOWED_FORMATS: readonly string[] = Object.values(Format);
-const ALLOWED_LEGALITIES: readonly string[] = Object.values(LegalityStatus);
-const ALLOWED_TRANSACTION_TYPES: readonly string[] = ['BUY', 'SELL'];
+// Accepted values per enumerated filter, derived from the source enums. Exported
+// so the controllers' OpenAPI `@ApiQuery` enums document the same lists the
+// validator enforces (no hand-maintained duplicate to drift out of sync).
+export const RARITY_VALUES: readonly string[] = [...PUBLIC_RARITIES];
+export const FORMAT_VALUES: readonly string[] = Object.values(Format);
+export const LEGALITY_VALUES: readonly string[] = Object.values(LegalityStatus);
 
 const SET_CODE_PATTERN = /^[a-zA-Z0-9]+$/;
 
@@ -65,8 +71,22 @@ export interface StrictQueryFlags {
     transactionType?: boolean;
 }
 
-function isAbsent(value: string | undefined): boolean {
-    return value === undefined || value === null || value.trim() === '';
+/**
+ * Reads one query param as a present, non-empty string. Returns undefined for an
+ * absent/empty value (skipped, matching the lenient sanitizer). Throws 400 for a
+ * non-string value - a repeated param (`?x=a&x=b`) that Express parsed as an
+ * array - rather than letting a later `.trim()`/`.toLowerCase()` throw a 500.
+ */
+function readParam(query: Record<string, unknown>, key: string): string | undefined {
+    const value = query[key];
+    if (value === undefined || value === null) return undefined;
+    if (typeof value !== 'string') {
+        throw new InvalidQueryParamException(
+            key,
+            `Query parameter '${key}' must be a single value, not a list.`
+        );
+    }
+    return value.trim() === '' ? undefined : value;
 }
 
 function enumError(
@@ -82,58 +102,57 @@ function enumError(
 }
 
 /**
- * Throws `InvalidQueryParamException` on the first invalid filter value among
- * the enabled flags. Absent or empty values are treated as "not provided" and
- * skipped, matching the lenient sanitizer.
+ * Throws `InvalidQueryParamException` on the first invalid filter value among the
+ * enabled flags. Absent or empty values are skipped, matching the lenient sanitizer.
  */
-export function validateApiQuery(
-    query: Record<string, string | undefined>,
-    flags: StrictQueryFlags
-): void {
-    if (flags.setCode && !isAbsent(query.setCode)) {
-        const value = query.setCode.trim();
-        if (!SET_CODE_PATTERN.test(value)) {
+export function validateApiQuery(query: Record<string, unknown>, flags: StrictQueryFlags): void {
+    if (flags.setCode) {
+        const value = readParam(query, 'setCode');
+        if (value !== undefined && !SET_CODE_PATTERN.test(value.trim())) {
             throw new InvalidQueryParamException(
                 'setCode',
-                `Invalid value '${value}' for query parameter 'setCode'. Must contain only letters and digits.`
+                `Invalid value '${value.trim()}' for query parameter 'setCode'. Must contain only letters and digits.`
             );
         }
     }
-    if (flags.sort && !isAbsent(query.sort) && !flags.sort.includes(query.sort as SortOptions)) {
-        throw enumError('sort', query.sort, flags.sort);
-    }
-    if (
-        flags.rarity &&
-        !isAbsent(query.rarity) &&
-        !ALLOWED_RARITIES.includes(query.rarity.toLowerCase())
-    ) {
-        throw enumError('rarity', query.rarity, ALLOWED_RARITIES);
-    }
-    if (
-        flags.format &&
-        !isAbsent(query.format) &&
-        !ALLOWED_FORMATS.includes(query.format.toLowerCase())
-    ) {
-        throw enumError('format', query.format, ALLOWED_FORMATS);
-    }
-    if (flags.legality && !isAbsent(query.legality)) {
-        if (!ALLOWED_LEGALITIES.includes(query.legality.toLowerCase())) {
-            throw enumError('legality', query.legality, ALLOWED_LEGALITIES);
-        }
-        // legality is only applied within a format join, so legality alone is a
-        // silently-ignored filter - 400 instead of dropping it.
-        if (isAbsent(query.format)) {
-            throw new InvalidQueryParamException(
-                'legality',
-                "Query parameter 'legality' requires 'format' to be set; legality is only meaningful within a format."
-            );
+    if (flags.sort) {
+        const value = readParam(query, 'sort');
+        if (value !== undefined && !flags.sort.includes(value as SortOptions)) {
+            throw enumError('sort', value, flags.sort);
         }
     }
-    if (
-        flags.transactionType &&
-        !isAbsent(query.type) &&
-        !ALLOWED_TRANSACTION_TYPES.includes(query.type.toUpperCase())
-    ) {
-        throw enumError('type', query.type, ALLOWED_TRANSACTION_TYPES);
+    if (flags.rarity) {
+        const value = readParam(query, 'rarity');
+        if (value !== undefined && safeRarity(value) === undefined) {
+            throw enumError('rarity', value, RARITY_VALUES);
+        }
+    }
+    if (flags.format) {
+        const value = readParam(query, 'format');
+        if (value !== undefined && safeFormat(value) === undefined) {
+            throw enumError('format', value, FORMAT_VALUES);
+        }
+    }
+    if (flags.legality) {
+        const value = readParam(query, 'legality');
+        if (value !== undefined) {
+            if (!LEGALITY_VALUES.includes(value.toLowerCase())) {
+                throw enumError('legality', value, LEGALITY_VALUES);
+            }
+            // legality is only applied within a format join, so legality alone is
+            // a silently-ignored filter - 400 instead of dropping it.
+            if (readParam(query, 'format') === undefined) {
+                throw new InvalidQueryParamException(
+                    'legality',
+                    "Query parameter 'legality' requires 'format' to be set; legality is only meaningful within a format."
+                );
+            }
+        }
+    }
+    if (flags.transactionType) {
+        const value = readParam(query, 'type');
+        if (value !== undefined && parseTransactionType(value) === undefined) {
+            throw enumError('type', value, TRANSACTION_TYPES);
+        }
     }
 }

--- a/src/http/api/shared/query-validation.ts
+++ b/src/http/api/shared/query-validation.ts
@@ -14,14 +14,22 @@ import { SortOptions } from 'src/core/query/sort-options.enum';
  * the filter worked. This validator runs in front of `SafeQueryOptions` on the
  * API controllers only and returns 400 instead of falling back.
  *
- * Each check mirrors the matching sanitizer (same casing rules) so a value the
- * API accepts is exactly a value `SafeQueryOptions` would keep, and vice versa.
+ * The rarity/format/type enum checks mirror the matching sanitizer's casing
+ * rules, so a value the API rejects is one `SafeQueryOptions` would have dropped
+ * anyway. Three checks are deliberately stricter than the sanitizer, because the
+ * sanitizer's lenient fallback is itself the footgun for an API consumer:
+ *   - `setCode`: 400s a non-alphanumeric code the sanitizer would silently coerce
+ *     to its alphanumeric remainder;
+ *   - `sort`: validated against the endpoint's honorable set (see StrictQueryFlags)
+ *     rather than the global enum, so a sort the endpoint can't apply 400s instead
+ *     of silently falling back to the default;
+ *   - `legality`: 400s when `format` is absent, since legality is only applied
+ *     within a format join and would otherwise be silently ignored.
  */
 
 const ALLOWED_RARITIES: readonly string[] = [...PUBLIC_RARITIES];
 const ALLOWED_FORMATS: readonly string[] = Object.values(Format);
 const ALLOWED_LEGALITIES: readonly string[] = Object.values(LegalityStatus);
-const ALLOWED_SORTS: readonly string[] = Object.values(SortOptions);
 const ALLOWED_TRANSACTION_TYPES: readonly string[] = ['BUY', 'SELL'];
 
 const SET_CODE_PATTERN = /^[a-zA-Z0-9]+$/;
@@ -44,7 +52,12 @@ export class InvalidQueryParamException extends BadRequestException {
 
 /** Which filters an endpoint actually consumes, and so should strictly validate. */
 export interface StrictQueryFlags {
-    sort?: boolean;
+    /**
+     * The sort keys this endpoint can honor (its repository's allowed set). A
+     * sort outside it 400s rather than silently falling back to the default.
+     * Omit for endpoints that don't sort (e.g. card search orders by name).
+     */
+    sort?: readonly SortOptions[];
     rarity?: boolean;
     format?: boolean;
     legality?: boolean;
@@ -86,8 +99,8 @@ export function validateApiQuery(
             );
         }
     }
-    if (flags.sort && !isAbsent(query.sort) && !ALLOWED_SORTS.includes(query.sort)) {
-        throw enumError('sort', query.sort, ALLOWED_SORTS);
+    if (flags.sort && !isAbsent(query.sort) && !flags.sort.includes(query.sort as SortOptions)) {
+        throw enumError('sort', query.sort, flags.sort);
     }
     if (
         flags.rarity &&
@@ -103,12 +116,18 @@ export function validateApiQuery(
     ) {
         throw enumError('format', query.format, ALLOWED_FORMATS);
     }
-    if (
-        flags.legality &&
-        !isAbsent(query.legality) &&
-        !ALLOWED_LEGALITIES.includes(query.legality.toLowerCase())
-    ) {
-        throw enumError('legality', query.legality, ALLOWED_LEGALITIES);
+    if (flags.legality && !isAbsent(query.legality)) {
+        if (!ALLOWED_LEGALITIES.includes(query.legality.toLowerCase())) {
+            throw enumError('legality', query.legality, ALLOWED_LEGALITIES);
+        }
+        // legality is only applied within a format join, so legality alone is a
+        // silently-ignored filter - 400 instead of dropping it.
+        if (isAbsent(query.format)) {
+            throw new InvalidQueryParamException(
+                'legality',
+                "Query parameter 'legality' requires 'format' to be set; legality is only meaningful within a format."
+            );
+        }
     }
     if (
         flags.transactionType &&

--- a/src/http/api/transaction/transaction-api.controller.ts
+++ b/src/http/api/transaction/transaction-api.controller.ts
@@ -29,6 +29,8 @@ import { TransactionRequestDto } from 'src/http/hbs/transaction/dto/transaction.
 import { TransactionUpdateRequestDto } from 'src/http/hbs/transaction/dto/transaction.update-request.dto';
 import { TransactionPresenter } from 'src/http/hbs/transaction/transaction.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
+import { validateApiQuery } from '../shared/query-validation';
 import { CostBasisApiDto, TransactionApiItemDto } from './dto/transaction-response.dto';
 import { TransactionApiPresenter } from './transaction-api.presenter';
 
@@ -52,10 +54,16 @@ export class TransactionApiController {
     @ApiQuery({ name: 'filter', required: false })
     @ApiQuery({ name: 'type', required: false, enum: ['BUY', 'SELL'] })
     @ApiResponse({ status: 200, description: 'Transaction list' })
+    @ApiResponse({
+        status: 400,
+        description: 'Invalid sort value or transaction type',
+        type: QueryValidationErrorDto,
+    })
     async findAll(
         @Query() query: Record<string, string>,
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<TransactionApiItemDto[]>> {
+        validateApiQuery(query, { sort: true, transactionType: true });
         const options = new SafeQueryOptions(query);
         const type = parseTransactionType(query.type);
         const subscribed = await this.subscriptionService.isUserSubscribed(req.user.id);

--- a/src/http/api/transaction/transaction-api.controller.ts
+++ b/src/http/api/transaction/transaction-api.controller.ts
@@ -20,6 +20,7 @@ import { freeTierHistoryCutoff } from 'src/core/billing/subscription-limits';
 import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
+import { TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
 import { parseTransactionType } from 'src/core/transaction/transaction.entity';
 import { TransactionService } from 'src/core/transaction/transaction.service';
 import { JwtOrApiKeyGuard } from 'src/http/api/shared/jwt-or-api-key.guard';
@@ -63,7 +64,7 @@ export class TransactionApiController {
         @Query() query: Record<string, string>,
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<TransactionApiItemDto[]>> {
-        validateApiQuery(query, { sort: true, transactionType: true });
+        validateApiQuery(query, { sort: TRANSACTION_SORTS, transactionType: true });
         const options = new SafeQueryOptions(query);
         const type = parseTransactionType(query.type);
         const subscribed = await this.subscriptionService.isUserSubscribed(req.user.id);

--- a/src/http/http.exception.filter.ts
+++ b/src/http/http.exception.filter.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { getLogger } from 'src/logger/global-app-logger';
+import { InvalidQueryParamException } from './api/shared/query-validation';
 import { ApiResponseDto } from './base/api-response.dto';
 import { LoginFormViewDto } from './hbs/auth/dto/login-form.view.dto';
 import { ActionStatus } from './base/action-status.enum';
@@ -30,9 +31,16 @@ export class HttpExceptionFilter implements ExceptionFilter {
             ? exception.getStatus()
             : HttpStatus.INTERNAL_SERVER_ERROR;
         if (this.isApiRequest(request)) {
-            response
-                .status(status)
-                .json(ApiResponseDto.error(exception.message || 'Internal Server Error'));
+            const body = ApiResponseDto.error(exception.message || 'Internal Server Error');
+            if (exception instanceof InvalidQueryParamException) {
+                response.status(status).json({
+                    ...body,
+                    param: exception.param,
+                    allowedValues: exception.allowedValues,
+                });
+            } else {
+                response.status(status).json(body);
+            }
         } else if (this.isFormRoute(request.url)) {
             this.handleFormError(response, request, exception);
         } else {

--- a/src/mcp/tools/cards.tools.ts
+++ b/src/mcp/tools/cards.tools.ts
@@ -7,7 +7,13 @@ import { parseDaysParam } from 'src/http/base/query.util';
 import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { McpToolDefinition } from '../mcp-tool.types';
-import { READ_ONLY, formatParam, refineLegalityRequiresFormat } from './common';
+import {
+    READ_ONLY,
+    formatParam,
+    legalityParam,
+    rarityParam,
+    refineLegalityRequiresFormat,
+} from './common';
 
 const cardKeySchema = {
     setCode: z.string().describe("Set code (e.g. 'lea')."),
@@ -44,10 +50,7 @@ export class CardMcpTools {
                             .string()
                             .optional()
                             .describe("3-5 character set code (e.g. 'lea', 'mh3')."),
-                        rarity: z
-                            .enum(['common', 'uncommon', 'rare', 'mythic'])
-                            .optional()
-                            .describe('Filter by rarity.'),
+                        rarity: rarityParam,
                         type: z
                             .string()
                             .optional()
@@ -55,12 +58,7 @@ export class CardMcpTools {
                                 "Substring match against card type line (e.g. 'Goblin', 'Instant')."
                             ),
                         format: formatParam,
-                        legality: z
-                            .enum(['legal', 'banned', 'restricted'])
-                            .optional()
-                            .describe(
-                                "Used with 'format'. Defaults to 'legal' when format is set."
-                            ),
+                        legality: legalityParam,
                         page: z.number().int().min(1).optional().describe('1-based page index.'),
                         limit: z
                             .number()

--- a/src/mcp/tools/cards.tools.ts
+++ b/src/mcp/tools/cards.tools.ts
@@ -7,7 +7,7 @@ import { parseDaysParam } from 'src/http/base/query.util';
 import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { McpToolDefinition } from '../mcp-tool.types';
-import { READ_ONLY, formatParam } from './common';
+import { READ_ONLY, formatParam, refineLegalityRequiresFormat } from './common';
 
 const cardKeySchema = {
     setCode: z.string().describe("Set code (e.g. 'lea')."),
@@ -32,41 +32,45 @@ export class CardMcpTools {
                 name: 'search_cards',
                 description:
                     'Search Magic: The Gathering cards by name (substring). A name query (q) is required to return results; set code, rarity, type, and format legality only narrow that name search. Returns a paginated list with prices and basic metadata. Use this for catalog lookups; for a specific printing prefer get_card with set+number.',
-                inputSchema: z.object({
-                    q: z
-                        .string()
-                        .optional()
-                        .describe(
-                            'Substring to search card name + flavor name. Required to return results - the other parameters only narrow a name search; omitting q returns an empty list.'
-                        ),
-                    setCode: z
-                        .string()
-                        .optional()
-                        .describe("3-5 character set code (e.g. 'lea', 'mh3')."),
-                    rarity: z
-                        .enum(['common', 'uncommon', 'rare', 'mythic'])
-                        .optional()
-                        .describe('Filter by rarity.'),
-                    type: z
-                        .string()
-                        .optional()
-                        .describe(
-                            "Substring match against card type line (e.g. 'Goblin', 'Instant')."
-                        ),
-                    format: formatParam,
-                    legality: z
-                        .enum(['legal', 'banned', 'restricted'])
-                        .optional()
-                        .describe("Used with 'format'. Defaults to 'legal' when format is set."),
-                    page: z.number().int().min(1).optional().describe('1-based page index.'),
-                    limit: z
-                        .number()
-                        .int()
-                        .min(1)
-                        .max(100)
-                        .optional()
-                        .describe('Page size (max 100).'),
-                }),
+                inputSchema: refineLegalityRequiresFormat(
+                    z.object({
+                        q: z
+                            .string()
+                            .optional()
+                            .describe(
+                                'Substring to search card name + flavor name. Required to return results - the other parameters only narrow a name search; omitting q returns an empty list.'
+                            ),
+                        setCode: z
+                            .string()
+                            .optional()
+                            .describe("3-5 character set code (e.g. 'lea', 'mh3')."),
+                        rarity: z
+                            .enum(['common', 'uncommon', 'rare', 'mythic'])
+                            .optional()
+                            .describe('Filter by rarity.'),
+                        type: z
+                            .string()
+                            .optional()
+                            .describe(
+                                "Substring match against card type line (e.g. 'Goblin', 'Instant')."
+                            ),
+                        format: formatParam,
+                        legality: z
+                            .enum(['legal', 'banned', 'restricted'])
+                            .optional()
+                            .describe(
+                                "Used with 'format'. Defaults to 'legal' when format is set."
+                            ),
+                        page: z.number().int().min(1).optional().describe('1-based page index.'),
+                        limit: z
+                            .number()
+                            .int()
+                            .min(1)
+                            .max(100)
+                            .optional()
+                            .describe('Page size (max 100).'),
+                    })
+                ),
                 requiresAuth: false,
                 annotations: READ_ONLY,
                 handler: async (args) => this.searchCards(args),

--- a/src/mcp/tools/cards.tools.ts
+++ b/src/mcp/tools/cards.tools.ts
@@ -7,7 +7,7 @@ import { parseDaysParam } from 'src/http/base/query.util';
 import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { McpToolDefinition } from '../mcp-tool.types';
-import { READ_ONLY } from './common';
+import { READ_ONLY, formatParam } from './common';
 
 const cardKeySchema = {
     setCode: z.string().describe("Set code (e.g. 'lea')."),
@@ -53,12 +53,7 @@ export class CardMcpTools {
                         .describe(
                             "Substring match against card type line (e.g. 'Goblin', 'Instant')."
                         ),
-                    format: z
-                        .string()
-                        .optional()
-                        .describe(
-                            "Filter to cards with a legality entry in this format (e.g. 'modern', 'commander')."
-                        ),
+                    format: formatParam,
                     legality: z
                         .enum(['legal', 'banned', 'restricted'])
                         .optional()

--- a/src/mcp/tools/common.ts
+++ b/src/mcp/tools/common.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { Format } from 'src/core/card/format.enum';
 import { McpToolAnnotations } from '../mcp-tool.types';
 
 /**
@@ -37,3 +38,12 @@ export const limitParam = z
     .max(100)
     .optional()
     .describe('Page size, 1-100. Server default applies if omitted.');
+
+/**
+ * Format-legality filter, enumerated so a typo is rejected rather than silently
+ * dropped (matching the strict JSON API). Shared by search_cards + list_set_cards.
+ */
+export const formatParam = z
+    .enum(Object.values(Format) as [string, ...string[]])
+    .optional()
+    .describe("Filter to cards with a legality entry in this format (e.g. 'modern', 'commander').");

--- a/src/mcp/tools/common.ts
+++ b/src/mcp/tools/common.ts
@@ -30,7 +30,12 @@ export const DESTRUCTIVE: McpToolAnnotations = {
 };
 
 /** Described pagination params reused across every paginated list tool. */
-export const pageParam = z.number().int().min(1).optional().describe('1-based page index. Defaults to 1.');
+export const pageParam = z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe('1-based page index. Defaults to 1.');
 export const limitParam = z
     .number()
     .int()
@@ -47,3 +52,18 @@ export const formatParam = z
     .enum(Object.values(Format) as [string, ...string[]])
     .optional()
     .describe("Filter to cards with a legality entry in this format (e.g. 'modern', 'commander').");
+
+/**
+ * Rejects `legality` without `format`. Legality is only applied within a format
+ * join, so legality alone is a silently-ignored filter - the same combo the strict
+ * JSON API (`validateApiQuery`) 400s. Wrap a card-filter object schema with this.
+ */
+export function refineLegalityRequiresFormat<T extends z.ZodTypeAny>(schema: T) {
+    return schema.refine(
+        (v: { format?: unknown; legality?: unknown }) => !(v.legality && !v.format),
+        {
+            message: 'legality requires format to be set; it is only applied within a format.',
+            path: ['legality'],
+        }
+    );
+}

--- a/src/mcp/tools/common.ts
+++ b/src/mcp/tools/common.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import { Format } from 'src/core/card/format.enum';
+import { LegalityStatus } from 'src/core/card/legality.status.enum';
+import { PUBLIC_RARITIES } from 'src/core/query/safe-query-options.dto';
 import { McpToolAnnotations } from '../mcp-tool.types';
 
 /**
@@ -44,14 +46,23 @@ export const limitParam = z
     .optional()
     .describe('Page size, 1-100. Server default applies if omitted.');
 
-/**
- * Format-legality filter, enumerated so a typo is rejected rather than silently
- * dropped (matching the strict JSON API). Shared by search_cards + list_set_cards.
- */
+// Card catalog filters, enumerated from the same source enums the JSON API uses
+// so a typo is rejected rather than silently dropped, and the accepted values
+// can't drift from the REST contract. Shared by search_cards + list_set_cards.
+export const rarityParam = z
+    .enum([...PUBLIC_RARITIES] as [string, ...string[]])
+    .optional()
+    .describe('Filter by rarity.');
+
 export const formatParam = z
     .enum(Object.values(Format) as [string, ...string[]])
     .optional()
     .describe("Filter to cards with a legality entry in this format (e.g. 'modern', 'commander').");
+
+export const legalityParam = z
+    .enum(Object.values(LegalityStatus) as [string, ...string[]])
+    .optional()
+    .describe("Used with 'format'. Defaults to 'legal' when format is set.");
 
 /**
  * Rejects `legality` without `format`. Legality is only applied within a format

--- a/src/mcp/tools/sets.tools.ts
+++ b/src/mcp/tools/sets.tools.ts
@@ -15,25 +15,21 @@ import { McpToolContext, McpToolDefinition } from '../mcp-tool.types';
 import {
     READ_ONLY,
     formatParam,
+    legalityParam,
     limitParam,
     pageParam,
+    rarityParam,
     refineLegalityRequiresFormat,
 } from './common';
 
 const setCardFilters = {
-    rarity: z
-        .enum(['common', 'uncommon', 'rare', 'mythic'])
-        .optional()
-        .describe('Filter by rarity.'),
+    rarity: rarityParam,
     type: z
         .string()
         .optional()
         .describe("Substring match against card type line (e.g. 'Goblin', 'Instant')."),
     format: formatParam,
-    legality: z
-        .enum(['legal', 'banned', 'restricted'])
-        .optional()
-        .describe("Used with 'format'. Defaults to 'legal' when format is set."),
+    legality: legalityParam,
     page: pageParam,
     limit: limitParam,
 };

--- a/src/mcp/tools/sets.tools.ts
+++ b/src/mcp/tools/sets.tools.ts
@@ -12,7 +12,7 @@ import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
 import { SealedProductApiPresenter } from 'src/http/api/sealed-product/sealed-product-api.presenter';
 import { SetApiPresenter } from 'src/http/api/set/set-api.presenter';
 import { McpToolContext, McpToolDefinition } from '../mcp-tool.types';
-import { READ_ONLY, limitParam, pageParam } from './common';
+import { READ_ONLY, formatParam, limitParam, pageParam } from './common';
 
 const setCardFilters = {
     rarity: z.enum(['common', 'uncommon', 'rare', 'mythic']).optional().describe('Filter by rarity.'),
@@ -20,10 +20,7 @@ const setCardFilters = {
         .string()
         .optional()
         .describe("Substring match against card type line (e.g. 'Goblin', 'Instant')."),
-    format: z
-        .string()
-        .optional()
-        .describe("Filter to cards with a legality entry in this format (e.g. 'modern', 'commander')."),
+    format: formatParam,
     legality: z
         .enum(['legal', 'banned', 'restricted'])
         .optional()

--- a/src/mcp/tools/sets.tools.ts
+++ b/src/mcp/tools/sets.tools.ts
@@ -12,10 +12,19 @@ import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
 import { SealedProductApiPresenter } from 'src/http/api/sealed-product/sealed-product-api.presenter';
 import { SetApiPresenter } from 'src/http/api/set/set-api.presenter';
 import { McpToolContext, McpToolDefinition } from '../mcp-tool.types';
-import { READ_ONLY, formatParam, limitParam, pageParam } from './common';
+import {
+    READ_ONLY,
+    formatParam,
+    limitParam,
+    pageParam,
+    refineLegalityRequiresFormat,
+} from './common';
 
 const setCardFilters = {
-    rarity: z.enum(['common', 'uncommon', 'rare', 'mythic']).optional().describe('Filter by rarity.'),
+    rarity: z
+        .enum(['common', 'uncommon', 'rare', 'mythic'])
+        .optional()
+        .describe('Filter by rarity.'),
     type: z
         .string()
         .optional()
@@ -71,10 +80,12 @@ export class SetMcpTools {
                 name: 'list_set_cards',
                 description:
                     'List all cards in a set, paginated. Supports the same filters as search_cards (rarity, type, format, legality).',
-                inputSchema: z.object({
-                    code: z.string().describe('Set code.'),
-                    ...setCardFilters,
-                }),
+                inputSchema: refineLegalityRequiresFormat(
+                    z.object({
+                        code: z.string().describe('Set code.'),
+                        ...setCardFilters,
+                    })
+                ),
                 requiresAuth: false,
                 annotations: READ_ONLY,
                 handler: async (args) => this.listSetCards(args),

--- a/src/mcp/tools/transactions.tools.ts
+++ b/src/mcp/tools/transactions.tools.ts
@@ -5,7 +5,7 @@ import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
-import { parseTransactionType } from 'src/core/transaction/transaction.entity';
+import { TRANSACTION_TYPES, parseTransactionType } from 'src/core/transaction/transaction.entity';
 import { TransactionService } from 'src/core/transaction/transaction.service';
 import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
 import { TransactionApiPresenter } from 'src/http/api/transaction/transaction-api.presenter';
@@ -15,7 +15,7 @@ import { DESTRUCTIVE, IDEMPOTENT_WRITE, READ_ONLY, WRITE, limitParam, pageParam 
 
 const transactionCreate = z.object({
     cardId: z.string().uuid().describe('Internal IWMM card UUID.'),
-    type: z.enum(['BUY', 'SELL']).describe('Transaction type: BUY or SELL.'),
+    type: z.enum(TRANSACTION_TYPES).describe('Transaction type: BUY or SELL.'),
     quantity: z.number().int().min(1).describe('Number of copies transacted.'),
     pricePerUnit: z.number().min(0).describe('Per-unit price in USD.'),
     isFoil: z.boolean().describe('Whether the transacted copies are the foil finish.'),
@@ -74,8 +74,8 @@ export class TransactionMcpTools {
                     filter: z.string().optional().describe('Substring filter on card name.'),
                     type: z
                         .preprocess(
-                            (v) => (typeof v === 'string' ? v.toUpperCase() : v),
-                            z.enum(['BUY', 'SELL'])
+                            (v) => (typeof v === 'string' ? v.trim().toUpperCase() : v),
+                            z.enum(TRANSACTION_TYPES)
                         )
                         .optional()
                         .describe(

--- a/src/mcp/tools/transactions.tools.ts
+++ b/src/mcp/tools/transactions.tools.ts
@@ -4,7 +4,7 @@ import { freeTierHistoryCutoff } from 'src/core/billing/subscription-limits';
 import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
-import { SortOptions } from 'src/core/query/sort-options.enum';
+import { TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
 import { parseTransactionType } from 'src/core/transaction/transaction.entity';
 import { TransactionService } from 'src/core/transaction/transaction.service';
 import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
@@ -62,12 +62,7 @@ export class TransactionMcpTools {
                     page: pageParam,
                     limit: limitParam,
                     sort: z
-                        .enum([
-                            SortOptions.TX_DATE,
-                            SortOptions.TX_TYPE,
-                            SortOptions.TX_CARD,
-                            SortOptions.TX_PRICE,
-                        ])
+                        .enum(TRANSACTION_SORTS as unknown as [string, ...string[]])
                         .optional()
                         .describe(
                             "Sort key: 'transaction.date', 'transaction.type', 'transaction_card.name', or 'transaction.pricePerUnit'."
@@ -132,7 +127,9 @@ export class TransactionMcpTools {
                             .string()
                             .uuid()
                             .optional()
-                            .describe('Internal IWMM card UUID. Provide this, or setCode + setNumber.'),
+                            .describe(
+                                'Internal IWMM card UUID. Provide this, or setCode + setNumber.'
+                            ),
                         setCode: z
                             .string()
                             .optional()

--- a/src/mcp/tools/transactions.tools.ts
+++ b/src/mcp/tools/transactions.tools.ts
@@ -4,6 +4,7 @@ import { freeTierHistoryCutoff } from 'src/core/billing/subscription-limits';
 import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
+import { SortOptions } from 'src/core/query/sort-options.enum';
 import { parseTransactionType } from 'src/core/transaction/transaction.entity';
 import { TransactionService } from 'src/core/transaction/transaction.service';
 import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
@@ -61,9 +62,16 @@ export class TransactionMcpTools {
                     page: pageParam,
                     limit: limitParam,
                     sort: z
-                        .string()
+                        .enum([
+                            SortOptions.TX_DATE,
+                            SortOptions.TX_TYPE,
+                            SortOptions.TX_CARD,
+                            SortOptions.TX_PRICE,
+                        ])
                         .optional()
-                        .describe('Sort key (e.g. TX_DATE, TX_TYPE, TX_CARD, TX_PRICE).'),
+                        .describe(
+                            "Sort key: 'transaction.date', 'transaction.type', 'transaction_card.name', or 'transaction.pricePerUnit'."
+                        ),
                     ascend: z
                         .boolean()
                         .optional()

--- a/test/core/query/query.util.spec.ts
+++ b/test/core/query/query.util.spec.ts
@@ -1,0 +1,17 @@
+import { resolveSort } from 'src/core/query/query.util';
+import { SortOptions, TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
+
+describe('resolveSort', () => {
+    it('returns the sort when it is in the allowed set', () => {
+        expect(resolveSort(SortOptions.TX_DATE, TRANSACTION_SORTS)).toBe(SortOptions.TX_DATE);
+    });
+
+    it('returns undefined for a sort outside the allowed set', () => {
+        // a real SortOptions value, just not honorable by this context
+        expect(resolveSort(SortOptions.CARD, TRANSACTION_SORTS)).toBeUndefined();
+    });
+
+    it('returns undefined when no sort is requested', () => {
+        expect(resolveSort(undefined, TRANSACTION_SORTS)).toBeUndefined();
+    });
+});

--- a/test/core/query/safe-query-options.spec.ts
+++ b/test/core/query/safe-query-options.spec.ts
@@ -4,6 +4,33 @@ import { LegalityStatus } from 'src/core/card/legality.status.enum';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 
 describe('SafeQueryOptions — public catalog filters', () => {
+    describe('array (repeated) query params', () => {
+        it('does not throw on array values and treats them as not provided', () => {
+            // Express/qs parses `?setCode=a&setCode=b` as an array; the sanitizers
+            // must not call string methods on it (would 500). HBS callers stay lenient.
+            const raw = {
+                setCode: ['a', 'b'],
+                rarity: ['common', 'mythic'],
+                format: ['modern'],
+                legality: ['legal'],
+                filter: ['x', 'y'],
+                sort: ['card.name'],
+                type: ['BUY'],
+                baseOnly: ['true'],
+            } as never;
+            const opts = new SafeQueryOptions(raw);
+            expect(opts.setCode).toBeUndefined();
+            expect(opts.rarity).toBeUndefined();
+            expect(opts.format).toBeUndefined();
+            expect(opts.filter).toBeUndefined();
+            expect(opts.sort).toBeUndefined();
+            expect(opts.type).toBeUndefined();
+            // numeric/boolean params fall back to their defaults
+            expect(opts.limit).toBe(25);
+            expect(opts.page).toBe(1);
+        });
+    });
+
     describe('setCode', () => {
         it('lowercases set codes to match DB storage convention', () => {
             const opts = new SafeQueryOptions({ setCode: 'LEA' });
@@ -27,13 +54,10 @@ describe('SafeQueryOptions — public catalog filters', () => {
     });
 
     describe('rarity', () => {
-        it.each(['common', 'uncommon', 'rare', 'mythic'])(
-            'accepts %s',
-            (value) => {
-                const opts = new SafeQueryOptions({ rarity: value });
-                expect(opts.rarity).toBe(value as CardRarity);
-            }
-        );
+        it.each(['common', 'uncommon', 'rare', 'mythic'])('accepts %s', (value) => {
+            const opts = new SafeQueryOptions({ rarity: value });
+            expect(opts.rarity).toBe(value as CardRarity);
+        });
 
         it('lowercases incoming values', () => {
             const opts = new SafeQueryOptions({ rarity: 'RARE' });
@@ -146,10 +170,7 @@ describe('SafeQueryOptions — public catalog filters', () => {
         });
 
         it('stores includedSetTypes from constructor extra arg', () => {
-            const opts = new SafeQueryOptions(
-                {},
-                { includedSetTypes: ['expansion', 'commander'] }
-            );
+            const opts = new SafeQueryOptions({}, { includedSetTypes: ['expansion', 'commander'] });
             expect(opts.includedSetTypes).toEqual(['expansion', 'commander']);
         });
 
@@ -159,10 +180,9 @@ describe('SafeQueryOptions — public catalog filters', () => {
         });
 
         it('withSetTypes(null) clears the field', () => {
-            const opts = new SafeQueryOptions(
-                {},
-                { includedSetTypes: ['expansion'] }
-            ).withSetTypes(null);
+            const opts = new SafeQueryOptions({}, { includedSetTypes: ['expansion'] }).withSetTypes(
+                null
+            );
             expect(opts.includedSetTypes).toBeNull();
         });
 

--- a/test/core/transaction/transaction-type.spec.ts
+++ b/test/core/transaction/transaction-type.spec.ts
@@ -1,0 +1,24 @@
+import { TRANSACTION_TYPES, parseTransactionType } from 'src/core/transaction/transaction.entity';
+
+describe('parseTransactionType', () => {
+    it('lists exactly BUY and SELL as the valid types', () => {
+        expect(TRANSACTION_TYPES).toEqual(['BUY', 'SELL']);
+    });
+
+    it.each(['BUY', 'SELL', 'buy', 'sell', 'Buy'])('accepts %s case-insensitively', (input) => {
+        expect(parseTransactionType(input)).toBe(input.toUpperCase());
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(parseTransactionType('  sell  ')).toBe('SELL');
+    });
+
+    it('returns undefined for a typo', () => {
+        expect(parseTransactionType('BOUGHT')).toBeUndefined();
+    });
+
+    it('returns undefined for a non-string (e.g. a repeated/array param)', () => {
+        expect(parseTransactionType(['BUY', 'SELL'])).toBeUndefined();
+        expect(parseTransactionType(undefined)).toBeUndefined();
+    });
+});

--- a/test/database/query/query-builder.helper.spec.ts
+++ b/test/database/query/query-builder.helper.spec.ts
@@ -412,6 +412,17 @@ describe('QueryBuilderHelper', () => {
                 );
             });
 
+            it('throws at construction if defaultSort is not in allowedSorts', () => {
+                expect(
+                    () =>
+                        new QueryBuilderHelper({
+                            table: 'transaction',
+                            defaultSort: SortOptions.CARD,
+                            allowedSorts: [SortOptions.TX_DATE, SortOptions.TX_TYPE],
+                        })
+                ).toThrow(/defaultSort/);
+            });
+
             it('accepts any sort when no allowedSorts is configured (legacy)', () => {
                 const config: QueryBuilderConfig = {
                     table: 'card',

--- a/test/database/query/query-builder.helper.spec.ts
+++ b/test/database/query/query-builder.helper.spec.ts
@@ -367,6 +367,68 @@ describe('QueryBuilderHelper', () => {
 
             expect(customHandler).toHaveBeenCalledWith(mockQueryBuilder, 'DESC');
         });
+
+        describe('allowedSorts guard', () => {
+            const transactionConfig: QueryBuilderConfig = {
+                table: 'transaction',
+                defaultSort: SortOptions.TX_DATE,
+                defaultSortDesc: true,
+                allowedSorts: [SortOptions.TX_DATE, SortOptions.TX_TYPE],
+            };
+
+            it('honors a requested sort that is in the allowed set', () => {
+                const helper = new QueryBuilderHelper(transactionConfig);
+                const options = new SafeQueryOptions({
+                    sort: SortOptions.TX_TYPE,
+                    ascend: 'false',
+                });
+
+                helper.applyOrdering(mockQueryBuilder, options);
+
+                expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+                    SortOptions.TX_TYPE,
+                    'DESC',
+                    'NULLS LAST'
+                );
+            });
+
+            it('falls back to the default sort when a requested sort is not allowed', () => {
+                const helper = new QueryBuilderHelper(transactionConfig);
+                // card.name is a real SortOptions value but references an alias this
+                // query never joins - would be a SQL error if passed to orderBy.
+                const options = new SafeQueryOptions({ sort: SortOptions.CARD });
+
+                helper.applyOrdering(mockQueryBuilder, options);
+
+                expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+                    SortOptions.TX_DATE,
+                    'ASC',
+                    'NULLS LAST'
+                );
+                expect(mockQueryBuilder.orderBy).not.toHaveBeenCalledWith(
+                    SortOptions.CARD,
+                    expect.anything(),
+                    expect.anything()
+                );
+            });
+
+            it('accepts any sort when no allowedSorts is configured (legacy)', () => {
+                const config: QueryBuilderConfig = {
+                    table: 'card',
+                    defaultSort: SortOptions.NUMBER,
+                };
+                const helper = new QueryBuilderHelper(config);
+                const options = new SafeQueryOptions({ sort: SortOptions.CARD_SET });
+
+                helper.applyOrdering(mockQueryBuilder, options);
+
+                expect(mockQueryBuilder.orderBy).toHaveBeenCalledWith(
+                    SortOptions.CARD_SET,
+                    'ASC',
+                    'NULLS LAST'
+                );
+            });
+        });
     });
 
     describe('QueryBuilderConfig', () => {

--- a/test/http/api/shared/query-validation.spec.ts
+++ b/test/http/api/shared/query-validation.spec.ts
@@ -1,0 +1,144 @@
+import {
+    InvalidQueryParamException,
+    validateApiQuery,
+} from 'src/http/api/shared/query-validation';
+
+const ALL_FLAGS = {
+    sort: true,
+    rarity: true,
+    format: true,
+    legality: true,
+    setCode: true,
+    transactionType: true,
+};
+
+describe('validateApiQuery', () => {
+    describe('valid values pass', () => {
+        it('accepts a fully valid query', () => {
+            expect(() =>
+                validateApiQuery(
+                    {
+                        sort: 'card.name',
+                        rarity: 'rare',
+                        format: 'modern',
+                        legality: 'banned',
+                        setCode: 'mh3',
+                        type: 'BUY',
+                    },
+                    ALL_FLAGS
+                )
+            ).not.toThrow();
+        });
+
+        it('treats absent and empty values as "not provided"', () => {
+            expect(() => validateApiQuery({}, ALL_FLAGS)).not.toThrow();
+            expect(() =>
+                validateApiQuery(
+                    { sort: '', rarity: '   ', format: undefined, setCode: '' },
+                    ALL_FLAGS
+                )
+            ).not.toThrow();
+        });
+
+        it('is case-insensitive for rarity, format, legality, and type', () => {
+            expect(() =>
+                validateApiQuery(
+                    { rarity: 'COMMON', format: 'Standard', legality: 'Legal', type: 'sell' },
+                    ALL_FLAGS
+                )
+            ).not.toThrow();
+        });
+
+        it('trims surrounding whitespace on setCode', () => {
+            expect(() => validateApiQuery({ setCode: '  mh3  ' }, { setCode: true })).not.toThrow();
+        });
+    });
+
+    describe('invalid values throw 400 with the offending param and allowed values', () => {
+        it('rejects an unknown rarity', () => {
+            try {
+                validateApiQuery({ rarity: 'foobar' }, ALL_FLAGS);
+                fail('expected throw');
+            } catch (e) {
+                expect(e).toBeInstanceOf(InvalidQueryParamException);
+                const err = e as InvalidQueryParamException;
+                expect(err.getStatus()).toBe(400);
+                expect(err.param).toBe('rarity');
+                expect(err.allowedValues).toEqual(['common', 'uncommon', 'rare', 'mythic']);
+                expect(err.message).toContain("Invalid value 'foobar'");
+                expect(err.message).toContain('common, uncommon, rare, mythic');
+            }
+        });
+
+        it('rejects a non-public rarity (bonus/special)', () => {
+            expect(() => validateApiQuery({ rarity: 'bonus' }, { rarity: true })).toThrow(
+                InvalidQueryParamException
+            );
+        });
+
+        it('rejects an unknown format', () => {
+            const err = capture({ format: 'pioneerish' }, { format: true });
+            expect(err.param).toBe('format');
+            expect(err.allowedValues).toContain('pioneer');
+        });
+
+        it('rejects an unknown legality', () => {
+            const err = capture({ legality: 'maybe' }, { legality: true });
+            expect(err.param).toBe('legality');
+            expect(err.allowedValues).toEqual(['legal', 'banned', 'restricted']);
+        });
+
+        it('rejects an unknown sort key', () => {
+            const err = capture({ sort: 'card.bogus' }, { sort: true });
+            expect(err.param).toBe('sort');
+            expect(err.allowedValues).toContain('card.name');
+        });
+
+        it('rejects sort by enum name rather than value (exact match)', () => {
+            expect(() => validateApiQuery({ sort: 'CARD' }, { sort: true })).toThrow(
+                InvalidQueryParamException
+            );
+        });
+
+        it('rejects an invalid transaction type', () => {
+            const err = capture({ type: 'BOUGHT' }, { transactionType: true });
+            expect(err.param).toBe('type');
+            expect(err.allowedValues).toEqual(['BUY', 'SELL']);
+        });
+
+        it('rejects a malformed setCode without an allowedValues list', () => {
+            const err = capture({ setCode: 'mh-3' }, { setCode: true });
+            expect(err.param).toBe('setCode');
+            expect(err.allowedValues).toBeUndefined();
+            expect(err.message).toContain('letters and digits');
+        });
+    });
+
+    describe('flag gating', () => {
+        it('does not validate a filter the endpoint does not consume', () => {
+            expect(() => validateApiQuery({ rarity: 'foobar' }, { sort: true })).not.toThrow();
+            expect(() =>
+                validateApiQuery({ type: 'BOUGHT' }, { sort: true, rarity: true })
+            ).not.toThrow();
+        });
+    });
+
+    describe('multiple invalid params', () => {
+        it('throws on setCode first by validation order', () => {
+            const err = capture({ setCode: 'bad!', sort: 'nope' }, ALL_FLAGS);
+            expect(err.param).toBe('setCode');
+        });
+    });
+});
+
+function capture(
+    query: Record<string, string | undefined>,
+    flags: Parameters<typeof validateApiQuery>[1]
+): InvalidQueryParamException {
+    try {
+        validateApiQuery(query, flags);
+    } catch (e) {
+        return e as InvalidQueryParamException;
+    }
+    throw new Error('expected validateApiQuery to throw');
+}

--- a/test/http/api/shared/query-validation.spec.ts
+++ b/test/http/api/shared/query-validation.spec.ts
@@ -1,10 +1,8 @@
-import {
-    InvalidQueryParamException,
-    validateApiQuery,
-} from 'src/http/api/shared/query-validation';
+import { SET_CARD_SORTS, SortOptions, TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
+import { InvalidQueryParamException, validateApiQuery } from 'src/http/api/shared/query-validation';
 
 const ALL_FLAGS = {
-    sort: true,
+    sort: SET_CARD_SORTS,
     rarity: true,
     format: true,
     legality: true,
@@ -18,7 +16,7 @@ describe('validateApiQuery', () => {
             expect(() =>
                 validateApiQuery(
                     {
-                        sort: 'card.name',
+                        sort: SortOptions.CARD,
                         rarity: 'rare',
                         format: 'modern',
                         legality: 'banned',
@@ -43,7 +41,12 @@ describe('validateApiQuery', () => {
         it('is case-insensitive for rarity, format, legality, and type', () => {
             expect(() =>
                 validateApiQuery(
-                    { rarity: 'COMMON', format: 'Standard', legality: 'Legal', type: 'sell' },
+                    {
+                        rarity: 'COMMON',
+                        format: 'Standard',
+                        legality: 'Legal',
+                        type: 'sell',
+                    },
                     ALL_FLAGS
                 )
             ).not.toThrow();
@@ -82,22 +85,10 @@ describe('validateApiQuery', () => {
             expect(err.allowedValues).toContain('pioneer');
         });
 
-        it('rejects an unknown legality', () => {
-            const err = capture({ legality: 'maybe' }, { legality: true });
+        it('rejects an unknown legality value', () => {
+            const err = capture({ legality: 'maybe', format: 'modern' }, ALL_FLAGS);
             expect(err.param).toBe('legality');
             expect(err.allowedValues).toEqual(['legal', 'banned', 'restricted']);
-        });
-
-        it('rejects an unknown sort key', () => {
-            const err = capture({ sort: 'card.bogus' }, { sort: true });
-            expect(err.param).toBe('sort');
-            expect(err.allowedValues).toContain('card.name');
-        });
-
-        it('rejects sort by enum name rather than value (exact match)', () => {
-            expect(() => validateApiQuery({ sort: 'CARD' }, { sort: true })).toThrow(
-                InvalidQueryParamException
-            );
         });
 
         it('rejects an invalid transaction type', () => {
@@ -114,11 +105,55 @@ describe('validateApiQuery', () => {
         });
     });
 
+    describe('legality requires format', () => {
+        it('400s legality when format is absent', () => {
+            const err = capture({ legality: 'banned' }, { legality: true });
+            expect(err.param).toBe('legality');
+            expect(err.allowedValues).toBeUndefined();
+            expect(err.message).toContain('format');
+        });
+
+        it('accepts legality when format is present', () => {
+            expect(() =>
+                validateApiQuery({ legality: 'banned', format: 'modern' }, ALL_FLAGS)
+            ).not.toThrow();
+        });
+    });
+
+    describe('endpoint-scoped sort', () => {
+        it('accepts a sort the endpoint can honor', () => {
+            expect(() =>
+                validateApiQuery({ sort: SortOptions.TX_DATE }, { sort: TRANSACTION_SORTS })
+            ).not.toThrow();
+        });
+
+        it('400s a globally-valid sort the endpoint cannot honor', () => {
+            // card.name is a real SortOptions value but not joinable by the
+            // transaction query - this used to 500, now it 400s.
+            const err = capture({ sort: SortOptions.CARD }, { sort: TRANSACTION_SORTS });
+            expect(err.param).toBe('sort');
+            expect(err.allowedValues).toEqual([...TRANSACTION_SORTS]);
+            expect(err.message).toContain(SortOptions.CARD);
+        });
+
+        it('400s a sort that is not a SortOptions value at all', () => {
+            expect(() =>
+                validateApiQuery({ sort: 'card.bogus' }, { sort: SET_CARD_SORTS })
+            ).toThrow(InvalidQueryParamException);
+        });
+
+        it('does not validate sort when the endpoint passes no sort set', () => {
+            expect(() => validateApiQuery({ sort: 'anything' }, { rarity: true })).not.toThrow();
+        });
+    });
+
     describe('flag gating', () => {
         it('does not validate a filter the endpoint does not consume', () => {
-            expect(() => validateApiQuery({ rarity: 'foobar' }, { sort: true })).not.toThrow();
             expect(() =>
-                validateApiQuery({ type: 'BOUGHT' }, { sort: true, rarity: true })
+                validateApiQuery({ rarity: 'foobar' }, { sort: SET_CARD_SORTS })
+            ).not.toThrow();
+            expect(() =>
+                validateApiQuery({ type: 'BOUGHT' }, { sort: SET_CARD_SORTS, rarity: true })
             ).not.toThrow();
         });
     });

--- a/test/http/api/shared/query-validation.spec.ts
+++ b/test/http/api/shared/query-validation.spec.ts
@@ -97,11 +97,31 @@ describe('validateApiQuery', () => {
             expect(err.allowedValues).toEqual(['BUY', 'SELL']);
         });
 
+        it('accepts a whitespace-padded transaction type (reuses parseTransactionType)', () => {
+            // parseTransactionType trims, and it is the same gate the controller
+            // filters with, so the validator must accept what the filter accepts.
+            expect(() =>
+                validateApiQuery({ type: '  sell  ' }, { transactionType: true })
+            ).not.toThrow();
+        });
+
         it('rejects a malformed setCode without an allowedValues list', () => {
             const err = capture({ setCode: 'mh-3' }, { setCode: true });
             expect(err.param).toBe('setCode');
             expect(err.allowedValues).toBeUndefined();
             expect(err.message).toContain('letters and digits');
+        });
+    });
+
+    describe('repeated (array) query params', () => {
+        it('400s a param parsed as an array instead of throwing a 500', () => {
+            const err = capture({ setCode: ['mh3', 'lea'] }, { setCode: true });
+            expect(err.param).toBe('setCode');
+            expect(err.message).toContain('single value');
+        });
+
+        it('does not choke on an array for a param the endpoint ignores', () => {
+            expect(() => validateApiQuery({ filter: ['a', 'b'] }, { setCode: true })).not.toThrow();
         });
     });
 
@@ -167,7 +187,7 @@ describe('validateApiQuery', () => {
 });
 
 function capture(
-    query: Record<string, string | undefined>,
+    query: Record<string, unknown>,
     flags: Parameters<typeof validateApiQuery>[1]
 ): InvalidQueryParamException {
     try {

--- a/test/integration/api-cards.e2e-spec.ts
+++ b/test/integration/api-cards.e2e-spec.ts
@@ -73,9 +73,9 @@ describe('Cards API (e2e)', () => {
                     .get('/api/v1/cards?q=Test&setCode=TST')
                     .expect(200);
 
-                expect(
-                    res.body.data.every((c: { setCode: string }) => c.setCode === 'tst')
-                ).toBe(true);
+                expect(res.body.data.every((c: { setCode: string }) => c.setCode === 'tst')).toBe(
+                    true
+                );
                 expect(res.body.data.length).toBeGreaterThan(0);
             });
 
@@ -185,10 +185,23 @@ describe('Cards API (e2e)', () => {
                 expect(res.body.allowedValues).toBeUndefined();
             });
 
-            it('400s on invalid filter even without a search term', async () => {
-                await request(app.getHttpServer())
-                    .get('/api/v1/cards?rarity=foobar')
+            it('returns 400 (not 500) for a repeated param parsed as an array', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&setCode=mh3&setCode=lea')
                     .expect(400);
+
+                expect(res.body.param).toBe('setCode');
+                expect(res.body.error).toContain('single value');
+            });
+
+            it('does not 500 when a non-validated param is repeated', async () => {
+                await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&filter=a&filter=b')
+                    .expect(200);
+            });
+
+            it('400s on invalid filter even without a search term', async () => {
+                await request(app.getHttpServer()).get('/api/v1/cards?rarity=foobar').expect(400);
             });
         });
     });

--- a/test/integration/api-cards.e2e-spec.ts
+++ b/test/integration/api-cards.e2e-spec.ts
@@ -141,6 +141,50 @@ describe('Cards API (e2e)', () => {
                 expect(filtered.body.meta.total).toBeLessThan(unfiltered.body.meta.total);
             });
         });
+
+        describe('strict filter validation', () => {
+            it('returns 400 with param + allowedValues for an unknown rarity', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&rarity=foobar')
+                    .expect(400);
+
+                expect(res.body.success).toBe(false);
+                expect(res.body.param).toBe('rarity');
+                expect(res.body.allowedValues).toEqual(['common', 'uncommon', 'rare', 'mythic']);
+                expect(res.body.error).toContain("Invalid value 'foobar'");
+            });
+
+            it('returns 400 for an unknown format', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&format=pioneerish')
+                    .expect(400);
+
+                expect(res.body.param).toBe('format');
+            });
+
+            it('returns 400 for an unknown sort key', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&sort=card.bogus')
+                    .expect(400);
+
+                expect(res.body.param).toBe('sort');
+            });
+
+            it('returns 400 for a malformed setCode (no allowedValues list)', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&setCode=mh-3')
+                    .expect(400);
+
+                expect(res.body.param).toBe('setCode');
+                expect(res.body.allowedValues).toBeUndefined();
+            });
+
+            it('400s on invalid filter even without a search term', async () => {
+                await request(app.getHttpServer())
+                    .get('/api/v1/cards?rarity=foobar')
+                    .expect(400);
+            });
+        });
     });
 
     describe('GET /api/v1/cards/:setCode/:setNumber', () => {

--- a/test/integration/api-cards.e2e-spec.ts
+++ b/test/integration/api-cards.e2e-spec.ts
@@ -162,12 +162,18 @@ describe('Cards API (e2e)', () => {
                 expect(res.body.param).toBe('format');
             });
 
-            it('returns 400 for an unknown sort key', async () => {
+            it('returns 400 for legality without format', async () => {
                 const res = await request(app.getHttpServer())
-                    .get('/api/v1/cards?q=Test&sort=card.bogus')
+                    .get('/api/v1/cards?q=Test&legality=banned')
                     .expect(400);
 
-                expect(res.body.param).toBe('sort');
+                expect(res.body.param).toBe('legality');
+            });
+
+            it('ignores sort (card search is name-ordered) rather than 400ing', async () => {
+                await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&sort=card.bogus')
+                    .expect(200);
             });
 
             it('returns 400 for a malformed setCode (no allowedValues list)', async () => {

--- a/test/integration/api-sets.e2e-spec.ts
+++ b/test/integration/api-sets.e2e-spec.ts
@@ -180,6 +180,15 @@ describe('Sets API (e2e)', () => {
 
                 expect(res.body.data).toEqual([]);
             });
+
+            it('returns 400 for an unknown rarity', async () => {
+                const res = await request(app.getHttpServer())
+                    .get(`/api/v1/sets/${TEST_SET_CODE}/cards?rarity=foobar`)
+                    .expect(400);
+
+                expect(res.body.success).toBe(false);
+                expect(res.body.param).toBe('rarity');
+            });
         });
     });
 

--- a/test/integration/api-transactions.e2e-spec.ts
+++ b/test/integration/api-transactions.e2e-spec.ts
@@ -214,6 +214,26 @@ describe('Transactions API (e2e)', () => {
             expect(types.has('BUY')).toBe(true);
             expect(types.has('SELL')).toBe(true);
         });
+
+        it('?type=BOUGHT returns 400 instead of silently ignoring the filter', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/transactions?type=BOUGHT')
+                .set('Authorization', bearerToken)
+                .expect(400);
+
+            expect(res.body.success).toBe(false);
+            expect(res.body.param).toBe('type');
+            expect(res.body.allowedValues).toEqual(['BUY', 'SELL']);
+        });
+
+        it('?sort=bogus returns 400', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/transactions?sort=bogus')
+                .set('Authorization', bearerToken)
+                .expect(400);
+
+            expect(res.body.param).toBe('sort');
+        });
     });
 
     describe('Validation', () => {

--- a/test/integration/api-transactions.e2e-spec.ts
+++ b/test/integration/api-transactions.e2e-spec.ts
@@ -234,6 +234,21 @@ describe('Transactions API (e2e)', () => {
 
             expect(res.body.param).toBe('sort');
         });
+
+        it('?sort=card.name (valid enum, inapplicable here) returns 400 not 500', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/transactions?sort=card.name')
+                .set('Authorization', bearerToken)
+                .expect(400);
+
+            expect(res.body.param).toBe('sort');
+            expect(res.body.allowedValues).toEqual([
+                'transaction.date',
+                'transaction.type',
+                'transaction_card.name',
+                'transaction.pricePerUnit',
+            ]);
+        });
     });
 
     describe('Validation', () => {

--- a/test/integration/api-transactions.e2e-spec.ts
+++ b/test/integration/api-transactions.e2e-spec.ts
@@ -235,6 +235,16 @@ describe('Transactions API (e2e)', () => {
             expect(res.body.param).toBe('sort');
         });
 
+        it('?type=%20SELL%20 (whitespace) is accepted, matching the filter gate', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/transactions?type=%20SELL%20')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.body.data.length).toBeGreaterThan(0);
+            expect(res.body.data.every((t: any) => t.type === 'SELL')).toBe(true);
+        });
+
         it('?sort=card.name (valid enum, inapplicable here) returns 400 not 500', async () => {
             const res = await request(app.getHttpServer())
                 .get('/api/v1/transactions?sort=card.name')


### PR DESCRIPTION
400 on invalid rarity/format/legality/sort, malformed setCode, and bad
transaction type instead of silently dropping the filter. Layered in front
of SafeQueryOptions so HBS pages stay lenient. MCP format/sort tightened to
enums. Bump 1.30.0.