### PR TITLE
refactor(views): bind HBS sortable headers to honorable sort sets (Roadmap 4.5)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Shipped work is condensed to one line per section under **Done**; small leftover
 items from those shipped sections live under **Catch-up**. Active and future work
-(4.4 onward) is kept in full detail. Verbose history of completed work lives in
+(Phase 6 onward) is kept in full detail. Verbose history of completed work lives in
 `CHANGELOG.md` and git.
 
 ---
@@ -43,11 +43,13 @@ items from those shipped sections live under **Catch-up**. Active and future wor
 - **3.3 Affiliate integration** — TCGPlayer Impact partner; `AffiliateLinkPolicy` wraps product URLs on card + sealed views.
 - **3.4 Freemium & billing** — Stripe subscriptions (Checkout, portal, webhooks), `SubscriptionGuard`, depth-gating site-wide, `/pricing`, analytics breakdown. *(model in Appendix)*
 
-### Phase 4: API & Developer Ecosystem (4.1–4.3)
+### Phase 4: API & Developer Ecosystem (4.1–4.5)
 
 - **4.1 API monetization & tiering** — `api_subscription`/`api_key`/`api_usage` (migration 032), per-user tier limits, key management + usage dashboard at `/user/api-keys`. *(loose ends in Catch-up)*
 - **4.2 Developer portal** — `/developer` hub, Redoc docs, three tutorial guides, public OpenAPI spec, RapidAPI listing live + proxy guard. *(loose ends in Catch-up)*
 - **4.3 MCP server** — stdio server (separate repo) + in-app streamable-HTTP `/mcp` (33 tools), typed API client, published to npm/registry/Glama/Smithery, Reddit + tutorial + demo GIF. *(loose ends in Catch-up)*
+- **4.4 Strict query-param validation (JSON API)** — `validateApiQuery()` 400s invalid filter values (`rarity`/`format`/`legality`/`sort`/`setCode`, transaction `type`) on the API controllers while `SafeQueryOptions` stays lenient for HBS/internal callers; per-context honorable sort sets in `sort-options.enum.ts` shared by repositories + validator and mirrored in the MCP tools. *(PR #507)*
+- **4.5 Unify HBS sortable headers with the honorable sort sets** — per-context typed header factories (`setCardSortHeader`/`setSortHeader`/`inventorySortHeader`/`transactionSortHeader`) bind each orchestrator's sortable columns to the matching `*_SORTS` set, so a header offering a non-honorable sort fails to compile (offered ⊆ honorable enforced at build time, not just currently-true).
 
 ### Other shipped
 
@@ -63,33 +65,6 @@ Small leftover items from otherwise-shipped sections (Phases 1–4.3). Mostly ma
 
 - **4.1 API tiering** — `api_usage` retention sweeper (daily cron, delete rows older than 90 days; revisit at ~1M rows); create Stripe API Developer/Business products + set `STRIPE_PRICE_API_*` in dev and prod (manual, not code).
 - **4.2 Developer portal** — run RapidAPI's "Test Endpoint" flow on each endpoint and fix unexpected shapes; list on adjacent free marketplaces (APIs.guru, Postman, public-apis) once RapidAPI is stable; color filtering (`?color=`, `?colorIdentity=`) on card search — blocked on Scry populating `card.colors` (see 10.2). Remaining Studio form-filling tracked in [`RAPIDAPI.md`](RAPIDAPI.md).
-
----
-
-## Active & upcoming
-
-### 4.4 Strict Query-Param Validation on the JSON API
-
-**Next up.** The `/api/v1` list endpoints silently ignore invalid query params: `SafeQueryOptions` drops unknown `rarity`/`format`/`legality`/`sort` and malformed `setCode` to `undefined`, and the transaction `type` filter (parsed separately via `parseTransactionType`) treats a typo like `?type=BOUGHT` as "no filter". For a browser that is fine, but for programmatic API consumers a silently-ignored filter is a footgun - they get unfiltered results and assume the filter worked.
-
-The constraint is that `SafeQueryOptions` is one shared sanitizer used by ~20 call sites, including the server-rendered HBS browse/search pages, which *need* the lenient fallback (a stale `?rarity=foobar` bookmark must still render the page, not 400). So the fix is a validation layer in front of the API controllers, not a change to the shared sanitizer's defaulting.
-
-Surfaced by Copilot on PR #497 (transaction `type`); deferred from that PR because 400-ing `type` alone would be inconsistent with every other filter.
-
-- [x] Add a strict validation path for the JSON API that returns 400 on invalid filter values (unknown `rarity`/`format`/`legality`/`sort`, malformed `setCode`, invalid transaction `type`) instead of silent fallback. `validateApiQuery()` (`src/http/api/shared/query-validation.ts`) runs in front of `SafeQueryOptions` on the API controllers; the sanitizer is unchanged.
-- [x] Keep `SafeQueryOptions` lenient for the HBS browse/search pages and the internal service callers - no 400s there.
-- [x] Apply consistently across cards, set-cards, set-list, inventory, and transactions. (The sealed-product list endpoints read only `page`/`limit` - no enumerated filter to validate.)
-- [x] Align the MCP tools: `format` is now an enum in `search_cards`/`list_set_cards` and `list_transactions` `sort` is an enum, so typos are rejected rather than silently dropped (the `type` enum already did).
-- [x] Contract settled: 400 body is `{ success: false, error, param, allowedValues }` (`allowedValues` omitted for `setCode`), documented via `QueryValidationErrorDto` + `@ApiResponse(400)` on each endpoint.
-- [x] PR #507 review follow-ups: `sort` is validated against each endpoint's honorable set (per-context constants in `sort-options.enum.ts`) rather than the global enum - an endpoint-inapplicable sort (e.g. `?sort=card.name` on `/transactions`) now 400s instead of 500ing. The ordering paths (`QueryBuilderHelper`, set `addSetOrdering`) fall back to the context default via `resolveSort()`, so HBS/internal callers can't hit the SQL error either. `legality` without `format` now 400s (mirrored in the MCP card tools).
-
-### 4.5 Unify HBS sortable headers with the honorable sort sets
-
-Follow-up from 4.4 (PR #507). The per-context honorable sort sets (`SET_CARD_SORTS`/`SET_SORTS`/`INVENTORY_SORTS`/`TRANSACTION_SORTS` in `sort-options.enum.ts`) are the single source of truth for "what a query can sort by", consumed by the repositories (`QueryBuilderHelper.allowedSorts` / set `addSetOrdering`) and the API validator. But each HBS orchestrator still lists its clickable `SortableHeaderView` columns independently. They agree today and a mismatch can't 500 (the `resolveSort` fallback degrades an inapplicable sort to the context default), but nothing *enforces* that every offered header is honorable - so a future header edit could quietly become a dead sort (UI says sortable, click falls back to default; the API would 400 the same value).
-
-- [ ] Decide the mechanism: derive each orchestrator's sortable headers from the honorable set (headers carry labels via `SortOptionLabels` + per-column CSS, so a small per-context header-config table is likely cleaner than a raw list), or keep the lists but add a guardrail test that asserts every `SortableHeaderView` sort key is a member of the matching `*_SORTS` set.
-- [ ] Implement the chosen approach so "offered ⊆ honorable" is enforced, not just currently-true.
-- [ ] Re-verify the browse/inventory/transaction/set pages with Playwright (sort links still work, default ordering unchanged) since this touches the view layer.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.30.0",
+    "version": "1.30.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "i-want-my-mtg",
-            "version": "1.30.0",
+            "version": "1.30.1",
             "license": "UNLICENSED",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.30.0",
+    "version": "1.30.1",
     "description": "MTG Collection Tracker",
     "author": "Matthew Towles",
     "private": true,

--- a/src/core/query/sort-options.enum.ts
+++ b/src/core/query/sort-options.enum.ts
@@ -49,22 +49,22 @@ export const SortOptionLabels: Record<SortOptions, string> = {
  * and ignores `sort` entirely, matching the `search_cards` MCP tool which exposes
  * no sort param.
  */
-export const SET_CARD_SORTS: readonly SortOptions[] = [
+export const SET_CARD_SORTS = [
     SortOptions.CARD,
     SortOptions.CARD_SET,
     SortOptions.NUMBER,
     SortOptions.PRICE,
     SortOptions.PRICE_FOIL,
-];
+] as const;
 
-export const SET_SORTS: readonly SortOptions[] = [
+export const SET_SORTS = [
     SortOptions.SET,
     SortOptions.SET_CODE,
     SortOptions.RELEASE_DATE,
     SortOptions.SET_BASE_PRICE,
-];
+] as const;
 
-export const INVENTORY_SORTS: readonly SortOptions[] = [
+export const INVENTORY_SORTS = [
     SortOptions.OWNED_QUANTITY,
     SortOptions.CARD,
     SortOptions.CARD_SET,
@@ -74,11 +74,11 @@ export const INVENTORY_SORTS: readonly SortOptions[] = [
     SortOptions.SET,
     SortOptions.SET_CODE,
     SortOptions.RELEASE_DATE,
-];
+] as const;
 
-export const TRANSACTION_SORTS: readonly SortOptions[] = [
+export const TRANSACTION_SORTS = [
     SortOptions.TX_DATE,
     SortOptions.TX_TYPE,
     SortOptions.TX_CARD,
     SortOptions.TX_PRICE,
-];
+] as const;

--- a/src/http/hbs/card/card.orchestrator.ts
+++ b/src/http/hbs/card/card.orchestrator.ts
@@ -14,7 +14,7 @@ import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { InventoryPresenter } from 'src/http/hbs/inventory/inventory.presenter';
 import { FilterView } from 'src/http/hbs/list/filter.view';
 import { PaginationView } from 'src/http/hbs/list/pagination.view';
-import { SortableHeaderView } from 'src/http/hbs/list/sortable-header.view';
+import { setCardSortHeader } from 'src/http/hbs/list/sortable-header.view';
 import { TableHeaderView } from 'src/http/hbs/list/table-header.view';
 import { TableHeadersRowView } from 'src/http/hbs/list/table-headers-row.view';
 import { TransactionPresenter } from 'src/http/hbs/transaction/transaction.presenter';
@@ -145,16 +145,14 @@ export class CardOrchestrator {
             const hasAnyFoilPrice = otherPrintings.some((c) => c.foilPriceRaw > 0);
 
             const printingHeaders = [
-                new SortableHeaderView(options, SortOptions.CARD_SET, ['pl-2']),
+                setCardSortHeader(options, SortOptions.CARD_SET, ['pl-2']),
                 new TableHeaderView('Card'),
             ];
             if (hasAnyNormalPrice) {
-                printingHeaders.push(new SortableHeaderView(options, SortOptions.PRICE));
+                printingHeaders.push(setCardSortHeader(options, SortOptions.PRICE));
             }
             if (hasAnyFoilPrice) {
-                printingHeaders.push(
-                    new SortableHeaderView(options, SortOptions.PRICE_FOIL, ['pr-2'])
-                );
+                printingHeaders.push(setCardSortHeader(options, SortOptions.PRICE_FOIL, ['pr-2']));
             }
 
             return new CardViewDto({

--- a/src/http/hbs/inventory/inventory.orchestrator.ts
+++ b/src/http/hbs/inventory/inventory.orchestrator.ts
@@ -24,7 +24,7 @@ import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { BaseOnlyToggleView } from 'src/http/hbs/list/base-only-toggle.view';
 import { FilterView } from 'src/http/hbs/list/filter.view';
 import { PaginationView } from 'src/http/hbs/list/pagination.view';
-import { SortableHeaderView } from 'src/http/hbs/list/sortable-header.view';
+import { inventorySortHeader } from 'src/http/hbs/list/sortable-header.view';
 import { TableHeaderView } from 'src/http/hbs/list/table-header.view';
 import { TableHeadersRowView } from 'src/http/hbs/list/table-headers-row.view';
 import { buildToggleConfig } from 'src/http/hbs/list/toggle-config';
@@ -114,10 +114,10 @@ export class InventoryOrchestrator {
                 pagination: new PaginationView(options, baseUrl, currentCount),
                 filter: new FilterView(options, baseUrl),
                 tableHeadersRow: new TableHeadersRowView([
-                    new SortableHeaderView(options, SortOptions.OWNED_QUANTITY, ['pl-2']),
-                    new SortableHeaderView(options, SortOptions.CARD),
-                    new SortableHeaderView(options, SortOptions.CARD_SET),
-                    new SortableHeaderView(options, SortOptions.PRICE),
+                    inventorySortHeader(options, SortOptions.OWNED_QUANTITY, ['pl-2']),
+                    inventorySortHeader(options, SortOptions.CARD),
+                    inventorySortHeader(options, SortOptions.CARD_SET),
+                    inventorySortHeader(options, SortOptions.PRICE),
                     new TableHeaderView('', ['pr-2', 'xs-hide']),
                 ]),
             });

--- a/src/http/hbs/list/sortable-header.view.ts
+++ b/src/http/hbs/list/sortable-header.view.ts
@@ -1,5 +1,12 @@
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
-import { SortOptionLabels, SortOptions } from 'src/core/query/sort-options.enum';
+import {
+    INVENTORY_SORTS,
+    SET_CARD_SORTS,
+    SET_SORTS,
+    SortOptionLabels,
+    SortOptions,
+    TRANSACTION_SORTS,
+} from 'src/core/query/sort-options.enum';
 import { buildQueryString } from 'src/http/base/http.util';
 import { TableHeaderView } from './table-header.view';
 
@@ -18,3 +25,25 @@ export class SortableHeaderView extends TableHeaderView {
         this.href = buildQueryString({ ...options, sort: sortOption, ascend: this.ascend });
     }
 }
+
+/**
+ * Per-context header factories. Each binds a clickable column's sort key to the
+ * honorable sort set its list query honors (the `*_SORTS` constants in
+ * sort-options.enum, shared by the repositories and the API validator). A header
+ * that offers a sort outside its set fails to compile, so "offered ⊆ honorable"
+ * is enforced at build time rather than only happening to hold today.
+ */
+const headerFactory =
+    <T extends SortOptions>() =>
+    (
+        options: SafeQueryOptions,
+        sort: T,
+        classes?: string[],
+        subtitle?: string
+    ): SortableHeaderView =>
+        new SortableHeaderView(options, sort, classes, subtitle);
+
+export const setCardSortHeader = headerFactory<(typeof SET_CARD_SORTS)[number]>();
+export const setSortHeader = headerFactory<(typeof SET_SORTS)[number]>();
+export const inventorySortHeader = headerFactory<(typeof INVENTORY_SORTS)[number]>();
+export const transactionSortHeader = headerFactory<(typeof TRANSACTION_SORTS)[number]>();

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -24,7 +24,7 @@ import { SealedProductHbsPresenter } from 'src/http/hbs/sealed-product/sealed-pr
 import { BaseOnlyToggleView } from 'src/http/hbs/list/base-only-toggle.view';
 import { FilterView } from 'src/http/hbs/list/filter.view';
 import { PaginationView } from 'src/http/hbs/list/pagination.view';
-import { SortableHeaderView } from 'src/http/hbs/list/sortable-header.view';
+import { setCardSortHeader, setSortHeader } from 'src/http/hbs/list/sortable-header.view';
 import { TableHeaderView } from 'src/http/hbs/list/table-header.view';
 import { TableHeadersRowView } from 'src/http/hbs/list/table-headers-row.view';
 import { buildToggleConfig } from 'src/http/hbs/list/toggle-config';
@@ -561,15 +561,13 @@ export class SetOrchestrator {
         authenticated: boolean
     ): TableHeadersRowView {
         const headers = new TableHeadersRowView([
-            new SortableHeaderView(options, SortOptions.SET, ['pl-2']),
-            new SortableHeaderView(options, SortOptions.SET_BASE_PRICE, ['pl-2', 'xxs-hide'], '7d'),
+            setSortHeader(options, SortOptions.SET, ['pl-2']),
+            setSortHeader(options, SortOptions.SET_BASE_PRICE, ['pl-2', 'xxs-hide'], '7d'),
         ]);
         if (authenticated) {
             headers.headers.push(new TableHeaderView('Owned Value'));
         }
-        headers.headers.push(
-            new SortableHeaderView(options, SortOptions.RELEASE_DATE, ['xs-hide', 'pr-2'])
-        );
+        headers.headers.push(setSortHeader(options, SortOptions.RELEASE_DATE, ['xs-hide', 'pr-2']));
         return headers;
     }
 
@@ -584,23 +582,21 @@ export class SetOrchestrator {
             headers.push(new TableHeaderView('Owned'));
         }
         headers.push(
-            new SortableHeaderView(options, SortOptions.NUMBER),
-            new SortableHeaderView(options, SortOptions.CARD),
+            setCardSortHeader(options, SortOptions.NUMBER),
+            setCardSortHeader(options, SortOptions.CARD),
             new TableHeaderView('Mana Cost', ['xs-hide']),
             new TableHeaderView('Rarity', ['xs-hide'])
         );
         if (hasAnyNormalPrice) {
-            headers.push(new SortableHeaderView(options, SortOptions.PRICE, ['xs-hide'], '7d'));
+            headers.push(setCardSortHeader(options, SortOptions.PRICE, ['xs-hide'], '7d'));
         }
         if (hasAnyFoilPrice) {
             headers.push(
-                new SortableHeaderView(options, SortOptions.PRICE_FOIL, ['xs-hide', 'pr-2'], '7d')
+                setCardSortHeader(options, SortOptions.PRICE_FOIL, ['xs-hide', 'pr-2'], '7d')
             );
         }
         if (hasAnyNormalPrice || hasAnyFoilPrice) {
-            headers.push(
-                new SortableHeaderView(options, SortOptions.PRICE, ['xs-show', 'pr-2'], '7d')
-            );
+            headers.push(setCardSortHeader(options, SortOptions.PRICE, ['xs-show', 'pr-2'], '7d'));
         }
         return new TableHeadersRowView(headers);
     }

--- a/src/http/hbs/transaction/transaction.orchestrator.ts
+++ b/src/http/hbs/transaction/transaction.orchestrator.ts
@@ -16,7 +16,7 @@ import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { FilterView } from 'src/http/hbs/list/filter.view';
 import { PaginationView } from 'src/http/hbs/list/pagination.view';
-import { SortableHeaderView } from 'src/http/hbs/list/sortable-header.view';
+import { transactionSortHeader } from 'src/http/hbs/list/sortable-header.view';
 import { TableHeaderView } from 'src/http/hbs/list/table-header.view';
 import { TableHeadersRowView } from 'src/http/hbs/list/table-headers-row.view';
 import { ImportResultDto } from 'src/http/hbs/import/import-result.dto';
@@ -86,11 +86,11 @@ export class TransactionOrchestrator {
                 filter: new FilterView(options, baseUrl, 'Filter by card name...'),
                 pagination: new PaginationView(options, baseUrl, totalCount),
                 tableHeadersRow: new TableHeadersRowView([
-                    new SortableHeaderView(options, SortOptions.TX_DATE),
-                    new SortableHeaderView(options, SortOptions.TX_TYPE),
-                    new SortableHeaderView(options, SortOptions.TX_CARD),
+                    transactionSortHeader(options, SortOptions.TX_DATE),
+                    transactionSortHeader(options, SortOptions.TX_TYPE),
+                    transactionSortHeader(options, SortOptions.TX_CARD),
                     new TableHeaderView('Qty'),
-                    new SortableHeaderView(options, SortOptions.TX_PRICE),
+                    transactionSortHeader(options, SortOptions.TX_PRICE),
                     new TableHeaderView('Total'),
                     new TableHeaderView('', ['tx-actions-cell']),
                 ]),


### PR DESCRIPTION
Per-context typed header factories (setCardSortHeader, setSortHeader, inventorySortHeader, transactionSortHeader) bind each HBS orchestrator's sortable columns to its honorable *_SORTS set, so a header offering a sort the query can't honor now fails to compile instead of only happening to agree today. Follow-up from Roadmap 4.4 (#507).

The *_SORTS constants become `as const` to derive the per-context union types; every consumer takes the wider readonly SortOptions[], so nothing else changes and behavior is identical (factories build the same SortableHeaderView). No behavior change.

Verified: typecheck clean, a negative compile check (a non-honorable sort is rejected), full unit suite (1174 pass), and live render of /sets and a set page (every sort link is in its honorable set, all 200).