### PR TITLE
Add rebuild:web script and drop stale env_file: .env from dev compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,6 @@ services:
         environment:
             - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
             - SCRY_LOG=${SCRY_LOG}
-        env_file:
-            - .env
         depends_on:
             postgres:
                 condition: service_healthy
@@ -60,8 +58,6 @@ services:
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - PGDATA=/var/lib/postgresql/data
-        env_file:
-            - .env
         ports:
             - '5432:5432'
         volumes:
@@ -84,8 +80,10 @@ services:
 
     migrate:
         image: postgres:18-alpine
-        env_file:
-            - .env
+        environment:
+            - POSTGRES_DB=${POSTGRES_DB}
+            - POSTGRES_USER=${POSTGRES_USER}
+            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
         depends_on:
             postgres:
                 condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "setup": "./scripts/setup.sh",
         "migrate": "./scripts/migrate.sh",
         "reset-db": "./scripts/reset-db.sh",
+        "rebuild:web": "./scripts/rebuild-web.sh",
         "logs": "./scripts/logs.sh",
         "db-backup": "./scripts/db-backup.sh",
         "free-docker-port": "./scripts/free-docker-port.sh",

--- a/scripts/rebuild-web.sh
+++ b/scripts/rebuild-web.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Rebuild the web container after package.json dependencies change.
+#
+# Recreates the container with -V (--renew-anon-volumes) so the anonymous
+# node_modules volume is repopulated from the freshly built image instead of
+# shadowing it with stale deps (TS2307: Cannot find module ...).
+#
+# You only need this when dependencies changed. For a plain code change a
+# normal `docker compose build web && docker compose up -d web` is enough.
+#
+# This script interpolates ${VAR} from docker-compose.yml, so run it with your
+# secrets injected (locally: `noenvy run -- npm run rebuild:web`).
+#
+# Usage: npm run rebuild:web   (or ./scripts/rebuild-web.sh)
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+docker compose up -d --build -V web
+
+echo "Web rebuilt with fresh node_modules. App: http://localhost:3000"


### PR DESCRIPTION
The dev compose file still referenced env_file: .env, a relic from before the noenvy switch. With no .env on disk, docker compose aborts parsing the whole file, so rebuild:web (and any docker compose command) failed.

Remove env_file from web/etl/postgres (already covered by environment: interpolation) and give migrate an explicit environment: block. Prod and CI are unaffected: prod uses docker-compose.prod.yml with a generated .env, CI uses docker-compose.test.yml.