### PR TITLE
6.3 buylist on card/set/binder + fix sealed inventory control (#510)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,13 +95,13 @@ Mirrors the existing `price` / `price_history` split — a lean current table th
 - [x] `GranularPriceRepositoryPort` + repo/mapper/ORM entity (read-only, current table; consumed by 6.3)
 - [x] Population owned by scry (scry#14): daily ingest writes **both** tables; historical backfill writes **history only** (current is filled by the next daily ingest). Retention runs on `granular_price_history` per `(card, provider, type, finish, condition)` series, daily → weekly → monthly. Granular capture is USD-only - providers `tcgplayer`, `cardkingdom`, `cardsphere`, `manapool` (Cardmarket/EUR excluded; no currency column); the derived `price` still averages only the original 3 providers, so it stays byte-identical.
 
-### 6.3 Show Buylist Prices on Card Views
+### 6.3 Show Buylist Prices on Card Views ✅
 
-Card page shipped on branch `spike/6.1-buylist-price-data` (read path, presenter, `card.hbs` tiles, vendor constant); set page / binder overlay is the only open item.
+Card price section overhauled into a **Buy** (retail tiles + TCGPlayer) / **Sell** (best buylist per finish, vendors behind a "compare" disclosure) split; set page / binder show a compact best-offer. Buylist is single-vendor (Card Kingdom) today (see 6.9), so the per-vendor compare gracefully collapses to one line.
 
 - [x] Read the current `granular_price` table directly via `GranularPriceRepositoryPort` (best buylist offer + per-vendor list, one row per series) — not the averaged `price` table or the dated `granular_price_history`
 - [x] Card presenter buylist fields; add buylist tile(s) to `card.hbs` price section, highlight best vendor, respect normal/foil; reuse existing `price-tile` theming
-- [ ] Same treatment in set page / binder overlay; display NM by default
+- [x] Same treatment in set page / binder overlay; display NM by default — compact best-offer ("sell $X" on rows, "Buylist $X" on the binder overlay), sourced from a batched `findCurrentBuylistByCardIds` read and `bestBuylistOffer` policy
 - [x] Vendor metadata (display name + sell-to flag for Card Kingdom, Cardsphere) as a code-level constant; DB `vendor` table deferred to 6.5
 
 ### 6.4 Inventory: Best Buylist, Group by Vendor, CSV Export

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.31.0",
+    "version": "1.32.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "i-want-my-mtg",
-            "version": "1.31.0",
+            "version": "1.32.0",
             "license": "UNLICENSED",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.31.0",
+    "version": "1.32.0",
     "description": "MTG Collection Tracker",
     "author": "Matthew Towles",
     "private": true,

--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -140,4 +140,32 @@ export class CardService {
             throw new Error(`Error finding buylist for card ${cardId}: ${error.message}`);
         }
     }
+
+    /**
+     * Current buylist offers for many cards, grouped by card id. For the set
+     * page / binder, which show a compact best-offer per card. Empty map for an
+     * empty input.
+     */
+    async findCurrentBuylistForCards(cardIds: string[]): Promise<Map<string, GranularPrice[]>> {
+        this.LOGGER.debug(`Find current buylist for ${cardIds.length} cards.`);
+        const grouped = new Map<string, GranularPrice[]>();
+        if (cardIds.length === 0) {
+            return grouped;
+        }
+        try {
+            const offers =
+                await this.granularPriceRepository.findCurrentBuylistByCardIds(cardIds);
+            for (const offer of offers) {
+                const list = grouped.get(offer.cardId);
+                if (list) {
+                    list.push(offer);
+                } else {
+                    grouped.set(offer.cardId, [offer]);
+                }
+            }
+            return grouped;
+        } catch (error) {
+            throw new Error(`Error finding buylist for cards: ${error.message}`);
+        }
+    }
 }

--- a/src/core/card/ports/granular-price.repository.port.ts
+++ b/src/core/card/ports/granular-price.repository.port.ts
@@ -9,4 +9,10 @@ export interface GranularPriceRepositoryPort {
      * store.
      */
     findCurrentBuylistByCardId(cardId: string): Promise<GranularPrice[]>;
+
+    /**
+     * Current buylist offers for many cards in one query (set page / binder).
+     * Empty array for an empty input or when no card has offers.
+     */
+    findCurrentBuylistByCardIds(cardIds: string[]): Promise<GranularPrice[]>;
 }

--- a/src/core/pricing/buylist.policy.ts
+++ b/src/core/pricing/buylist.policy.ts
@@ -4,13 +4,16 @@ import { GranularPrice } from 'src/core/card/granular-price.entity';
  * Buylist (sell-to-vendor) policy for Phase 6.3.
  *
  * The card page renders the full per-vendor breakdown; the set page and binder
- * overlay only need the single best number. NM is the only graded condition the
+ * overlay only need the single best offer. NM is the only graded condition the
  * granular store carries today (6.2), so "best" is the highest positive NM offer
- * across all finishes and vendors.
+ * across all finishes and vendors. Returns the whole offer (not just the price)
+ * so callers can show which finish it is for when it is not the default normal.
  */
-export function bestBuylistOffer(offers: GranularPrice[]): number | null {
-    const prices = offers
+export function bestBuylistOffer(offers: GranularPrice[]): GranularPrice | null {
+    return offers
         .filter((o) => o.condition === 'NM' && o.price != null && o.price > 0)
-        .map((o) => o.price as number);
-    return prices.length ? Math.max(...prices) : null;
+        .reduce<GranularPrice | null>(
+            (best, o) => (best === null || (o.price as number) > (best.price as number) ? o : best),
+            null
+        );
 }

--- a/src/core/pricing/buylist.policy.ts
+++ b/src/core/pricing/buylist.policy.ts
@@ -1,0 +1,16 @@
+import { GranularPrice } from 'src/core/card/granular-price.entity';
+
+/**
+ * Buylist (sell-to-vendor) policy for Phase 6.3.
+ *
+ * The card page renders the full per-vendor breakdown; the set page and binder
+ * overlay only need the single best number. NM is the only graded condition the
+ * granular store carries today (6.2), so "best" is the highest positive NM offer
+ * across all finishes and vendors.
+ */
+export function bestBuylistOffer(offers: GranularPrice[]): number | null {
+    const prices = offers
+        .filter((o) => o.condition === 'NM' && o.price != null && o.price > 0)
+        .map((o) => o.price as number);
+    return prices.length ? Math.max(...prices) : null;
+}

--- a/src/database/granular-price/granular-price.repository.ts
+++ b/src/database/granular-price/granular-price.repository.ts
@@ -23,4 +23,16 @@ export class GranularPriceRepository implements GranularPriceRepositoryPort {
             .getMany();
         return rows.map(GranularPriceMapper.toCore);
     }
+
+    async findCurrentBuylistByCardIds(cardIds: string[]): Promise<GranularPrice[]> {
+        if (cardIds.length === 0) {
+            return [];
+        }
+        const rows = await this.repo
+            .createQueryBuilder('gp')
+            .where('gp.cardId IN (:...cardIds)', { cardIds })
+            .andWhere('gp.priceType = :type', { type: 'buylist' })
+            .getMany();
+        return rows.map(GranularPriceMapper.toCore);
+    }
 }

--- a/src/http/api/card/card-api.presenter.ts
+++ b/src/http/api/card/card-api.presenter.ts
@@ -3,9 +3,13 @@ import { Card } from 'src/core/card/card.entity';
 import { CardApiResponseDto } from './dto/card-response.dto';
 
 export class CardApiPresenter {
-    static toCardApiResponse(card: Card): CardApiResponseDto {
+    static toCardApiResponse(
+        card: Card,
+        bestBuylist: number | null = null
+    ): CardApiResponseDto {
         const latestPrice = card.prices?.[0];
         return {
+            bestBuylist,
             id: card.id,
             name: card.name,
             setCode: card.setCode,

--- a/src/http/api/card/card-api.presenter.ts
+++ b/src/http/api/card/card-api.presenter.ts
@@ -1,15 +1,18 @@
 import { AffiliateLinkPolicy } from 'src/core/affiliate/affiliate-link.policy';
 import { Card } from 'src/core/card/card.entity';
+import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { CardApiResponseDto } from './dto/card-response.dto';
 
 export class CardApiPresenter {
     static toCardApiResponse(
         card: Card,
-        bestBuylist: number | null = null
+        bestBuylist: GranularPrice | null = null
     ): CardApiResponseDto {
         const latestPrice = card.prices?.[0];
         return {
-            bestBuylist,
+            bestBuylist: bestBuylist ? Number(bestBuylist.price) : null,
+            bestBuylistFinish:
+                bestBuylist && bestBuylist.finish !== 'normal' ? bestBuylist.finish : null,
             id: card.id,
             name: card.name,
             setCode: card.setCode,

--- a/src/http/api/card/dto/card-response.dto.ts
+++ b/src/http/api/card/dto/card-response.dto.ts
@@ -63,6 +63,13 @@ export class CardApiResponseDto {
     })
     readonly bestBuylist?: number | null;
 
+    @ApiPropertyOptional({
+        description:
+            "Finish of the best buylist offer when it is not the default 'normal' (e.g. 'foil', 'etched'); null otherwise",
+        nullable: true,
+    })
+    readonly bestBuylistFinish?: string | null;
+
     @ApiPropertyOptional()
     readonly setName?: string;
 

--- a/src/http/api/card/dto/card-response.dto.ts
+++ b/src/http/api/card/dto/card-response.dto.ts
@@ -57,6 +57,12 @@ export class CardApiResponseDto {
     @ApiPropertyOptional({ type: CardPriceDto })
     readonly prices?: CardPriceDto;
 
+    @ApiPropertyOptional({
+        description: 'Best NM buylist (sell-to-vendor) offer in USD; null when none',
+        nullable: true,
+    })
+    readonly bestBuylist?: number | null;
+
     @ApiPropertyOptional()
     readonly setName?: string;
 

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -40,11 +40,14 @@ import {
 } from '../shared/query-validation';
 import { formatUtcDate } from 'src/http/base/date.util';
 import { parseDaysParam } from 'src/http/base/query.util';
+import { getLogger } from 'src/logger/global-app-logger';
 
 @ApiTags('Sets')
 @Controller('api/v1/sets')
 @UseGuards(OptionalAuthOrApiKeyGuard, ApiRateLimitGuard)
 export class SetApiController {
+    private readonly LOGGER = getLogger(SetApiController.name);
+
     constructor(
         @Inject(SetService) private readonly setService: SetService,
         @Inject(CardService) private readonly cardService: CardService,
@@ -219,8 +222,9 @@ export class SetApiController {
         let buylistMap = new Map<string, GranularPrice[]>();
         try {
             buylistMap = await this.cardService.findCurrentBuylistForCards(cards.map((c) => c.id));
-        } catch {
+        } catch (error) {
             // best-effort; buylist is supplementary and must not fail the listing
+            this.LOGGER.debug(`Buylist unavailable for set ${code}: ${error?.message}`);
         }
 
         return ApiResponseDto.ok(

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -11,7 +11,9 @@ import {
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
+import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { InventoryService } from 'src/core/inventory/inventory.service';
+import { bestBuylistOffer } from 'src/core/pricing/buylist.policy';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { SET_CARD_SORTS, SET_SORTS } from 'src/core/query/sort-options.enum';
 import { SetService } from 'src/core/set/set.service';
@@ -213,8 +215,18 @@ export class SetApiController {
             this.cardService.totalInSet(code, effectiveOptions),
         ]);
 
+        // Compact best-buylist per card for the set list / binder (6.3).
+        let buylistMap = new Map<string, GranularPrice[]>();
+        try {
+            buylistMap = await this.cardService.findCurrentBuylistForCards(cards.map((c) => c.id));
+        } catch {
+            // best-effort; buylist is supplementary and must not fail the listing
+        }
+
         return ApiResponseDto.ok(
-            cards.map((c) => CardApiPresenter.toCardApiResponse(c)),
+            cards.map((c) =>
+                CardApiPresenter.toCardApiResponse(c, bestBuylistOffer(buylistMap.get(c.id) ?? []))
+            ),
             new PaginationMeta(effectiveOptions.page, effectiveOptions.limit, total)
         );
     }

--- a/src/http/hbs/card/card.presenter.ts
+++ b/src/http/hbs/card/card.presenter.ts
@@ -40,7 +40,7 @@ export class CardPresenter {
             throw new Error('Card is required to create CardResponseDto');
         }
         const price: Price | undefined = card.prices ? card.prices[0] : undefined;
-        const bestBuylistRaw = bestBuylistOffer(buylistOffers);
+        const bestBuylist = bestBuylistOffer(buylistOffers);
         return new CardResponseDto({
             cardId: card.id,
             hasFoil: card.hasFoil,
@@ -60,7 +60,9 @@ export class CardPresenter {
                 card.hasNonFoil && inventory?.normalQuantity ? inventory.normalQuantity : 0,
             normalPriceRaw: price?.normal ? Math.round(price.normal * 100) / 100 : 0,
             foilPriceRaw: price?.foil ? Math.round(price.foil * 100) / 100 : 0,
-            bestBuylist: bestBuylistRaw != null ? toDollar(bestBuylistRaw) : '',
+            bestBuylist: bestBuylist ? toDollar(bestBuylist.price) : '',
+            bestBuylistFinish:
+                bestBuylist && bestBuylist.finish !== 'normal' ? bestBuylist.finish : '',
             ...this.formatPriceChange(price),
             tags: this.createTags(card),
         });

--- a/src/http/hbs/card/card.presenter.ts
+++ b/src/http/hbs/card/card.presenter.ts
@@ -5,6 +5,7 @@ import { CardRarity } from 'src/core/card/card.rarity.enum';
 import { Format } from 'src/core/card/format.enum';
 import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { Price } from 'src/core/card/price.entity';
+import { bestBuylistOffer } from 'src/core/pricing/buylist.policy';
 import { vendorDisplayName } from 'src/core/pricing/vendor';
 import { formatUtcDate } from 'src/http/base/date.util';
 import { BASE_IMAGE_URL, buildCardUrl, toDollar } from 'src/http/base/http.util';
@@ -32,12 +33,14 @@ export class CardPresenter {
     static toCardResponse(
         card: Card,
         inventory: InventoryQuantities,
-        imageType: CardImgType = CardImgType.SMALL
+        imageType: CardImgType = CardImgType.SMALL,
+        buylistOffers: GranularPrice[] = []
     ): CardResponseDto {
         if (!card) {
             throw new Error('Card is required to create CardResponseDto');
         }
         const price: Price | undefined = card.prices ? card.prices[0] : undefined;
+        const bestBuylistRaw = bestBuylistOffer(buylistOffers);
         return new CardResponseDto({
             cardId: card.id,
             hasFoil: card.hasFoil,
@@ -57,6 +60,7 @@ export class CardPresenter {
                 card.hasNonFoil && inventory?.normalQuantity ? inventory.normalQuantity : 0,
             normalPriceRaw: price?.normal ? Math.round(price.normal * 100) / 100 : 0,
             foilPriceRaw: price?.foil ? Math.round(price.foil * 100) / 100 : 0,
+            bestBuylist: bestBuylistRaw != null ? toDollar(bestBuylistRaw) : '',
             ...this.formatPriceChange(price),
             tags: this.createTags(card),
         });
@@ -112,7 +116,12 @@ export class CardPresenter {
                     priceRaw: o.price ?? 0,
                     isBest: (o.price ?? 0) === bestPrice,
                 }));
-                return { finish: this.FINISH_LABELS[finishKey], offers: views };
+                return {
+                    finish: this.FINISH_LABELS[finishKey],
+                    best: views[0],
+                    offers: views,
+                    hasMultiple: views.length > 1,
+                };
             })
             .filter((f): f is BuylistFinishView => f !== null);
 

--- a/src/http/hbs/card/dto/buylist.view.dto.ts
+++ b/src/http/hbs/card/dto/buylist.view.dto.ts
@@ -9,7 +9,9 @@ export interface BuylistOfferView {
 /** Buylist offers for one finish (Normal / Foil), best first. */
 export interface BuylistFinishView {
     finish: string; // 'Normal' | 'Foil' | 'Etched'
+    best: BuylistOfferView; // highest offer; headlined on the card page
     offers: BuylistOfferView[];
+    hasMultiple: boolean; // more than one vendor -> show the "compare" expander
 }
 
 /** Card-page buylist section. `hasAny` gates rendering. */

--- a/src/http/hbs/card/dto/card.response.dto.ts
+++ b/src/http/hbs/card/dto/card.response.dto.ts
@@ -29,6 +29,7 @@ export class CardResponseDto {
     readonly normalPriceRaw?: number;
     readonly foilPriceRaw?: number;
     readonly bestBuylist?: string; // formatted best NM buylist offer, '' when none
+    readonly bestBuylistFinish?: string; // finish to call out when not 'normal', else ''
     readonly tags: string[];
 
     constructor(init: Partial<CardResponseDto>) {
@@ -54,6 +55,7 @@ export class CardResponseDto {
         this.normalPriceRaw = init.normalPriceRaw || 0;
         this.foilPriceRaw = init.foilPriceRaw || 0;
         this.bestBuylist = init.bestBuylist || '';
+        this.bestBuylistFinish = init.bestBuylistFinish || '';
         this.tags = init.tags || [];
     }
 }

--- a/src/http/hbs/card/dto/card.response.dto.ts
+++ b/src/http/hbs/card/dto/card.response.dto.ts
@@ -28,6 +28,7 @@ export class CardResponseDto {
     readonly foilPriceChangeWeeklySign?: string;
     readonly normalPriceRaw?: number;
     readonly foilPriceRaw?: number;
+    readonly bestBuylist?: string; // formatted best NM buylist offer, '' when none
     readonly tags: string[];
 
     constructor(init: Partial<CardResponseDto>) {
@@ -52,6 +53,7 @@ export class CardResponseDto {
         this.foilPriceChangeWeeklySign = init.foilPriceChangeWeeklySign || '';
         this.normalPriceRaw = init.normalPriceRaw || 0;
         this.foilPriceRaw = init.foilPriceRaw || 0;
+        this.bestBuylist = init.bestBuylist || '';
         this.tags = init.tags || [];
     }
 }

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { CardImgType } from 'src/core/card/card.img.type.enum';
 import { CardService } from 'src/core/card/card.service';
+import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { InventoryImportService } from 'src/core/inventory/import/inventory-import.service';
 import { SetImportRow } from 'src/core/inventory/import/inventory-import.types';
 import { InventoryService } from 'src/core/inventory/inventory.service';
@@ -692,6 +693,19 @@ export class SetOrchestrator {
 
         const effectiveSize = set.effectiveSize;
 
+        // Compact best-buylist per card for the table / binder (6.3). Best-effort:
+        // buylist is secondary and must never take down the set page.
+        let buylistMap = new Map<string, GranularPrice[]>();
+        if (setPayloadSize > 0) {
+            try {
+                buylistMap = await this.cardService.findCurrentBuylistForCards(
+                    set.cards.map((c) => c.id)
+                );
+            } catch (error) {
+                this.LOGGER.debug(`Buylist unavailable for set ${set.code}: ${error?.message}`);
+            }
+        }
+
         return new SetResponseDto({
             baseSize: set.baseSize,
             block: set.block ?? set.name,
@@ -711,7 +725,8 @@ export class SetOrchestrator {
                       CardPresenter.toCardResponse(
                           card,
                           InventoryPresenter.toQuantityMap(inventory)?.get(card.id),
-                          CardImgType.NORMAL
+                          CardImgType.NORMAL,
+                          buylistMap.get(card.id) ?? []
                       )
                   )
                 : [],

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -3038,6 +3038,14 @@ input:where([type='file']):focus {
   color: rgb(253 224 71 / var(--tw-text-opacity, 1));
 }
 
+.binder-card-overlay-buylist {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+}
+
 .binder-card-stepper {
   margin-top: 0.375rem;
 }
@@ -4661,6 +4669,23 @@ input:where([type='file']):focus {
   font-weight: 500;
 }
 
+/* Compact best-buylist (sell-to-vendor) indicator on set rows / binder */
+
+.price-buylist {
+  margin-top: 0.125rem;
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(4 120 87 / var(--tw-text-opacity, 1));
+}
+
+.price-buylist:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(52 211 153 / var(--tw-text-opacity, 1));
+}
+
 .price-change-positive {
   --tw-text-opacity: 1;
   color: rgb(21 128 61 / var(--tw-text-opacity, 1));
@@ -5772,6 +5797,69 @@ input:where([type='file']):focus {
   overflow-wrap: break-word;
   word-break: break-word;
   font-weight: 700;
+}
+
+/* Buy / Sell group labels in the card price section */
+
+.price-group-label {
+  margin-bottom: 0.5rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.price-group-label:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+.price-group-label-note {
+  font-weight: 400;
+  text-transform: none;
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+.price-group-label-note:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+/* Per-vendor buylist disclosure */
+
+.buylist-compare-summary {
+  margin-top: 0.25rem;
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .buylist-compare-summary:hover {
+    --tw-text-opacity: 1;
+    color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  }
+}
+
+.buylist-compare-summary:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .buylist-compare-summary:hover:is(.dark *) {
+    --tw-text-opacity: 1;
+    color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+  }
 }
 
 /* ===== Stat Cards ===== */

--- a/src/http/public/js/binderRenderer.js
+++ b/src/http/public/js/binderRenderer.js
@@ -87,6 +87,13 @@
             html += '</span>';
         }
 
+        if (card.bestBuylist != null) {
+            html +=
+                '<span class="binder-card-overlay-buylist">Buylist ' +
+                AjaxUtils.toDollar(card.bestBuylist) +
+                '</span>';
+        }
+
         if (options.authenticated) {
             html +=
                 '<div class="binder-card-stepper">' +

--- a/src/http/public/js/binderRenderer.js
+++ b/src/http/public/js/binderRenderer.js
@@ -88,9 +88,13 @@
         }
 
         if (card.bestBuylist != null) {
+            var buylistFinish = card.bestBuylistFinish
+                ? ' ' + escapeHtml(card.bestBuylistFinish)
+                : '';
             html +=
                 '<span class="binder-card-overlay-buylist">Buylist ' +
                 AjaxUtils.toDollar(card.bestBuylist) +
+                buylistFinish +
                 '</span>';
         }
 

--- a/src/http/public/js/setCardListAjax.js
+++ b/src/http/public/js/setCardListAjax.js
@@ -315,6 +315,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     html += ' ' + AjaxUtils.renderPriceChange(card.prices.normalChangeWeekly);
                 }
             }
+            html += renderBuylist(card);
             html += '</td>';
         }
 
@@ -353,11 +354,22 @@ document.addEventListener('DOMContentLoaded', function () {
                     html += ' ' + AjaxUtils.renderPriceChange(card.prices.foilChangeWeekly);
                 }
             }
+            html += renderBuylist(card);
             html += '</td>';
         }
 
         html += '</tr>';
         return html;
+    }
+
+    // Compact best-buylist (sell-to-vendor) indicator, mirrors set.hbs (6.3).
+    function renderBuylist(card) {
+        if (card.bestBuylist == null) return '';
+        return (
+            '<span class="price-buylist" title="Best buylist offer (NM)">sell ' +
+            AjaxUtils.toDollar(card.bestBuylist) +
+            '</span>'
+        );
     }
 
     function renderManaCost(manaCost) {

--- a/src/http/public/js/setCardListAjax.js
+++ b/src/http/public/js/setCardListAjax.js
@@ -363,11 +363,16 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Compact best-buylist (sell-to-vendor) indicator, mirrors set.hbs (6.3).
+    // Calls out the finish when the best offer is not the default normal.
     function renderBuylist(card) {
         if (card.bestBuylist == null) return '';
+        var finish = card.bestBuylistFinish
+            ? ' ' + AjaxUtils.escapeHtml(card.bestBuylistFinish)
+            : '';
         return (
             '<span class="price-buylist" title="Best buylist offer (NM)">sell ' +
             AjaxUtils.toDollar(card.bestBuylist) +
+            finish +
             '</span>'
         );
     }

--- a/src/http/public/js/updateInventory.js
+++ b/src/http/public/js/updateInventory.js
@@ -36,6 +36,12 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!btn) return;
         if (btn.hasAttribute('disabled')) return;
 
+        // Sealed-product steppers reuse the .inv-stepper-btn classes but carry a
+        // sealedProductUuid (not a cardId) and are handled by
+        // updateSealedInventory.js. Bail before stopImmediatePropagation so that
+        // handler still runs; otherwise we'd POST an empty cardId. (#510)
+        if (btn.closest('.sealed-inv-stepper')) return;
+
         event.stopImmediatePropagation();
         const stepper = btn.closest('.inv-stepper');
         const cardId = stepper.getAttribute('data-card-id');

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -231,6 +231,10 @@
     @apply text-yellow-300;
 }
 
+.binder-card-overlay-buylist {
+    @apply block text-[0.7rem] font-medium text-gray-300;
+}
+
 .binder-card-stepper {
     @apply mt-1.5;
 }
@@ -774,6 +778,11 @@
     @apply inline-block text-xs font-medium ml-1;
 }
 
+/* Compact best-buylist (sell-to-vendor) indicator on set rows / binder */
+.price-buylist {
+    @apply block mt-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400;
+}
+
 .price-change-positive {
     @apply text-green-700 dark:text-green-400;
 }
@@ -1200,6 +1209,21 @@
     overflow-wrap: break-word;
     word-break: break-word;
     @apply font-bold;
+}
+
+/* Buy / Sell group labels in the card price section */
+.price-group-label {
+    @apply text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2;
+}
+
+.price-group-label-note {
+    @apply normal-case font-normal text-gray-400 dark:text-gray-500;
+}
+
+/* Per-vendor buylist disclosure */
+.buylist-compare-summary {
+    @apply mt-1 text-xs text-gray-400 dark:text-gray-500 cursor-pointer select-none
+           hover:text-gray-600 dark:hover:text-gray-300;
 }
 
 /* ===== Stat Cards ===== */

--- a/src/http/views/card.hbs
+++ b/src/http/views/card.hbs
@@ -66,10 +66,13 @@
         <section class="price-info md:w-1/4 flex-shrink-0 md:pl-6 mb-4 md:mb-0 border-none min-w-0">
             <section class="subsection-container">
                 <h2 class="section-title">Pricing</h2>
+
+                {{!-- Buy: retail prices + purchase links --}}
+                <h3 class="price-group-label">Buy <span class="price-group-label-note">retail</span></h3>
                 <div class="grid {{#if card.hasNormal}}{{#if card.hasFoil}}grid-cols-2{{else}}grid-cols-1{{/if}}{{else}}grid-cols-1{{/if}} gap-2 mb-3">
                     {{#if card.hasNormal}}
                     <div class="price-tile border-teal-300 dark:border-teal-600 bg-white dark:bg-midnight-800">
-                        <h3 class="font-semibold text-teal-700 dark:text-teal-300 text-xs uppercase tracking-wide mb-1">Normal</h3>
+                        <h4 class="font-semibold text-teal-700 dark:text-teal-300 text-xs uppercase tracking-wide mb-1">Normal</h4>
                         <div class="price-tile-value font-bold text-gray-900 dark:text-gray-100 font-mono">
                             {{card.normalPrice}}
                         </div>
@@ -80,7 +83,7 @@
                     {{/if}}
                     {{#if card.hasFoil}}
                     <div class="price-tile border-purple-300 dark:border-purple-600 bg-purple-50 dark:bg-purple-950/30">
-                        <h3 class="font-semibold text-purple-700 dark:text-purple-300 text-xs uppercase tracking-wide mb-1">Foil</h3>
+                        <h4 class="font-semibold text-purple-700 dark:text-purple-300 text-xs uppercase tracking-wide mb-1">Foil</h4>
                         <div class="price-tile-value font-bold text-purple-900 dark:text-purple-200 font-mono">
                             {{card.foilPrice}}
                         </div>
@@ -96,20 +99,30 @@
                 {{#if card.purchaseUrlTcgplayerEtched}}
                 {{>buyOnTcgplayer url=card.purchaseUrlTcgplayerEtched label="Buy Etched on TCGPlayer"}}
                 {{/if}}
+
+                {{!-- Sell: best buylist offer per finish; vendors behind a disclosure --}}
                 {{#if buylist.hasAny}}
-                <div class="buylist-info mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
-                    <h3 class="font-semibold text-gray-700 dark:text-gray-300 text-xs uppercase tracking-wide mb-2">Buylist <span class="text-gray-400 dark:text-gray-500 normal-case">(NM)</span></h3>
+                <div class="buylist-info mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <h3 class="price-group-label">Sell <span class="price-group-label-note">buylist · NM</span></h3>
                     {{#each buylist.finishes}}
-                    <div class="mb-2 last:mb-0">
-                        <div class="text-xs text-gray-500 dark:text-gray-400 mb-1">{{this.finish}}</div>
-                        <ul class="space-y-1">
-                            {{#each this.offers}}
-                            <li class="buylist-offer flex items-center justify-between text-sm {{#if this.isBest}}buylist-best font-semibold text-emerald-700 dark:text-emerald-300{{else}}text-gray-600 dark:text-gray-400{{/if}}">
-                                <span>{{this.vendor}}{{#if this.isBest}} <span class="text-xs uppercase tracking-wide">Best</span>{{/if}}</span>
-                                <span class="font-mono">{{this.price}}</span>
-                            </li>
-                            {{/each}}
-                        </ul>
+                    <div class="buylist-finish mb-2 last:mb-0">
+                        <div class="flex items-center justify-between text-sm">
+                            <span class="text-gray-600 dark:text-gray-400">{{this.finish}} <span class="text-gray-400 dark:text-gray-500">· {{this.best.vendor}}</span></span>
+                            <span class="font-mono font-semibold text-emerald-700 dark:text-emerald-300">{{this.best.price}}</span>
+                        </div>
+                        {{#if this.hasMultiple}}
+                        <details class="buylist-compare">
+                            <summary class="buylist-compare-summary">compare vendors</summary>
+                            <ul class="mt-1 space-y-1">
+                                {{#each this.offers}}
+                                <li class="buylist-offer flex items-center justify-between text-xs {{#if this.isBest}}buylist-best text-emerald-700 dark:text-emerald-300 font-semibold{{else}}text-gray-500 dark:text-gray-400{{/if}}">
+                                    <span>{{this.vendor}}</span>
+                                    <span class="font-mono">{{this.price}}</span>
+                                </li>
+                                {{/each}}
+                            </ul>
+                        </details>
+                        {{/if}}
                     </div>
                     {{/each}}
                 </div>

--- a/src/http/views/set.hbs
+++ b/src/http/views/set.hbs
@@ -356,6 +356,9 @@
                         <span class="price-change price-change-{{this.priceChangeWeeklySign}}">{{this.priceChangeWeekly}}</span>
                         {{/if}}
                         {{/if}}
+                        {{#if this.bestBuylist}}
+                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}</span>
+                        {{/if}}
                     </td>
                     {{/if}}
                     {{#if ../hasAnyFoilPrice}}
@@ -381,6 +384,9 @@
                         {{#if this.foilPriceChangeWeekly}}
                         <span class="price-change price-change-{{this.foilPriceChangeWeeklySign}}">{{this.foilPriceChangeWeekly}}</span>
                         {{/if}}
+                        {{/if}}
+                        {{#if this.bestBuylist}}
+                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}</span>
                         {{/if}}
                     </td>
                     {{/if}}

--- a/src/http/views/set.hbs
+++ b/src/http/views/set.hbs
@@ -357,7 +357,7 @@
                         {{/if}}
                         {{/if}}
                         {{#if this.bestBuylist}}
-                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}</span>
+                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}{{#if this.bestBuylistFinish}} {{this.bestBuylistFinish}}{{/if}}</span>
                         {{/if}}
                     </td>
                     {{/if}}
@@ -386,7 +386,7 @@
                         {{/if}}
                         {{/if}}
                         {{#if this.bestBuylist}}
-                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}</span>
+                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}{{#if this.bestBuylistFinish}} {{this.bestBuylistFinish}}{{/if}}</span>
                         {{/if}}
                     </td>
                     {{/if}}

--- a/test/core/card/card.service.spec.ts
+++ b/test/core/card/card.service.spec.ts
@@ -77,6 +77,7 @@ describe('CardService', () => {
 
     const mockGranularPriceRepository = {
         findCurrentBuylistByCardId: jest.fn(),
+        findCurrentBuylistByCardIds: jest.fn(),
     };
 
     beforeAll(async () => {
@@ -392,6 +393,31 @@ describe('CardService', () => {
             await expect(service.findCurrentBuylist('test-card-id')).rejects.toThrow(
                 'Error finding buylist for card test-card-id'
             );
+        });
+    });
+
+    describe('findCurrentBuylistForCards', () => {
+        it('returns an empty map without querying for an empty input', async () => {
+            const result = await service.findCurrentBuylistForCards([]);
+
+            expect(result.size).toBe(0);
+            expect(
+                mockGranularPriceRepository.findCurrentBuylistByCardIds
+            ).not.toHaveBeenCalled();
+        });
+
+        it('groups offers by card id', async () => {
+            const offers = [
+                new GranularPrice({ cardId: 'a', provider: 'cardkingdom', finish: 'normal', price: 1 }),
+                new GranularPrice({ cardId: 'a', provider: 'cardkingdom', finish: 'foil', price: 2 }),
+                new GranularPrice({ cardId: 'b', provider: 'cardkingdom', finish: 'normal', price: 3 }),
+            ];
+            mockGranularPriceRepository.findCurrentBuylistByCardIds.mockResolvedValue(offers);
+
+            const result = await service.findCurrentBuylistForCards(['a', 'b']);
+
+            expect(result.get('a')).toHaveLength(2);
+            expect(result.get('b')).toHaveLength(1);
         });
     });
 });

--- a/test/core/pricing/buylist.policy.spec.ts
+++ b/test/core/pricing/buylist.policy.spec.ts
@@ -21,12 +21,13 @@ describe('bestBuylistOffer', () => {
         expect(bestBuylistOffer([offer({ price: null })])).toBeNull();
     });
 
-    it('returns the highest NM offer across finishes and vendors', () => {
+    it('returns the highest NM offer across finishes and vendors, with its finish', () => {
         const result = bestBuylistOffer([
             offer({ provider: 'cardkingdom', finish: 'normal', price: 3.5 }),
             offer({ provider: 'cardsphere', finish: 'normal', price: 3.25 }),
             offer({ provider: 'cardkingdom', finish: 'foil', price: 7 }),
         ]);
-        expect(result).toBe(7);
+        expect(result?.price).toBe(7);
+        expect(result?.finish).toBe('foil');
     });
 });

--- a/test/core/pricing/buylist.policy.spec.ts
+++ b/test/core/pricing/buylist.policy.spec.ts
@@ -1,0 +1,32 @@
+import { GranularPrice } from 'src/core/card/granular-price.entity';
+import { bestBuylistOffer } from 'src/core/pricing/buylist.policy';
+
+function offer(overrides: Partial<GranularPrice> = {}): GranularPrice {
+    return new GranularPrice({
+        cardId: 'card-1',
+        provider: 'cardkingdom',
+        priceType: 'buylist',
+        finish: 'normal',
+        condition: 'NM',
+        price: 1,
+        ...overrides,
+    });
+}
+
+describe('bestBuylistOffer', () => {
+    it('returns null when there are no usable offers', () => {
+        expect(bestBuylistOffer([])).toBeNull();
+        expect(bestBuylistOffer([offer({ condition: 'LP', price: 9 })])).toBeNull();
+        expect(bestBuylistOffer([offer({ price: 0 })])).toBeNull();
+        expect(bestBuylistOffer([offer({ price: null })])).toBeNull();
+    });
+
+    it('returns the highest NM offer across finishes and vendors', () => {
+        const result = bestBuylistOffer([
+            offer({ provider: 'cardkingdom', finish: 'normal', price: 3.5 }),
+            offer({ provider: 'cardsphere', finish: 'normal', price: 3.25 }),
+            offer({ provider: 'cardkingdom', finish: 'foil', price: 7 }),
+        ]);
+        expect(result).toBe(7);
+    });
+});

--- a/test/frontend/sealedStepperCollision.spec.js
+++ b/test/frontend/sealedStepperCollision.spec.js
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression for #510: on the set page both updateInventory.js (card steppers)
+ * and updateSealedInventory.js (sealed steppers) attach body click handlers, and
+ * sealed stepper buttons reuse the generic .inv-stepper-btn classes. The card
+ * handler must ignore sealed steppers so it never POSTs an empty cardId to
+ * /inventory ("Invalid initialization: cardId is required").
+ */
+
+var fetchMock;
+
+beforeEach(function () {
+    jest.resetModules();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock;
+});
+
+afterEach(function () {
+    delete global.fetch;
+});
+
+// Mirrors the production sealed stepper markup (sealed-list.hbs): buttons carry
+// BOTH sealed-inv-btn and inv-stepper-btn classes, nested in .inv-stepper inside
+// .sealed-inv-stepper.
+function setupSealedDom(uuid, qty) {
+    document.body.innerHTML =
+        '<div class="sealed-inv-stepper" data-sealed-uuid="' + uuid + '">' +
+        '<div class="inv-stepper inv-stepper--sm">' +
+        '<button type="button" class="sealed-inv-btn sealed-inv-btn--dec inv-stepper-btn inv-stepper-btn--dec"' +
+        (qty <= 0 ? ' disabled' : '') + '>-</button>' +
+        '<span class="sealed-inv-qty inv-stepper-qty' + (qty <= 0 ? ' sealed-inv-qty--zero inv-stepper-qty--zero' : '') + '">' + qty + '</span>' +
+        '<button type="button" class="sealed-inv-btn sealed-inv-btn--inc inv-stepper-btn inv-stepper-btn--inc">+</button>' +
+        '</div></div>';
+}
+
+// Load both scripts in the same order set.hbs does: card handler first.
+function loadBothScripts() {
+    require('../../src/http/public/js/updateInventory.js');
+    require('../../src/http/public/js/updateSealedInventory.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+}
+
+function mockApiResponse(data) {
+    fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: function () {
+            return Promise.resolve({ success: true, data: data });
+        },
+    });
+}
+
+describe('sealed stepper / card stepper collision (#510)', function () {
+    test('clicking a sealed stepper hits the sealed endpoint, never /inventory', function () {
+        setupSealedDom('test-uuid', 0);
+        mockApiResponse({ sealedProductUuid: 'test-uuid', quantity: 1 });
+        loadBothScripts();
+
+        document.querySelector('.sealed-inv-btn--inc').click();
+
+        return new Promise(function (resolve) {
+            setTimeout(function () {
+                expect(fetchMock).toHaveBeenCalledTimes(1);
+                expect(fetchMock).toHaveBeenCalledWith(
+                    '/api/v1/inventory/sealed',
+                    expect.objectContaining({ method: 'POST' })
+                );
+                var urls = fetchMock.mock.calls.map(function (c) {
+                    return c[0];
+                });
+                expect(urls).not.toContain('/inventory');
+                resolve();
+            }, 10);
+        });
+    });
+});

--- a/test/http/api/card/card-api.presenter.spec.ts
+++ b/test/http/api/card/card-api.presenter.spec.ts
@@ -1,6 +1,7 @@
 import { TCGPLAYER_PRODUCT_URL_TEMPLATE } from 'src/core/affiliate/affiliate-link.policy';
 import { Card } from 'src/core/card/card.entity';
 import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { Price } from 'src/core/card/price.entity';
 import { Set } from 'src/core/set/set.entity';
 import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
@@ -56,6 +57,42 @@ describe('CardApiPresenter', () => {
                 normalChangeWeekly: 0.25,
                 foilChangeWeekly: -0.1,
             });
+        });
+
+        it('maps the best buylist offer and calls out a non-normal finish', () => {
+            const card = createCard();
+            const foilBest = new GranularPrice({
+                cardId: 'card-1',
+                provider: 'cardkingdom',
+                priceType: 'buylist',
+                finish: 'foil',
+                condition: 'NM',
+                price: 7,
+            });
+            const result = CardApiPresenter.toCardApiResponse(card, foilBest);
+
+            expect(result.bestBuylist).toBe(7);
+            expect(result.bestBuylistFinish).toBe('foil');
+        });
+
+        it('omits the finish callout when the best offer is normal, and nulls when absent', () => {
+            const card = createCard();
+            const normalBest = new GranularPrice({
+                cardId: 'card-1',
+                provider: 'cardkingdom',
+                priceType: 'buylist',
+                finish: 'normal',
+                condition: 'NM',
+                price: 2.5,
+            });
+
+            const withOffer = CardApiPresenter.toCardApiResponse(card, normalBest);
+            expect(withOffer.bestBuylist).toBe(2.5);
+            expect(withOffer.bestBuylistFinish).toBeNull();
+
+            const none = CardApiPresenter.toCardApiResponse(card);
+            expect(none.bestBuylist).toBeNull();
+            expect(none.bestBuylistFinish).toBeNull();
         });
 
         it('should return undefined prices when card has no prices', () => {

--- a/test/http/card.presenter.spec.ts
+++ b/test/http/card.presenter.spec.ts
@@ -252,5 +252,20 @@ describe('CardPresenter', () => {
 
             expect(result.finishes[0].offers.every((o) => o.isBest)).toBe(true);
         });
+
+        it('headlines the best offer and flags multiple vendors per finish', () => {
+            const result = CardPresenter.toBuylistView([
+                offer({ provider: 'cardkingdom', finish: 'normal', price: 2 }),
+                offer({ provider: 'cardsphere', finish: 'normal', price: 5 }),
+                offer({ provider: 'cardkingdom', finish: 'foil', price: 9 }),
+            ]);
+
+            const normal = result.finishes.find((f) => f.finish === 'Normal');
+            const foil = result.finishes.find((f) => f.finish === 'Foil');
+            expect(normal.best).toMatchObject({ vendor: 'Cardsphere', price: '$5.00' });
+            expect(normal.hasMultiple).toBe(true);
+            expect(foil.best).toMatchObject({ vendor: 'Card Kingdom' });
+            expect(foil.hasMultiple).toBe(false);
+        });
     });
 });

--- a/test/integration/api-sets.e2e-spec.ts
+++ b/test/integration/api-sets.e2e-spec.ts
@@ -119,6 +119,16 @@ describe('Sets API (e2e)', () => {
             expect(typeof card.keyruneCode).toBe('string');
         });
 
+        it('returns the best NM buylist offer per card (6.3)', async () => {
+            const res = await request(app.getHttpServer())
+                .get(`/api/v1/sets/${TEST_SET_CODE}/cards`)
+                .expect(200);
+
+            // Seed card 1 has CK normal 3.50 / Cardsphere normal 3.25 / CK foil 7.00.
+            const card = res.body.data.find((c) => c.number === '1');
+            expect(card.bestBuylist).toBe(7);
+        });
+
         it('supports filter parameter', async () => {
             const res = await request(app.getHttpServer())
                 .get(`/api/v1/sets/${TEST_SET_CODE}/cards?filter=Angel`)

--- a/test/integration/api-sets.e2e-spec.ts
+++ b/test/integration/api-sets.e2e-spec.ts
@@ -124,9 +124,11 @@ describe('Sets API (e2e)', () => {
                 .get(`/api/v1/sets/${TEST_SET_CODE}/cards`)
                 .expect(200);
 
-            // Seed card 1 has CK normal 3.50 / Cardsphere normal 3.25 / CK foil 7.00.
+            // Seed card 1 has CK normal 3.50 / Cardsphere normal 3.25 / CK foil 7.00,
+            // so the best offer is the foil one and the finish is called out.
             const card = res.body.data.find((c) => c.number === '1');
             expect(card.bestBuylist).toBe(7);
+            expect(card.bestBuylistFinish).toBe('foil');
         });
 
         it('supports filter parameter', async () => {


### PR DESCRIPTION
Completes ROADMAP 6.3 (buylist prices on card views) and fixes #510.

## 6.3 - Buylist prices (#501)

**Card page price section, reworked into Buy / Sell.** A clear **Buy** group (retail Normal/Foil tiles + the TCGPlayer buttons) and a **Sell** group (best buylist offer per finish, headlined with the vendor). Extra vendors for a finish tuck behind a small "compare vendors" disclosure so the narrow column stays quiet. Heading levels fixed (h2 Pricing -> h3 Buy/Sell -> h4 Normal/Foil).

**Set list + binder overlay** (the open ROADMAP checkbox). Compact best-offer only: "sell \$X" under the price on set rows, "Buylist \$X" on the binder hover overlay. Full per-vendor detail stays on the card page.

**Plumbing.** Batched `findCurrentBuylistByCardIds` read + a `bestBuylistOffer` policy in `core/pricing`, shared by the HBS and JSON-API presenters (so the API layer doesn't reach into view code). The set cards JSON API gained an optional `bestBuylist` field, fetched best-effort so buylist can never fail a listing.

Note: buylist is single-vendor (Card Kingdom) in real data today (see ROADMAP 6.9), so the compare list collapses to one line until a second source lands.

## #510 - Sealed inventory "cardId is required"

The sealed backend already works (real `/api/v1/inventory/sealed` endpoint keyed on `sealedProductUuid`). The bug was a frontend collision: on the set page both `updateInventory.js` and `updateSealedInventory.js` load, the sealed buttons reuse the generic `inv-stepper-btn` classes, and the card handler grabbed the click first and POSTed an empty `cardId`. Fixed with a guard in `updateInventory.js` so the sealed handler runs. The detail page was already fine (global subscription interceptor populates `subscribed`).

## Tests
- New: `bestBuylistOffer` policy, presenter `best`/`hasMultiple`, service grouping, a `bestBuylist` API e2e assertion, and a #510 regression test (both scripts loaded -> sealed click hits the sealed endpoint, never `/inventory`).
- Green: 1187 unit, 97 frontend, integration (public, api-sets, api-cards, mcp).
- Verified live against the dev DB on the card page, set list, and binder overlay.

Closes #501, #510