### PR TITLE
6.3.1 buylist trim + responsive hardening + granular PK hotfix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Test suites: `test/integration/*.e2e-spec.ts`. Seed data: `test/integration/seed
 
 **Local dev**: PostgreSQL 18 via Docker (docker-compose.yml). Migrations run via `docker compose run --rm migrate`.
 
-Schema defined in `docker/postgres/init/001_complete_schema.sql`. Migrations in `migrations/` (numbered sequentially). Core tables: `card`, `set`, `price`, `price_history`, `legality`, `inventory`, `user`, `pending_user`, `set_price`, `set_price_history`.
+Schema defined in `docker/postgres/init/001_complete_schema.sql`. Migrations in `migrations/` (numbered sequentially). Core tables: `card`, `set`, `price`, `price_history`, `legality`, `inventory`, `user`, `pending_user`, `set_price`, `set_price_history`, `granular_price`, `granular_price_history`.
 
 ### Price History
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,12 +97,21 @@ Mirrors the existing `price` / `price_history` split — a lean current table th
 
 ### 6.3 Show Buylist Prices on Card Views ✅
 
-Card price section overhauled into a **Buy** (retail tiles + TCGPlayer) / **Sell** (best buylist per finish, vendors behind a "compare" disclosure) split; set page / binder show a compact best-offer. Buylist is single-vendor (Card Kingdom) today (see 6.9), so the per-vendor compare gracefully collapses to one line.
+Card price section overhauled into a **Buy** (retail tiles + TCGPlayer) / **Sell** (best buylist per finish, vendors behind a "compare" disclosure) split. (A compact best-offer on the set page / binder was added then **removed in 6.3.1** — buylist now lives only on the card page.) Buylist is single-vendor (Card Kingdom) today (see 6.9), so the per-vendor compare gracefully collapses to one line.
 
 - [x] Read the current `granular_price` table directly via `GranularPriceRepositoryPort` (best buylist offer + per-vendor list, one row per series) — not the averaged `price` table or the dated `granular_price_history`
 - [x] Card presenter buylist fields; add buylist tile(s) to `card.hbs` price section, highlight best vendor, respect normal/foil; reuse existing `price-tile` theming
-- [x] Same treatment in set page / binder overlay; display NM by default — compact best-offer ("sell $X" on rows, "Buylist $X" on the binder overlay), sourced from a batched `findCurrentBuylistByCardIds` read and `bestBuylistOffer` policy
+- [x] ~~Same treatment in set page / binder overlay; compact best-offer ("sell $X" on rows, "Buylist $X" on the binder overlay)~~ **Scope-corrected in 6.3.1:** buylist now lives only on the card page; the set-list / binder surfaces were removed (clutter + overflow risk). The batched `findCurrentBuylistByCardIds` read and `bestBuylistOffer` policy are kept for 6.4 inventory best-buylist.
 - [x] Vendor metadata (display name + sell-to flag for Card Kingdom, Cardsphere) as a code-level constant; DB `vendor` table deferred to 6.5
+
+### 6.3.1 Buylist surface trim + UI parity + responsive hardening ✅
+
+- [x] Limit buylist to the card page (remove from set list + binder overlay; keep batched read for 6.4)
+- [x] Buy/Sell visual parity: render Sell offers as price-tiles (emerald accent) matching retail
+- [x] Responsive contract: base-layer min-width:0 / max-width / overflow-wrap guards
+- [x] `.cluster` + `.badge-pill` utilities; fix legality-tag and set-toolbar overflow
+- [x] Fix navbar mobile overflow: container-query that hides Sign In/Sign Up <599px now ordered after the base `display` rules so it wins (was a source-order bug the guard caught)
+- [x] Playwright overflow guard at 320/375px across key pages (regression gate)
 
 ### 6.4 Inventory: Best Buylist, Group by Vendor, CSV Export
 

--- a/docs/6.3-cleanup-responsive-plan.md
+++ b/docs/6.3-cleanup-responsive-plan.md
@@ -1,5 +1,11 @@
 # Plan: 6.3 Buylist Cleanup + Durable Responsive Hardening
 
+> **Status: implemented** as Roadmap **6.3.1**. One deviation from the plan
+> below: `renderBuylist()` and its two call sites were in `setCardListAjax.js`
+> (not `binderRenderer.js`, which only had the inline overlay block). The guard
+> also surfaced a real pre-existing navbar overflow (Sign In/Sign Up leaking on
+> mobile from a CSS source-order bug), fixed in `app.css`.
+
 > **Scope note:** Parts A and B are buylist-specific. **Part C (CSS / responsive
 > hardening) is app-wide** — a global defense layer plus a whole-page CI guard
 > that prevents overflow/warping anywhere in the app, not just on buylist UI.

--- a/docs/6.3-cleanup-responsive-plan.md
+++ b/docs/6.3-cleanup-responsive-plan.md
@@ -1,0 +1,154 @@
+# Plan: 6.3 Buylist Cleanup + Durable Responsive Hardening
+
+> **Scope note:** Parts A and B are buylist-specific. **Part C (CSS / responsive
+> hardening) is app-wide** — a global defense layer plus a whole-page CI guard
+> that prevents overflow/warping anywhere in the app, not just on buylist UI.
+
+---
+
+## Current state (findings)
+
+Buylist (6.3) is plumbed into **three surfaces**, not one:
+
+- **Card page** (`card.hbs`) — full "Sell" section: best offer per finish +
+  "compare vendors" disclosure. ✅ keep
+- **Set page card list** (`set.hbs` rows + `setCardListAjax.js`) — compact
+  `sell $X` line per row. ❌ remove
+- **Binder overlay** (`binderRenderer.js`) — `Buylist $X` chip. ❌ remove
+
+Retail ("Buy") on the card page uses **bordered tiles** (`.price-tile`,
+teal/purple) in a grid; buylist ("Sell") uses **thin emerald text rows** —
+visually unrelated, which is the mismatch.
+
+Overflow/warping traces to a few repeatable root causes: flex/grid children
+defaulting to `min-width:auto` (can't shrink → blowout), pill badges that aren't
+`whitespace-nowrap`/`flex-shrink-0` (legality tags warp), non-wrapping
+button/toolbar rows, and long unbreakable strings.
+
+---
+
+## Part A — Remove buylist everywhere except the card page
+
+| File | Change |
+|------|--------|
+| `src/http/views/set.hbs` | Remove both `<span class="price-buylist">…</span>` blocks (~359-361, ~388-390) |
+| `src/http/public/js/binderRenderer.js` | Remove `binder-card-overlay-buylist` block (~90-99) and the `renderBuylist()` fn + its two call sites (~318, 357, 367-377) |
+| `src/http/hbs/set/set.orchestrator.ts` | Drop the `buylistMap` fetch (~696-706) and stop passing `buylistOffers` to the presenter (~729) |
+| `src/http/api/set/set-api.controller.ts` | Drop the `buylistMap` fetch (~221-228) and the `bestBuylistOffer(...)` arg (~232) |
+| `src/http/api/card/card-api.presenter.ts` + `dto/card-response.dto.ts` | Remove `bestBuylist` / `bestBuylistFinish` fields (API set-list/binder feed) |
+| `src/http/hbs/card/card.presenter.ts` + `dto/card.response.dto.ts` | Remove `bestBuylist` / `bestBuylistFinish` from `CardResponseDto` (only set rows consumed these). **Keep** `toBuylistView()` / `BuylistView` — the card page Sell section |
+| `src/http/styles/tailwind.css` | Remove now-dead `.price-buylist` and `.binder-card-overlay-buylist` rules |
+
+**Keep** `buylist.policy.ts`, `vendor.ts`, `GranularPriceRepositoryPort`, and
+`CardService.findCurrentBuylistForCards()` — that batched read is exactly what
+**6.4 (inventory best buylist)** needs. It becomes temporarily unused at its call
+sites; leave a one-line comment pointing to 6.4 rather than delete it.
+
+**Tests to update:** `card-api.presenter.spec.ts`, `card.presenter.spec.ts`,
+`set-api.controller.spec.ts`, `binderRenderer.spec.js`, `setListAjax.spec.js`,
+and the buylist assertions in `test/integration/api-sets.e2e-spec.ts` /
+`public.e2e-spec.ts`. `buylist.policy.spec.ts` stays (still used by the card page).
+
+---
+
+## Part B — Make Buy and Sell match (recommendation)
+
+**Promote Sell to the same tile language as Buy** — don't demote Buy to text.
+
+Rationale: tiles are the dominant price idiom across the app (card Buy section
+*and* the set-page price-info popover both use `.price-tile`). Demoting Buy to
+thin rows would fight that convention and lose scannability. Instead, render each
+buylist finish as a `.price-tile` with an **emerald accent** (mirroring
+teal=normal / purple=foil), in a grid that parallels the Buy grid. The "compare
+vendors" `<details>` stays nested under the tile. Result: Buy and Sell read as two
+parallel tile groups under the "Pricing" heading.
+
+Contained to `card.hbs` + a couple of CSS classes; fully reversible.
+
+---
+
+## Part C — The durable "this just can't happen" fix (APP-WIDE)
+
+A three-layer defense so overflow is prevented by default, and regressions are
+caught automatically instead of by memory. **Nothing here is buylist-specific.**
+
+**1. Defensive base-layer CSS contract** (`@layer base` in `tailwind.css`) — kills
+the root causes globally, at specificity 0 so any component can still override:
+
+```css
+@layer base {
+  /* #1 cause of blowout: flex/grid children won't shrink below content */
+  :where(.flex, .inline-flex, .grid) > * { min-width: 0; }
+  /* replaced elements never exceed their box */
+  img, svg, video, canvas, iframe { max-width: 100%; }
+  /* long unbreakable tokens (card names, URLs) wrap instead of pushing width */
+  :where(h1,h2,h3,h4,p,a,td,th,li,span) { overflow-wrap: anywhere; }
+}
+```
+
+(`overflow-wrap` tuned to `break-word` where `anywhere` is too aggressive.) We do
+**not** paper over it with `body { overflow-x: clip }` as the fix — that hides
+bugs; the CI test below is what makes it durable.
+
+**2. Two reusable utilities** for the recurring patterns, replacing ad-hoc markup:
+
+- `.cluster` → `@apply flex flex-wrap items-center gap-2;` for button/toolbar rows.
+  The set toolbar (`set.hbs:300`, non-wrapping: filter + base-only + view-toggle)
+  is a current mobile overflow source — switch it to `.cluster`.
+- `.badge-pill` → `@apply inline-flex items-center whitespace-nowrap flex-shrink-0 …;`
+  for the legality statuses (`card.hbs:51-58`) and `.tag` (currently
+  `display:inline`, which is *why* tags warp — change to `inline-block
+  whitespace-nowrap`). Pair with `min-w-0` on the adjacent label so the label
+  truncates, not the pill.
+
+**3. Automated regression guard** — `test/e2e/responsive-overflow.e2e.ts`
+(Playwright; infra already exists). Visits representative pages — `/`, `/sets`, a
+set detail, a card detail, `/search`, `/inventory`, `/billing`, `/pricing` — at
+**320px and 375px** and asserts no horizontal overflow:
+
+```
+expect(documentElement.scrollWidth).toBeLessThanOrEqual(innerWidth + 1)
+```
+
+plus a DOM walk flagging any element wider than its parent (whitelisting
+intentionally-scrollable `.table-wrapper` and chart canvases) with the offending
+selector in the failure. Runs under `npm run test:pw` and turns "did we leak
+again?" into a CI gate.
+
+---
+
+## Part D — Roadmap updates
+
+In `ROADMAP.md`, append a follow-up block after 6.3:
+
+```
+### 6.3.1 Buylist surface trim + UI parity + responsive hardening
+- [ ] Limit buylist to the card page (remove from set list + binder overlay; keep batched read for 6.4)
+- [ ] Buy/Sell visual parity: render Sell offers as price-tiles (emerald accent) matching retail
+- [ ] Responsive contract: base-layer min-width:0 / max-width / overflow-wrap guards
+- [ ] .cluster + .badge-pill utilities; fix legality-tag and set-toolbar overflow
+- [ ] Playwright overflow guard at 320/375px across key pages (regression gate)
+```
+
+And flip 6.3's "set page / binder show a compact best-offer" line to note the
+scope correction.
+
+---
+
+## Sequencing & verification
+
+1. Part A (remove) → 2. Part B (tile parity) → 3. Part C (hardening + guard test)
+   → 4. Part D (roadmap).
+2. `npm run build:css`, then `npm test` + `npm run test:frontend` +
+   `npm run test:pw` (incl. the new guard), `npm run lint`.
+3. Commit in logical chunks, push to
+   `claude/roadmap-6.3-cleanup-responsive-abn1wv`.
+
+---
+
+## Open items to eyeball
+
+- **Part B direction:** went with tiles for Sell; reversible if you'd rather go
+  compact for both.
+- **`overflow-wrap: anywhere`:** the one global rule worth checking on real pages
+  in case it over-breaks short labels.

--- a/docs/phase6-buylist-handoff.md
+++ b/docs/phase6-buylist-handoff.md
@@ -156,7 +156,9 @@ reversible function of scryfall_id). Drop the stored column and derive the image
   serves `/front/`); back/DFC images stay a separate future feature.
 
 ### Later
-- 6.3 remainder: buylist on the **set page + binder overlay** (card page is done).
+- ~~6.3 remainder: buylist on the **set page + binder overlay**~~ **Descoped in 6.3.1** — buylist
+  lives only on the card page; the set-list "sell $X" rows and binder "Buylist $X" overlay were
+  removed (clutter + mobile overflow). The batched `findCurrentBuylistByCardIds` read is kept for 6.4.
 - 6.4 inventory best-buylist / group-by-vendor / CSV; 6.5 optimizer (needs DB `vendor` table).
 - Possible: currency column → then Cardmarket (only if non-USD is ever wanted; currently out).
 - ROADMAP 6.6: condition grade vocabulary (when a multi-grade source lands; note CK's

--- a/migrations/035_fix_granular_price_pkeys.sql
+++ b/migrations/035_fix_granular_price_pkeys.sql
@@ -1,0 +1,65 @@
+BEGIN;
+
+-- Hotfix: production's granular_price / granular_price_history tables were
+-- created during the 6.x buylist spike WITHOUT their primary keys. Migration
+-- 034 defines those tables with CREATE TABLE IF NOT EXISTS, which is a no-op
+-- once the tables already exist -- so it never added the PKs to the pre-existing
+-- spike tables. scry's daily price ingest UPSERTs into them with
+--   INSERT ... ON CONFLICT (card_id, provider, price_type, finish, condition)
+-- which fails with "there is no unique or exclusion constraint matching the
+-- ON CONFLICT specification", aborting the entire price update.
+--
+-- This migration adds the missing primary keys. It is idempotent (re-run on
+-- every deploy via run_migrations.sh) and defensive: it de-duplicates any stray
+-- rows first so the PK can form (the tables are expected to be empty, since
+-- every granular insert has been failing, but a spike may have left rows). Note
+-- ADD PRIMARY KEY also sets the key columns NOT NULL automatically.
+
+-- granular_price: current per-vendor offer, one row per series (no date in key)
+DELETE FROM public.granular_price a
+USING public.granular_price b
+WHERE a.ctid < b.ctid
+  AND a.card_id = b.card_id
+  AND a.provider = b.provider
+  AND a.price_type = b.price_type
+  AND a.finish = b.finish
+  AND a.condition = b.condition;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'granular_price_pkey'
+          AND conrelid = 'public.granular_price'::regclass
+    ) THEN
+        ALTER TABLE public.granular_price
+            ADD CONSTRAINT granular_price_pkey
+            PRIMARY KEY (card_id, provider, price_type, finish, condition);
+    END IF;
+END $$;
+
+-- granular_price_history: dated series (date is part of the key)
+DELETE FROM public.granular_price_history a
+USING public.granular_price_history b
+WHERE a.ctid < b.ctid
+  AND a.card_id = b.card_id
+  AND a.provider = b.provider
+  AND a.price_type = b.price_type
+  AND a.finish = b.finish
+  AND a.condition = b.condition
+  AND a.date = b.date;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'granular_price_history_pkey'
+          AND conrelid = 'public.granular_price_history'::regclass
+    ) THEN
+        ALTER TABLE public.granular_price_history
+            ADD CONSTRAINT granular_price_history_pkey
+            PRIMARY KEY (card_id, provider, price_type, finish, condition, date);
+    END IF;
+END $$;
+
+COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.32.0",
+    "version": "1.32.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "i-want-my-mtg",
-            "version": "1.32.0",
+            "version": "1.32.1",
             "license": "UNLICENSED",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.32.0",
+    "version": "1.32.1",
     "description": "MTG Collection Tracker",
     "author": "Matthew Towles",
     "private": true,

--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -142,9 +142,10 @@ export class CardService {
     }
 
     /**
-     * Current buylist offers for many cards, grouped by card id. For the set
-     * page / binder, which show a compact best-offer per card. Empty map for an
-     * empty input.
+     * Current buylist offers for many cards, grouped by card id. Empty map for
+     * an empty input. Currently unused at call sites (buylist was trimmed to the
+     * card page in 6.3.1); kept for 6.4 inventory best-buylist, which needs this
+     * batched read.
      */
     async findCurrentBuylistForCards(cardIds: string[]): Promise<Map<string, GranularPrice[]>> {
         this.LOGGER.debug(`Find current buylist for ${cardIds.length} cards.`);

--- a/src/http/api/card/card-api.presenter.ts
+++ b/src/http/api/card/card-api.presenter.ts
@@ -1,18 +1,11 @@
 import { AffiliateLinkPolicy } from 'src/core/affiliate/affiliate-link.policy';
 import { Card } from 'src/core/card/card.entity';
-import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { CardApiResponseDto } from './dto/card-response.dto';
 
 export class CardApiPresenter {
-    static toCardApiResponse(
-        card: Card,
-        bestBuylist: GranularPrice | null = null
-    ): CardApiResponseDto {
+    static toCardApiResponse(card: Card): CardApiResponseDto {
         const latestPrice = card.prices?.[0];
         return {
-            bestBuylist: bestBuylist ? Number(bestBuylist.price) : null,
-            bestBuylistFinish:
-                bestBuylist && bestBuylist.finish !== 'normal' ? bestBuylist.finish : null,
             id: card.id,
             name: card.name,
             setCode: card.setCode,

--- a/src/http/api/card/dto/card-response.dto.ts
+++ b/src/http/api/card/dto/card-response.dto.ts
@@ -57,19 +57,6 @@ export class CardApiResponseDto {
     @ApiPropertyOptional({ type: CardPriceDto })
     readonly prices?: CardPriceDto;
 
-    @ApiPropertyOptional({
-        description: 'Best NM buylist (sell-to-vendor) offer in USD; null when none',
-        nullable: true,
-    })
-    readonly bestBuylist?: number | null;
-
-    @ApiPropertyOptional({
-        description:
-            "Finish of the best buylist offer when it is not the default 'normal' (e.g. 'foil', 'etched'); null otherwise",
-        nullable: true,
-    })
-    readonly bestBuylistFinish?: string | null;
-
     @ApiPropertyOptional()
     readonly setName?: string;
 

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -11,9 +11,7 @@ import {
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
-import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { InventoryService } from 'src/core/inventory/inventory.service';
-import { bestBuylistOffer } from 'src/core/pricing/buylist.policy';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { SET_CARD_SORTS, SET_SORTS } from 'src/core/query/sort-options.enum';
 import { SetService } from 'src/core/set/set.service';
@@ -40,14 +38,11 @@ import {
 } from '../shared/query-validation';
 import { formatUtcDate } from 'src/http/base/date.util';
 import { parseDaysParam } from 'src/http/base/query.util';
-import { getLogger } from 'src/logger/global-app-logger';
 
 @ApiTags('Sets')
 @Controller('api/v1/sets')
 @UseGuards(OptionalAuthOrApiKeyGuard, ApiRateLimitGuard)
 export class SetApiController {
-    private readonly LOGGER = getLogger(SetApiController.name);
-
     constructor(
         @Inject(SetService) private readonly setService: SetService,
         @Inject(CardService) private readonly cardService: CardService,
@@ -218,19 +213,8 @@ export class SetApiController {
             this.cardService.totalInSet(code, effectiveOptions),
         ]);
 
-        // Compact best-buylist per card for the set list / binder (6.3).
-        let buylistMap = new Map<string, GranularPrice[]>();
-        try {
-            buylistMap = await this.cardService.findCurrentBuylistForCards(cards.map((c) => c.id));
-        } catch (error) {
-            // best-effort; buylist is supplementary and must not fail the listing
-            this.LOGGER.debug(`Buylist unavailable for set ${code}: ${error?.message}`);
-        }
-
         return ApiResponseDto.ok(
-            cards.map((c) =>
-                CardApiPresenter.toCardApiResponse(c, bestBuylistOffer(buylistMap.get(c.id) ?? []))
-            ),
+            cards.map((c) => CardApiPresenter.toCardApiResponse(c)),
             new PaginationMeta(effectiveOptions.page, effectiveOptions.limit, total)
         );
     }

--- a/src/http/hbs/card/card.presenter.ts
+++ b/src/http/hbs/card/card.presenter.ts
@@ -5,7 +5,6 @@ import { CardRarity } from 'src/core/card/card.rarity.enum';
 import { Format } from 'src/core/card/format.enum';
 import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { Price } from 'src/core/card/price.entity';
-import { bestBuylistOffer } from 'src/core/pricing/buylist.policy';
 import { vendorDisplayName } from 'src/core/pricing/vendor';
 import { formatUtcDate } from 'src/http/base/date.util';
 import { BASE_IMAGE_URL, buildCardUrl, toDollar } from 'src/http/base/http.util';
@@ -33,14 +32,12 @@ export class CardPresenter {
     static toCardResponse(
         card: Card,
         inventory: InventoryQuantities,
-        imageType: CardImgType = CardImgType.SMALL,
-        buylistOffers: GranularPrice[] = []
+        imageType: CardImgType = CardImgType.SMALL
     ): CardResponseDto {
         if (!card) {
             throw new Error('Card is required to create CardResponseDto');
         }
         const price: Price | undefined = card.prices ? card.prices[0] : undefined;
-        const bestBuylist = bestBuylistOffer(buylistOffers);
         return new CardResponseDto({
             cardId: card.id,
             hasFoil: card.hasFoil,
@@ -60,9 +57,6 @@ export class CardPresenter {
                 card.hasNonFoil && inventory?.normalQuantity ? inventory.normalQuantity : 0,
             normalPriceRaw: price?.normal ? Math.round(price.normal * 100) / 100 : 0,
             foilPriceRaw: price?.foil ? Math.round(price.foil * 100) / 100 : 0,
-            bestBuylist: bestBuylist ? toDollar(bestBuylist.price) : '',
-            bestBuylistFinish:
-                bestBuylist && bestBuylist.finish !== 'normal' ? bestBuylist.finish : '',
             ...this.formatPriceChange(price),
             tags: this.createTags(card),
         });

--- a/src/http/hbs/card/dto/card.response.dto.ts
+++ b/src/http/hbs/card/dto/card.response.dto.ts
@@ -28,8 +28,6 @@ export class CardResponseDto {
     readonly foilPriceChangeWeeklySign?: string;
     readonly normalPriceRaw?: number;
     readonly foilPriceRaw?: number;
-    readonly bestBuylist?: string; // formatted best NM buylist offer, '' when none
-    readonly bestBuylistFinish?: string; // finish to call out when not 'normal', else ''
     readonly tags: string[];
 
     constructor(init: Partial<CardResponseDto>) {
@@ -54,8 +52,6 @@ export class CardResponseDto {
         this.foilPriceChangeWeeklySign = init.foilPriceChangeWeeklySign || '';
         this.normalPriceRaw = init.normalPriceRaw || 0;
         this.foilPriceRaw = init.foilPriceRaw || 0;
-        this.bestBuylist = init.bestBuylist || '';
-        this.bestBuylistFinish = init.bestBuylistFinish || '';
         this.tags = init.tags || [];
     }
 }

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { CardImgType } from 'src/core/card/card.img.type.enum';
 import { CardService } from 'src/core/card/card.service';
-import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { InventoryImportService } from 'src/core/inventory/import/inventory-import.service';
 import { SetImportRow } from 'src/core/inventory/import/inventory-import.types';
 import { InventoryService } from 'src/core/inventory/inventory.service';
@@ -693,19 +692,6 @@ export class SetOrchestrator {
 
         const effectiveSize = set.effectiveSize;
 
-        // Compact best-buylist per card for the table / binder (6.3). Best-effort:
-        // buylist is secondary and must never take down the set page.
-        let buylistMap = new Map<string, GranularPrice[]>();
-        if (setPayloadSize > 0) {
-            try {
-                buylistMap = await this.cardService.findCurrentBuylistForCards(
-                    set.cards.map((c) => c.id)
-                );
-            } catch (error) {
-                this.LOGGER.debug(`Buylist unavailable for set ${set.code}: ${error?.message}`);
-            }
-        }
-
         return new SetResponseDto({
             baseSize: set.baseSize,
             block: set.block ?? set.name,
@@ -725,8 +711,7 @@ export class SetOrchestrator {
                       CardPresenter.toCardResponse(
                           card,
                           InventoryPresenter.toQuantityMap(inventory)?.get(card.id),
-                          CardImgType.NORMAL,
-                          buylistMap.get(card.id) ?? []
+                          CardImgType.NORMAL
                       )
                   )
                 : [],

--- a/src/http/public/css/app.css
+++ b/src/http/public/css/app.css
@@ -806,18 +806,6 @@ html:not(.dark) .iwm-search:focus {
     color: #0d0b1a;
 }
 
-/* Auth buttons (unauth state) — hide below the primary-nav breakpoint
-   since Sign In / Sign Up are reachable from the drawer. Upgrade CTA stays
-   visible (it's the main conversion signal for authenticated free users)
-   but is hidden at very narrow widths where it competes with the hamburger. */
-@container navbar (max-width: 599px) {
-    .iwm-auth-signin,
-    .iwm-auth-signup { display: none; }
-}
-@container navbar (max-width: 380px) {
-    .iwm-upgrade-cta { display: none; }
-}
-
 .iwm-auth-signin {
     display: inline-flex;
     align-items: center;
@@ -863,6 +851,20 @@ html:not(.dark) .iwm-auth-signin:hover {
     box-shadow: 0 0 20px rgba(44, 200, 202, 0.35);
     text-decoration: none;
     color: #0d0b1a;
+}
+
+/* Auth buttons (unauth state) — hide below the primary-nav breakpoint
+   since Sign In / Sign Up are reachable from the drawer. Upgrade CTA stays
+   visible (it's the main conversion signal for authenticated free users)
+   but is hidden at very narrow widths where it competes with the hamburger.
+   These come after the base display rules above so the container-query
+   `display: none` wins on source order (same specificity). */
+@container navbar (max-width: 599px) {
+    .iwm-auth-signin,
+    .iwm-auth-signup { display: none; }
+}
+@container navbar (max-width: 380px) {
+    .iwm-upgrade-cta { display: none; }
 }
 
 /* Icon buttons */

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -754,6 +754,32 @@ input:where([type='file']):focus {
   outline-offset: 2px;
 }
 
+/* #1 cause of blowout: flex/grid children won't shrink below their content */
+
+:where(.flex, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+:where(.flex, .\!inline-flex, .grid) > * {
+  min-width: 0 !important;
+}
+
+/* replaced elements never exceed their box */
+
+img,
+    svg,
+    video,
+    canvas,
+    iframe {
+  max-width: 100%;
+}
+
+/* long unbreakable tokens (card names, URLs) wrap instead of pushing width */
+
+:where(h1, h2, h3, h4, p, a, td, th, li, span) {
+  overflow-wrap: anywhere;
+}
+
 .\!container {
   width: 100% !important;
 }
@@ -1569,6 +1595,11 @@ input:where([type='file']):focus {
   border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
 }
 
+.border-emerald-300 {
+  --tw-border-opacity: 1;
+  border-color: rgb(110 231 183 / var(--tw-border-opacity, 1));
+}
+
 .border-gray-100 {
   --tw-border-opacity: 1;
   border-color: rgb(243 244 246 / var(--tw-border-opacity, 1));
@@ -1642,6 +1673,11 @@ input:where([type='file']):focus {
 .bg-blue-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
+}
+
+.bg-emerald-50 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(236 253 245 / var(--tw-bg-opacity, 1));
 }
 
 .bg-gray-100 {
@@ -2118,6 +2154,11 @@ input:where([type='file']):focus {
   color: rgb(4 120 87 / var(--tw-text-opacity, 1));
 }
 
+.text-emerald-900 {
+  --tw-text-opacity: 1;
+  color: rgb(6 78 59 / var(--tw-text-opacity, 1));
+}
+
 .text-gray-100 {
   --tw-text-opacity: 1;
   color: rgb(243 244 246 / var(--tw-text-opacity, 1));
@@ -2364,6 +2405,11 @@ input:where([type='file']):focus {
 
 /* ===== Accessibility ===== */
 
+/* ===== Responsive defense layer =====
+   Kills the recurring overflow root causes globally, at specificity 0 (:where)
+   so any component can still override. The Playwright overflow guard
+   (test/e2e/responsive-overflow.e2e.ts) is what keeps this honest. */
+
 .skip-link {
   position: absolute;
   width: 1px;
@@ -2404,6 +2450,44 @@ input:where([type='file']):focus {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+/* ===== Responsive utilities =====
+   Reusable patterns for the recurring overflow sources. */
+
+/* Wrapping button / toolbar rows that never blow out horizontally. */
+
+:where(.cluster, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+.cluster {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Pills (legality statuses, tags) that keep their shape and never warp;
+   pair with min-w-0 on the adjacent label so the label truncates, not the pill. */
+
+:where(.flex,.badge-pill, .grid) > * {
+  min-width: 0;
+}
+
+.badge-pill {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  white-space: nowrap;
+  border-radius: 9999px;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+}
+
 /* ===== Breadcrumbs ===== */
 
 .breadcrumb-item {
@@ -2416,6 +2500,10 @@ input:where([type='file']):focus {
 .breadcrumb-item:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+:where(.breadcrumb-layout, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .breadcrumb-layout {
@@ -2435,6 +2523,10 @@ input:where([type='file']):focus {
 }
 
 /* ===== Buttons ===== */
+
+:where(.flex,.btn, .grid) > * {
+  min-width: 0;
+}
 
 .btn {
   display: inline-flex;
@@ -2770,6 +2862,10 @@ input:where([type='file']):focus {
 
 /* Binder wrapper: side arrows + grid */
 
+:where(.binder-wrapper, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .binder-wrapper {
   position: relative;
   margin-left: auto;
@@ -2778,6 +2874,10 @@ input:where([type='file']):focus {
   align-items: stretch;
   justify-content: center;
   max-width: 720px;
+}
+
+:where(.binder-side-btn, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .binder-side-btn {
@@ -2878,6 +2978,10 @@ input:where([type='file']):focus {
 :is(.dark) .binder-side-btn--left,
 :is(.dark) .binder-side-btn--right {
   border-color: #241e45;
+}
+
+:where(.flex, .inline-flex,.binder-grid) > * {
+  min-width: 0;
 }
 
 .binder-grid {
@@ -3038,14 +3142,6 @@ input:where([type='file']):focus {
   color: rgb(253 224 71 / var(--tw-text-opacity, 1));
 }
 
-.binder-card-overlay-buylist {
-  display: block;
-  font-size: 0.7rem;
-  font-weight: 500;
-  --tw-text-opacity: 1;
-  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
-}
-
 .binder-card-stepper {
   margin-top: 0.375rem;
 }
@@ -3122,6 +3218,10 @@ input:where([type='file']):focus {
   color: rgb(219 181 245 / 0.8);
 }
 
+:where(.binder-page-nav, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .binder-page-nav {
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
@@ -3188,6 +3288,10 @@ input:where([type='file']):focus {
     --tw-bg-opacity: 1;
     background-color: rgb(26 21 51 / var(--tw-bg-opacity, 1));
   }
+}
+
+:where(.flex,.binder-page-indicator, .grid) > * {
+  min-width: 0;
 }
 
 .binder-page-indicator {
@@ -3356,6 +3460,10 @@ input:where([type='file']):focus {
 .binder-card-unowned img {
   opacity: 0.25;
   filter: grayscale(100%);
+}
+
+:where(.binder-card-unowned .binder-card-number, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .binder-card-unowned .binder-card-number {
@@ -3711,6 +3819,10 @@ input:where([type='file']):focus {
 
 /* ===== Delete Inventory ===== */
 
+:where(.delete-inventory-button, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .delete-inventory-button {
   display: flex;
   cursor: pointer;
@@ -3834,6 +3946,10 @@ input:where([type='file']):focus {
 
 /* ===== Foil Badge ===== */
 
+:where(.flex,.foil-badge, .grid) > * {
+  min-width: 0;
+}
+
 .foil-badge {
   margin-left: 0.25rem;
   display: inline-flex;
@@ -3949,6 +4065,10 @@ input:where([type='file']):focus {
 
 /* ===== Inventory Controls ===== */
 
+:where(.inventory-controller-button-normal, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .inventory-controller-button-normal {
   display: flex;
   align-items: center;
@@ -3978,6 +4098,10 @@ input:where([type='file']):focus {
 .inventory-controller-button-normal:is(.dark *) {
   --tw-bg-opacity: 1;
   background-color: rgb(32 153 143 / var(--tw-bg-opacity, 1));
+}
+
+:where(.inventory-controller-button-foil, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .inventory-controller-button-foil {
@@ -4049,6 +4173,10 @@ input:where([type='file']):focus {
 }
 
 /* ===== Mana Cost ===== */
+
+:where(.flex,.mana-cost, .grid) > * {
+  min-width: 0;
+}
 
 .mana-cost {
   display: inline-flex;
@@ -4123,6 +4251,10 @@ input:where([type='file']):focus {
   background-color: rgb(19 16 37 / var(--tw-bg-opacity, 1));
   --tw-text-opacity: 1;
   color: rgb(69 221 214 / var(--tw-text-opacity, 1));
+}
+
+:where(.suggest-item, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .suggest-item {
@@ -4447,6 +4579,10 @@ input:where([type='file']):focus {
 
 /* ===== Pagination ===== */
 
+:where(.pagination-container, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .pagination-container {
   margin-top: 1.5rem;
   display: flex;
@@ -4483,8 +4619,19 @@ input:where([type='file']):focus {
 
 .pagination-btn {
   border-radius: 9999px;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
   font-size: 0.75rem;
   line-height: 1rem;
+}
+
+:where(.flex,.pagination-btn, .grid) > * {
+  min-width: 0;
+}
+
+.pagination-btn {
   display: inline-flex;
   cursor: pointer;
   align-items: center;
@@ -4669,23 +4816,6 @@ input:where([type='file']):focus {
   font-weight: 500;
 }
 
-/* Compact best-buylist (sell-to-vendor) indicator on set rows / binder */
-
-.price-buylist {
-  margin-top: 0.125rem;
-  display: block;
-  font-size: 0.75rem;
-  line-height: 1rem;
-  font-weight: 500;
-  --tw-text-opacity: 1;
-  color: rgb(4 120 87 / var(--tw-text-opacity, 1));
-}
-
-.price-buylist:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(52 211 153 / var(--tw-text-opacity, 1));
-}
-
 .price-change-positive {
   --tw-text-opacity: 1;
   color: rgb(21 128 61 / var(--tw-text-opacity, 1));
@@ -4737,6 +4867,10 @@ input:where([type='file']):focus {
   }
 }
 
+:where(.flex,.quantity-form-foil, .grid) > * {
+  min-width: 0;
+}
+
 .quantity-form-foil {
   margin: 0.25rem;
   display: inline-flex;
@@ -4750,6 +4884,10 @@ input:where([type='file']):focus {
   --tw-gradient-to: rgb(196 138 237 / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
   --tw-gradient-to: #72ece5 var(--tw-gradient-to-position);
+}
+
+:where(.flex,.quantity-form-normal, .grid) > * {
+  min-width: 0;
 }
 
 .quantity-form-normal {
@@ -4822,12 +4960,20 @@ input:where([type='file']):focus {
 
 /* ===== Inventory Stepper ===== */
 
+:where(.flex,.inv-stepper-group, .grid) > * {
+  min-width: 0;
+}
+
 .inv-stepper-group {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
   max-width: 100%;
+}
+
+:where(.flex,.inv-stepper, .grid) > * {
+  min-width: 0;
 }
 
 .inv-stepper {
@@ -4908,6 +5054,10 @@ input:where([type='file']):focus {
 .inv-stepper-label--foil:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(196 138 237 / var(--tw-text-opacity, 1));
+}
+
+:where(.inv-stepper-btn, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .inv-stepper-btn {
@@ -5038,6 +5188,10 @@ input:where([type='file']):focus {
   }
 }
 
+:where(.inv-stepper-qty, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .inv-stepper-qty {
   display: flex;
   min-width: 2rem;
@@ -5151,6 +5305,10 @@ input:where([type='file']):focus {
 
 .response-message.toast-exit {
   animation: toast-slide-out 0.25s ease-in forwards;
+}
+
+:where(.toast-body, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .toast-body {
@@ -5372,6 +5530,10 @@ input:where([type='file']):focus {
   -webkit-user-select: none;
      -moz-user-select: none;
           user-select: none;
+}
+
+:where(.sort-btn, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .sort-btn {
@@ -5731,7 +5893,8 @@ input:where([type='file']):focus {
 .tag {
   margin-left: 0.125rem;
   margin-right: 0.125rem;
-  display: inline;
+  display: inline-block;
+  white-space: nowrap;
   border-radius: 0.25rem;
   --tw-bg-opacity: 1;
   background-color: rgb(139 66 198 / var(--tw-bg-opacity, 1));
@@ -5955,6 +6118,10 @@ input:where([type='file']):focus {
   background-color: rgb(19 16 37 / var(--tw-bg-opacity, 1));
 }
 
+:where(.action-card-label, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .action-card-label {
   margin-bottom: 0.75rem;
   display: flex;
@@ -6073,6 +6240,10 @@ input:where([type='file']):focus {
         radial-gradient(ellipse 40% 35% at 75% 60%, rgba(44, 200, 202, 0.10) 0%, transparent 70%);
 }
 
+:where(.flex,.pricing-hero-badge, .grid) > * {
+  min-width: 0;
+}
+
 .pricing-hero-badge {
   margin-bottom: 1.5rem;
   display: inline-flex;
@@ -6151,6 +6322,10 @@ input:where([type='file']):focus {
   line-height: 1.6;
 }
 
+:where(.flex,.billing-toggle, .grid) > * {
+  min-width: 0;
+}
+
 .billing-toggle {
   display: inline-flex;
   align-items: center;
@@ -6169,6 +6344,10 @@ input:where([type='file']):focus {
   border-color: rgb(46 39 88 / var(--tw-border-opacity, 1));
   --tw-bg-opacity: 1;
   background-color: rgb(26 21 51 / var(--tw-bg-opacity, 1));
+}
+
+:where(.toggle-option, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .toggle-option {
@@ -6228,6 +6407,10 @@ input:where([type='file']):focus {
   font-size: 0.68rem;
   padding: 0.15rem 0.45rem;
   letter-spacing: 0.01em;
+}
+
+:where(.flex, .inline-flex,.pricing-cards-grid) > * {
+  min-width: 0;
 }
 
 .pricing-cards-grid {
@@ -6321,6 +6504,10 @@ input:where([type='file']):focus {
 .card-tier.teal:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(69 221 214 / var(--tw-text-opacity, 1));
+}
+
+:where(.card-price, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .card-price {
@@ -6418,6 +6605,10 @@ input:where([type='file']):focus {
   line-height: 1.5;
 }
 
+:where(.card-features, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .card-features {
   margin-bottom: 1.75rem;
   display: flex;
@@ -6425,6 +6616,10 @@ input:where([type='file']):focus {
   flex-direction: column;
   gap: 0.75rem;
   padding: 0px;
+}
+
+:where(.card-feature, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .card-feature {
@@ -6460,6 +6655,10 @@ input:where([type='file']):focus {
 .pricing-feat-icon-check:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(69 221 214 / var(--tw-text-opacity, 1));
+}
+
+:where(.flex,.pricing-btn, .grid) > * {
+  min-width: 0;
 }
 
 .pricing-btn {
@@ -6794,6 +6993,10 @@ input:where([type='file']):focus {
   display: none;
 }
 
+:where(.pricing-faq-question, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .pricing-faq-question {
   display: flex;
   cursor: pointer;
@@ -6907,6 +7110,10 @@ input:where([type='file']):focus {
   line-height: 1.6;
 }
 
+:where(.pricing-bottom-cta-btns, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .pricing-bottom-cta-btns {
   display: flex;
   flex-wrap: wrap;
@@ -6939,6 +7146,10 @@ input:where([type='file']):focus {
         radial-gradient(ellipse 65% 55% at 50% -10%, rgba(114, 51, 164, 0.30) 0%, transparent 70%),
         radial-gradient(ellipse 45% 40% at 80% 65%, rgba(44, 200, 202, 0.12) 0%, transparent 70%),
         radial-gradient(ellipse 35% 35% at 15% 70%, rgba(214, 74, 154, 0.08) 0%, transparent 70%);
+}
+
+:where(.flex,.home-hero-badge, .grid) > * {
+  min-width: 0;
 }
 
 .home-hero-badge {
@@ -7019,6 +7230,10 @@ input:where([type='file']):focus {
   line-height: 1.6;
 }
 
+:where(.home-hero-ctas, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .home-hero-ctas {
   margin-bottom: 2.5rem;
   display: flex;
@@ -7034,6 +7249,10 @@ input:where([type='file']):focus {
   padding: 0.7rem 1.75rem;
 }
 
+:where(.home-hero-feats, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .home-hero-feats {
   margin: 0px;
   display: flex;
@@ -7045,6 +7264,10 @@ input:where([type='file']):focus {
        column-gap: 1.5rem;
   row-gap: 0.75rem;
   padding: 0px;
+}
+
+:where(.flex,.home-hero-feats li, .grid) > * {
+  min-width: 0;
 }
 
 .home-hero-feats li {
@@ -7353,6 +7576,10 @@ input:where([type='file']):focus {
   color: rgb(114 236 229 / var(--tw-text-opacity, 1));
 }
 
+:where(.breakdown-list, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .breakdown-list {
   display: flex;
   flex-direction: column;
@@ -7388,6 +7615,10 @@ input:where([type='file']):focus {
   border-color: rgb(44 200 202 / 0.4);
 }
 
+:where(.breakdown-row-header, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
 .breakdown-row-header {
   margin-bottom: 0.5rem;
   display: flex;
@@ -7412,6 +7643,10 @@ input:where([type='file']):focus {
 
 .breakdown-label {
   text-transform: capitalize;
+}
+
+:where(.breakdown-stats, .inline-flex, .grid) > * {
+  min-width: 0;
 }
 
 .breakdown-stats {
@@ -7479,6 +7714,10 @@ input:where([type='file']):focus {
 }
 
 /* ===== Tile quick-add (+) overlay ===== */
+
+:where(.tile-quick-add, .inline-flex, .grid) > * {
+  min-width: 0;
+}
 
 .tile-quick-add {
   position: absolute;
@@ -7605,10 +7844,6 @@ input:where([type='file']):focus {
   transition-duration: 150ms;
 }
 
-.last\:mb-0:last-child {
-  margin-bottom: 0px;
-}
-
 @media (hover: hover) and (pointer: fine) {
   .hover\:border-teal-400:hover {
     --tw-border-opacity: 1;
@@ -7731,6 +7966,11 @@ input:where([type='file']):focus {
   border-color: rgb(180 83 9 / 0.5);
 }
 
+.dark\:border-emerald-600:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(5 150 105 / var(--tw-border-opacity, 1));
+}
+
 .dark\:border-gray-700:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
@@ -7787,6 +8027,10 @@ input:where([type='file']):focus {
 
 .dark\:bg-blue-900\/30:is(.dark *) {
   background-color: rgb(30 58 138 / 0.3);
+}
+
+.dark\:bg-emerald-950\/30:is(.dark *) {
+  background-color: rgb(2 44 34 / 0.3);
 }
 
 .dark\:bg-gray-800:is(.dark *) {
@@ -7911,6 +8155,11 @@ input:where([type='file']):focus {
 .dark\:text-blue-200:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(191 219 254 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-emerald-200:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(167 243 208 / var(--tw-text-opacity, 1));
 }
 
 .dark\:text-emerald-300:is(.dark *) {

--- a/src/http/public/js/binderRenderer.js
+++ b/src/http/public/js/binderRenderer.js
@@ -87,17 +87,6 @@
             html += '</span>';
         }
 
-        if (card.bestBuylist != null) {
-            var buylistFinish = card.bestBuylistFinish
-                ? ' ' + escapeHtml(card.bestBuylistFinish)
-                : '';
-            html +=
-                '<span class="binder-card-overlay-buylist">Buylist ' +
-                AjaxUtils.toDollar(card.bestBuylist) +
-                buylistFinish +
-                '</span>';
-        }
-
         if (options.authenticated) {
             html +=
                 '<div class="binder-card-stepper">' +

--- a/src/http/public/js/setCardListAjax.js
+++ b/src/http/public/js/setCardListAjax.js
@@ -315,7 +315,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     html += ' ' + AjaxUtils.renderPriceChange(card.prices.normalChangeWeekly);
                 }
             }
-            html += renderBuylist(card);
             html += '</td>';
         }
 
@@ -354,27 +353,11 @@ document.addEventListener('DOMContentLoaded', function () {
                     html += ' ' + AjaxUtils.renderPriceChange(card.prices.foilChangeWeekly);
                 }
             }
-            html += renderBuylist(card);
             html += '</td>';
         }
 
         html += '</tr>';
         return html;
-    }
-
-    // Compact best-buylist (sell-to-vendor) indicator, mirrors set.hbs (6.3).
-    // Calls out the finish when the best offer is not the default normal.
-    function renderBuylist(card) {
-        if (card.bestBuylist == null) return '';
-        var finish = card.bestBuylistFinish
-            ? ' ' + AjaxUtils.escapeHtml(card.bestBuylistFinish)
-            : '';
-        return (
-            '<span class="price-buylist" title="Best buylist offer (NM)">sell ' +
-            AjaxUtils.toDollar(card.bestBuylist) +
-            finish +
-            '</span>'
-        );
     }
 
     function renderManaCost(manaCost) {

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -11,9 +11,47 @@
     }
 }
 
+/* ===== Responsive defense layer =====
+   Kills the recurring overflow root causes globally, at specificity 0 (:where)
+   so any component can still override. The Playwright overflow guard
+   (test/e2e/responsive-overflow.e2e.ts) is what keeps this honest. */
+@layer base {
+    /* #1 cause of blowout: flex/grid children won't shrink below their content */
+    :where(.flex, .inline-flex, .grid) > * {
+        min-width: 0;
+    }
+    /* replaced elements never exceed their box */
+    img,
+    svg,
+    video,
+    canvas,
+    iframe {
+        max-width: 100%;
+    }
+    /* long unbreakable tokens (card names, URLs) wrap instead of pushing width */
+    :where(h1, h2, h3, h4, p, a, td, th, li, span) {
+        overflow-wrap: anywhere;
+    }
+}
+
 .skip-link {
     @apply sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50
            focus:px-4 focus:py-2 focus:rounded-lg focus:bg-teal-700 focus:text-white focus:font-medium focus:shadow-lg;
+}
+
+/* ===== Responsive utilities =====
+   Reusable patterns for the recurring overflow sources. */
+
+/* Wrapping button / toolbar rows that never blow out horizontally. */
+.cluster {
+    @apply flex flex-wrap items-center gap-2;
+}
+
+/* Pills (legality statuses, tags) that keep their shape and never warp;
+   pair with min-w-0 on the adjacent label so the label truncates, not the pill. */
+.badge-pill {
+    @apply inline-flex items-center whitespace-nowrap flex-shrink-0
+           px-2 py-0.5 rounded-full text-xs font-medium;
 }
 
 /* ===== Breadcrumbs ===== */
@@ -229,10 +267,6 @@
 
 .binder-card-overlay-price-foil {
     @apply text-yellow-300;
-}
-
-.binder-card-overlay-buylist {
-    @apply block text-[0.7rem] font-medium text-gray-300;
 }
 
 .binder-card-stepper {
@@ -778,11 +812,6 @@
     @apply inline-block text-xs font-medium ml-1;
 }
 
-/* Compact best-buylist (sell-to-vendor) indicator on set rows / binder */
-.price-buylist {
-    @apply block mt-0.5 text-xs font-medium text-emerald-700 dark:text-emerald-400;
-}
-
 .price-change-positive {
     @apply text-green-700 dark:text-green-400;
 }
@@ -1185,7 +1214,7 @@
 /* ===== Tags ===== */
 
 .tag {
-    @apply inline text-[0.65rem] font-medium text-white bg-purple-600 dark:bg-purple-700
+    @apply inline-block whitespace-nowrap text-[0.65rem] font-medium text-white bg-purple-600 dark:bg-purple-700
            px-1 py-0 mx-0.5 rounded;
 }
 

--- a/src/http/views/card.hbs
+++ b/src/http/views/card.hbs
@@ -46,16 +46,16 @@
                 <h2 class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-3">Legalities</h2>
                 <div class="grid grid-cols-2 gap-x-4 gap-y-2">
                     {{#each card.legalities as |legality|}}
-                    <div class="flex items-center justify-between text-sm">
-                        <span class="text-gray-600 dark:text-gray-400">{{capitalize legality.format}}</span>
+                    <div class="flex items-center justify-between gap-2 text-sm">
+                        <span class="min-w-0 truncate text-gray-600 dark:text-gray-400">{{capitalize legality.format}}</span>
                         {{#if (eq legality.status 'legal')}}
-                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-teal-100 text-teal-800 dark:bg-teal-900/40 dark:text-teal-300">{{capitalize legality.status}}</span>
+                        <span class="badge-pill bg-teal-100 text-teal-800 dark:bg-teal-900/40 dark:text-teal-300">{{capitalize legality.status}}</span>
                         {{else if (eq legality.status 'banned')}}
-                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-hotpink-100 text-hotpink-700 dark:bg-hotpink-700/30 dark:text-hotpink-300">{{capitalize legality.status}}</span>
+                        <span class="badge-pill bg-hotpink-100 text-hotpink-700 dark:bg-hotpink-700/30 dark:text-hotpink-300">{{capitalize legality.status}}</span>
                         {{else if (eq legality.status 'restricted')}}
-                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">{{capitalize legality.status}}</span>
+                        <span class="badge-pill bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300">{{capitalize legality.status}}</span>
                         {{else}}
-                        <span class="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">{{capitalize legality.status}}</span>
+                        <span class="badge-pill bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">{{capitalize legality.status}}</span>
                         {{/if}}
                     </div>
                     {{/each}}

--- a/src/http/views/card.hbs
+++ b/src/http/views/card.hbs
@@ -100,31 +100,34 @@
                 {{>buyOnTcgplayer url=card.purchaseUrlTcgplayerEtched label="Buy Etched on TCGPlayer"}}
                 {{/if}}
 
-                {{!-- Sell: best buylist offer per finish; vendors behind a disclosure --}}
+                {{!-- Sell: best buylist offer per finish as emerald tiles; vendors behind a disclosure --}}
                 {{#if buylist.hasAny}}
-                <div class="buylist-info mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
                     <h3 class="price-group-label">Sell <span class="price-group-label-note">buylist · NM</span></h3>
-                    {{#each buylist.finishes}}
-                    <div class="buylist-finish mb-2 last:mb-0">
-                        <div class="flex items-center justify-between text-sm">
-                            <span class="text-gray-600 dark:text-gray-400">{{this.finish}} <span class="text-gray-400 dark:text-gray-500">· {{this.best.vendor}}</span></span>
-                            <span class="font-mono font-semibold text-emerald-700 dark:text-emerald-300">{{this.best.price}}</span>
+                    <div class="grid {{#if (gt buylist.finishes.length 1)}}grid-cols-2{{else}}grid-cols-1{{/if}} gap-2">
+                        {{#each buylist.finishes}}
+                        <div class="price-tile border-emerald-300 dark:border-emerald-600 bg-emerald-50 dark:bg-emerald-950/30">
+                            <h4 class="font-semibold text-emerald-700 dark:text-emerald-300 text-xs uppercase tracking-wide mb-1">{{this.finish}}</h4>
+                            <div class="price-tile-value font-bold text-emerald-900 dark:text-emerald-200 font-mono">
+                                {{this.best.price}}
+                            </div>
+                            <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{this.best.vendor}}</div>
+                            {{#if this.hasMultiple}}
+                            <details class="buylist-compare">
+                                <summary class="buylist-compare-summary">compare vendors</summary>
+                                <ul class="mt-1 space-y-1">
+                                    {{#each this.offers}}
+                                    <li class="buylist-offer flex items-center justify-between text-xs {{#if this.isBest}}buylist-best text-emerald-700 dark:text-emerald-300 font-semibold{{else}}text-gray-500 dark:text-gray-400{{/if}}">
+                                        <span class="min-w-0 truncate">{{this.vendor}}</span>
+                                        <span class="font-mono flex-shrink-0">{{this.price}}</span>
+                                    </li>
+                                    {{/each}}
+                                </ul>
+                            </details>
+                            {{/if}}
                         </div>
-                        {{#if this.hasMultiple}}
-                        <details class="buylist-compare">
-                            <summary class="buylist-compare-summary">compare vendors</summary>
-                            <ul class="mt-1 space-y-1">
-                                {{#each this.offers}}
-                                <li class="buylist-offer flex items-center justify-between text-xs {{#if this.isBest}}buylist-best text-emerald-700 dark:text-emerald-300 font-semibold{{else}}text-gray-500 dark:text-gray-400{{/if}}">
-                                    <span>{{this.vendor}}</span>
-                                    <span class="font-mono">{{this.price}}</span>
-                                </li>
-                                {{/each}}
-                            </ul>
-                        </details>
-                        {{/if}}
+                        {{/each}}
                     </div>
-                    {{/each}}
                 </div>
                 {{/if}}
                 <section class="inventory-info">

--- a/src/http/views/set.hbs
+++ b/src/http/views/set.hbs
@@ -356,9 +356,6 @@
                         <span class="price-change price-change-{{this.priceChangeWeeklySign}}">{{this.priceChangeWeekly}}</span>
                         {{/if}}
                         {{/if}}
-                        {{#if this.bestBuylist}}
-                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}{{#if this.bestBuylistFinish}} {{this.bestBuylistFinish}}{{/if}}</span>
-                        {{/if}}
                     </td>
                     {{/if}}
                     {{#if ../hasAnyFoilPrice}}
@@ -384,9 +381,6 @@
                         {{#if this.foilPriceChangeWeekly}}
                         <span class="price-change price-change-{{this.foilPriceChangeWeeklySign}}">{{this.foilPriceChangeWeekly}}</span>
                         {{/if}}
-                        {{/if}}
-                        {{#if this.bestBuylist}}
-                        <span class="price-buylist" title="Best buylist offer (NM)">sell {{this.bestBuylist}}{{#if this.bestBuylistFinish}} {{this.bestBuylistFinish}}{{/if}}</span>
                         {{/if}}
                     </td>
                     {{/if}}

--- a/src/http/views/set.hbs
+++ b/src/http/views/set.hbs
@@ -297,7 +297,7 @@
 
 <div id="set-cards-panel" {{#if set.sealedProducts.length}}role="tabpanel" aria-labelledby="set-tab-cards"{{/if}}>
 <div id="set-card-list-ajax" data-set-code="{{set.code}}" data-authenticated="{{authenticated}}" class="content-wrapper">
-    <div class="flex items-center gap-2">
+    <div class="cluster">
         <div class="flex-1" id="filter-wrapper">
             {{>filter}}
         </div>

--- a/test/e2e/responsive-overflow.e2e.ts
+++ b/test/e2e/responsive-overflow.e2e.ts
@@ -1,0 +1,144 @@
+import { test as authTest, expect } from './fixtures/auth.fixture';
+import { test, type Page } from '@playwright/test';
+
+/**
+ * Regression gate for horizontal overflow / warping (Roadmap 6.3.1, Part C).
+ *
+ * Visits representative pages at narrow mobile widths and asserts the page
+ * never scrolls horizontally. When it does, the DOM walk names the offending
+ * element so the failure points at the cause instead of "something leaked".
+ *
+ * Containers that are intentionally scrollable (the responsive table wrapper)
+ * and chart canvases are whitelisted — their content legitimately exceeds the
+ * viewport and is clipped/scrolled, not warping the page.
+ */
+const WIDTHS = [320, 375] as const;
+const HEIGHT = 800;
+const OVERFLOW_WHITELIST = ['.table-wrapper', 'canvas'];
+
+interface Offender {
+    selector: string;
+    right: number;
+    docWidth: number;
+}
+
+/**
+ * Diagnostic only — runs after we already know the page overflows, to name the
+ * likely culprits in the failure message. Skips `position: fixed` subtrees
+ * (off-canvas drawers, sticky bars) since those don't grow the document's
+ * scroll width, and the whitelisted scroll containers.
+ */
+async function findOverflowOffenders(page: Page, whitelist: string[]): Promise<Offender[]> {
+    return page.evaluate((whitelistSelectors) => {
+        const docWidth = document.documentElement.clientWidth;
+        const isInFixed = (el: HTMLElement): boolean => {
+            let node: HTMLElement | null = el;
+            while (node && node !== document.body) {
+                if (getComputedStyle(node).position === 'fixed') return true;
+                node = node.parentElement;
+            }
+            return false;
+        };
+        const offenders: Offender[] = [];
+        const elements = document.body.querySelectorAll<HTMLElement>('*');
+        for (const el of Array.from(elements)) {
+            if (whitelistSelectors.some((sel) => el.closest(sel))) continue;
+            const rect = el.getBoundingClientRect();
+            if (rect.width === 0 || rect.height === 0) continue;
+            if (rect.right <= docWidth + 1 && rect.left >= -1) continue;
+            if (isInFixed(el)) continue;
+            const id = el.id ? `#${el.id}` : '';
+            const cls =
+                typeof el.className === 'string' && el.className.trim()
+                    ? '.' + el.className.trim().split(/\s+/).slice(0, 3).join('.')
+                    : '';
+            offenders.push({
+                selector: `${el.tagName.toLowerCase()}${id}${cls}`,
+                right: Math.round(rect.right),
+                docWidth,
+            });
+        }
+        return offenders;
+    }, whitelist) as Promise<Offender[]>;
+}
+
+async function assertNoHorizontalOverflow(page: Page, label: string): Promise<void> {
+    const { scrollWidth, innerWidth } = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        innerWidth: window.innerWidth,
+    }));
+    const limit = innerWidth + 1;
+
+    let message = `Page scrolls horizontally on ${label}: scrollWidth=${scrollWidth} > innerWidth=${innerWidth}`;
+    if (scrollWidth > limit) {
+        const offenders = await findOverflowOffenders(page, OVERFLOW_WHITELIST);
+        if (offenders.length) {
+            message +=
+                '\nLikely culprits:\n' +
+                offenders
+                    .map((o) => `  ${o.selector} (right=${o.right} > viewport=${o.docWidth})`)
+                    .join('\n');
+        }
+    }
+    expect(scrollWidth, message).toBeLessThanOrEqual(limit);
+}
+
+async function resolveSetHref(page: Page): Promise<string> {
+    await page.goto('/sets');
+    return (await page.locator('.table-row a').first().getAttribute('href'))!;
+}
+
+async function resolveCardHref(page: Page, setHref: string): Promise<string> {
+    await page.goto(setHref);
+    const cardLink = page.locator('#set-card-list-ajax a[href^="/card/"]').first();
+    await cardLink.waitFor();
+    return (await cardLink.getAttribute('href'))!;
+}
+
+test.describe('Responsive overflow guard (public)', () => {
+    for (const width of WIDTHS) {
+        test(`no horizontal overflow at ${width}px across public pages`, async ({ page }) => {
+            await page.setViewportSize({ width, height: HEIGHT });
+
+            const setHref = await resolveSetHref(page);
+            const cardHref = await resolveCardHref(page, setHref);
+
+            const pages: Array<{ url: string; label: string }> = [
+                { url: '/', label: 'home' },
+                { url: '/sets', label: 'sets' },
+                { url: setHref, label: 'set detail' },
+                { url: cardHref, label: 'card detail' },
+                { url: '/search?q=Angel', label: 'search' },
+                { url: '/pricing', label: 'pricing' },
+            ];
+
+            for (const { url, label } of pages) {
+                await page.goto(url);
+                await page.locator('main, body').first().waitFor();
+                await assertNoHorizontalOverflow(page, `${label} @ ${width}px`);
+            }
+        });
+    }
+});
+
+authTest.describe('Responsive overflow guard (authenticated)', () => {
+    for (const width of WIDTHS) {
+        authTest(
+            `no horizontal overflow at ${width}px across authenticated pages`,
+            async ({ authedPage: page }) => {
+                await page.setViewportSize({ width, height: HEIGHT });
+
+                const pages: Array<{ url: string; label: string }> = [
+                    { url: '/inventory', label: 'inventory' },
+                    { url: '/billing', label: 'billing' },
+                ];
+
+                for (const { url, label } of pages) {
+                    await page.goto(url);
+                    await page.locator('main, body').first().waitFor();
+                    await assertNoHorizontalOverflow(page, `${label} @ ${width}px`);
+                }
+            }
+        );
+    }
+});

--- a/test/http/api/card/card-api.presenter.spec.ts
+++ b/test/http/api/card/card-api.presenter.spec.ts
@@ -1,7 +1,6 @@
 import { TCGPLAYER_PRODUCT_URL_TEMPLATE } from 'src/core/affiliate/affiliate-link.policy';
 import { Card } from 'src/core/card/card.entity';
 import { CardRarity } from 'src/core/card/card.rarity.enum';
-import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { Price } from 'src/core/card/price.entity';
 import { Set } from 'src/core/set/set.entity';
 import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
@@ -57,42 +56,6 @@ describe('CardApiPresenter', () => {
                 normalChangeWeekly: 0.25,
                 foilChangeWeekly: -0.1,
             });
-        });
-
-        it('maps the best buylist offer and calls out a non-normal finish', () => {
-            const card = createCard();
-            const foilBest = new GranularPrice({
-                cardId: 'card-1',
-                provider: 'cardkingdom',
-                priceType: 'buylist',
-                finish: 'foil',
-                condition: 'NM',
-                price: 7,
-            });
-            const result = CardApiPresenter.toCardApiResponse(card, foilBest);
-
-            expect(result.bestBuylist).toBe(7);
-            expect(result.bestBuylistFinish).toBe('foil');
-        });
-
-        it('omits the finish callout when the best offer is normal, and nulls when absent', () => {
-            const card = createCard();
-            const normalBest = new GranularPrice({
-                cardId: 'card-1',
-                provider: 'cardkingdom',
-                priceType: 'buylist',
-                finish: 'normal',
-                condition: 'NM',
-                price: 2.5,
-            });
-
-            const withOffer = CardApiPresenter.toCardApiResponse(card, normalBest);
-            expect(withOffer.bestBuylist).toBe(2.5);
-            expect(withOffer.bestBuylistFinish).toBeNull();
-
-            const none = CardApiPresenter.toCardApiResponse(card);
-            expect(none.bestBuylist).toBeNull();
-            expect(none.bestBuylistFinish).toBeNull();
         });
 
         it('should return undefined prices when card has no prices', () => {

--- a/test/integration/api-sets.e2e-spec.ts
+++ b/test/integration/api-sets.e2e-spec.ts
@@ -119,18 +119,6 @@ describe('Sets API (e2e)', () => {
             expect(typeof card.keyruneCode).toBe('string');
         });
 
-        it('returns the best NM buylist offer per card (6.3)', async () => {
-            const res = await request(app.getHttpServer())
-                .get(`/api/v1/sets/${TEST_SET_CODE}/cards`)
-                .expect(200);
-
-            // Seed card 1 has CK normal 3.50 / Cardsphere normal 3.25 / CK foil 7.00,
-            // so the best offer is the foil one and the finish is called out.
-            const card = res.body.data.find((c) => c.number === '1');
-            expect(card.bestBuylist).toBe(7);
-            expect(card.bestBuylistFinish).toBe('foil');
-        });
-
         it('supports filter parameter', async () => {
             const res = await request(app.getHttpServer())
                 .get(`/api/v1/sets/${TEST_SET_CODE}/cards?filter=Angel`)


### PR DESCRIPTION
Bumps **1.32.0 → 1.32.1** (assetVersion + service-worker cache-bust, so returning users get the new CSS/JS).

## ⚠️ Contains a production hotfix
`migrations/035_fix_granular_price_pkeys.sql` adds the missing primary keys to `granular_price` / `granular_price_history`. Production's tables were created during the 6.x spike **without** their PKs; migration 034's `CREATE TABLE IF NOT EXISTS` is inert once the tables exist, so it never added them. scry's daily `ON CONFLICT` ingest has been failing (*"no unique or exclusion constraint matching the ON CONFLICT specification"*), aborting the whole price refresh and leaving prices stale site-wide. The migration is idempotent + de-dupes; verified by reproducing the exact error locally, applying it, and confirming the UPSERT then succeeds.

To unblock prod **before** this merges, apply it directly: `psql "$DATABASE_URL" -f migrations/035_fix_granular_price_pkeys.sql`.

Paired with scry PR matthewdtowles/scry#16 (best-effort granular writes so a granular failure can never again stall the price refresh). Independent of this PR; safe in any order.

## A — Buylist trimmed to the card page
Removed the set-list "sell $X" rows and binder "Buylist $X" overlay (clutter + mobile overflow). Kept `findCurrentBuylistForCards` / `bestBuylistOffer` (batched read) for 6.4 inventory best-buylist.

## B — Buy/Sell visual parity
Card-page Sell offers now render as emerald `.price-tile`s paralleling the retail Buy grid; "compare vendors" stays nested per tile.

## C — App-wide responsive hardening + regression gate
- Base-layer CSS contract (`min-width:0` on flex/grid children, `max-width` on replaced elements, `overflow-wrap`).
- `.cluster` / `.badge-pill` utilities; applied to the set toolbar + card legality statuses; `.tag` made `inline-block`/nowrap.
- New Playwright overflow guard (`test/e2e/responsive-overflow.e2e.ts`) asserting no horizontal scroll at 320/375px across key pages. It caught — and this PR fixes — a real navbar overflow where the container-query hiding Sign In/Sign Up on mobile was source-order-shadowed by the base `display` rules (`app.css`).

## D — Docs
ROADMAP 6.3.1 block + 6.3 scope correction; `phase6-buylist-handoff.md`; plan doc marked implemented; CLAUDE.md core-tables list now includes the granular tables.

## Verification
TypeScript clean · unit 1187 · frontend 97 · integration 230 · Playwright 30 (incl. 4 new guards) · migration 035 reproduced+fixed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)