### PR TITLE
fix(http): stop CacheControlInterceptor clobbering explicit Cache-Control + verify releases

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -113,4 +113,8 @@ ssh -o StrictHostKeyChecking=no -i private_key ubuntu@$LIGHTSAIL_IP \
 log_info "Cleaning up..."
 rm -f private_key
 
+# Verify the released version is actually being served before declaring success
+log_info "Verifying released version is live at $APP_URL..."
+./.github/scripts/verify-release.sh
+
 log_info "Deployment completed successfully!"

--- a/.github/scripts/verify-release.sh
+++ b/.github/scripts/verify-release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Post-deploy release verification.
+#
+# Asserts the live site actually serves the version that was just released:
+#   1. The app responds (with retries while the container finishes starting).
+#   2. Rendered HTML references assets at ?v=<released version>.
+#   3. The versioned stylesheet at that URL is served and non-trivial.
+#   4. The service worker is stamped with the released version.
+#
+# A green deploy job then means "the release is verifiably live", not just
+# "the scripts ran". Usable locally too:
+#   APP_URL=https://iwantmymtg.net ./.github/scripts/verify-release.sh [version]
+set -euo pipefail
+
+APP_URL="${APP_URL:?APP_URL is required}"
+EXPECTED_VERSION="${1:-$(jq -r .version package.json)}"
+
+fail() {
+    echo "[VERIFY] FAIL: $1" >&2
+    exit 1
+}
+
+pass() {
+    echo "[VERIFY] OK: $1"
+}
+
+echo "[VERIFY] Verifying $APP_URL serves version $EXPECTED_VERSION..."
+
+# 1. Wait for the app to respond after the container swap.
+for i in $(seq 1 12); do
+    if curl -fsS -o /dev/null --max-time 10 "$APP_URL/"; then
+        break
+    fi
+    [ "$i" -eq 12 ] && fail "app did not respond at $APP_URL within 60s"
+    sleep 5
+done
+pass "app is responding"
+
+# 2. Rendered HTML must reference assets at the released version.
+html=$(curl -fsS --max-time 10 "$APP_URL/")
+echo "$html" | grep -q "?v=$EXPECTED_VERSION" \
+    || fail "HTML does not reference assets at ?v=$EXPECTED_VERSION (found: $(echo "$html" | grep -oE '\?v=[0-9a-zA-Z.\-]+' | sort -u | tr '\n' ' '))"
+pass "HTML references ?v=$EXPECTED_VERSION"
+
+# 3. The versioned stylesheet must be served and non-trivial.
+css_bytes=$(curl -fsS --max-time 10 "$APP_URL/public/css/tailwind.css?v=$EXPECTED_VERSION" | wc -c)
+[ "$css_bytes" -gt 1024 ] || fail "tailwind.css?v=$EXPECTED_VERSION is missing or suspiciously small ($css_bytes bytes)"
+pass "tailwind.css?v=$EXPECTED_VERSION served ($css_bytes bytes)"
+
+# 4. The service worker must be stamped with the released version. A unique
+# query param bypasses any CDN-cached copy so we verify origin truth.
+sw=$(curl -fsS --max-time 10 "$APP_URL/sw.js?verify=$(date +%s)")
+echo "$sw" | grep -q "APP_VERSION = '$EXPECTED_VERSION'" \
+    || fail "sw.js is not stamped with $EXPECTED_VERSION (found: $(echo "$sw" | grep -m1 "APP_VERSION = " || echo 'no APP_VERSION line'))"
+pass "sw.js stamped with $EXPECTED_VERSION"
+
+echo "[VERIFY] Release $EXPECTED_VERSION is live and correct."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,8 +76,37 @@ jobs:
                   NODE_ENV: test
               run: npx jest --config test/jest-e2e.json --runInBand
 
+    e2e-test:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
+            - name: Run Playwright E2E tests
+              run: npm run test:pw:full
+
+            - name: Upload Playwright report
+              if: failure()
+              uses: actions/upload-artifact@v6
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 7
+
     tag:
-        needs: [test, integration-test]
+        needs: [test, integration-test, e2e-test]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:
@@ -106,7 +135,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     build:
-        needs: [test, integration-test]
+        needs: [test, integration-test, e2e-test]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:

--- a/src/http/api/shared/cache-control.interceptor.ts
+++ b/src/http/api/shared/cache-control.interceptor.ts
@@ -21,6 +21,10 @@ export const CacheTTL = (seconds: number) => SetMetadata(CACHE_TTL_KEY, seconds)
  * - Authenticated endpoints (cookie/bearer): no-store
  * - Public GET endpoints: short TTL with stale-while-revalidate
  * - Non-GET requests: no-store
+ *
+ * Registered as a global interceptor, so it runs after every route handler.
+ * Handlers that set Cache-Control explicitly (e.g. @Header on /sw.js) win;
+ * this interceptor only fills in the header when none was set.
  */
 @Injectable()
 export class CacheControlInterceptor implements NestInterceptor {
@@ -35,7 +39,7 @@ export class CacheControlInterceptor implements NestInterceptor {
                 const req = context.switchToHttp().getRequest();
                 const res = context.switchToHttp().getResponse();
 
-                if (res.headersSent) {
+                if (res.headersSent || res.getHeader('Cache-Control')) {
                     return;
                 }
 

--- a/test/http/api/shared/cache-control.interceptor.spec.ts
+++ b/test/http/api/shared/cache-control.interceptor.spec.ts
@@ -3,7 +3,9 @@ import { Reflector } from '@nestjs/core';
 import { of } from 'rxjs';
 import { CacheControlInterceptor } from 'src/http/api/shared/cache-control.interceptor';
 
-function createMockContext(overrides: { method?: string; user?: { id: number } } = {}): {
+function createMockContext(
+    overrides: { method?: string; user?: { id: number }; existingCacheControl?: string } = {}
+): {
     context: ExecutionContext;
     setHeader: jest.Mock;
 } {
@@ -12,7 +14,11 @@ function createMockContext(overrides: { method?: string; user?: { id: number } }
         method: overrides.method ?? 'GET',
         user: overrides.user ?? undefined,
     };
-    const res = { setHeader };
+    const res = {
+        setHeader,
+        getHeader: (name: string) =>
+            name.toLowerCase() === 'cache-control' ? overrides.existingCacheControl : undefined,
+    };
     const context = {
         switchToHttp: () => ({ getRequest: () => req, getResponse: () => res }),
         getHandler: () => ({}),
@@ -80,6 +86,25 @@ describe('CacheControlInterceptor', () => {
                 'Cache-Control',
                 expect.stringContaining('max-age=120')
             );
+            done();
+        });
+    });
+
+    it('should not overwrite a Cache-Control header the route handler already set', (done) => {
+        const { context, setHeader } = createMockContext({ existingCacheControl: 'no-cache' });
+        interceptor.intercept(context, createNext()).subscribe(() => {
+            expect(setHeader).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    it('should not overwrite an explicit Cache-Control header on non-GET requests', (done) => {
+        const { context, setHeader } = createMockContext({
+            method: 'POST',
+            existingCacheControl: 'no-cache',
+        });
+        interceptor.intercept(context, createNext()).subscribe(() => {
+            expect(setHeader).not.toHaveBeenCalled();
             done();
         });
     });


### PR DESCRIPTION
## Background

Investigation of "the latest release didn't apply our CSS changes in prod": the 6.3.1 release **did** land correctly (verified at every layer — container artifact, origin, CDN cache-keying, rendered pages at mobile widths). What the report surfaced was a real header bug plus two verification gaps that make short post-deploy staleness windows possible and invisible.

## The bug

`CacheControlInterceptor` is registered as a global `APP_INTERCEPTOR`, and its `res.setHeader` runs after every route handler — overwriting headers set via `@Header` (Nest applies those *before* the interceptor chain). Observed on prod:

- `/sw.js`: intended `no-cache`, actually served `public, max-age=60, stale-while-revalidate=300` — and CloudFront cached it (`x-cache: Hit`), delaying service-worker updates after a deploy.
- `/favicon.ico`: intended 7 days, clobbered to 60s.

**Fix:** the interceptor now skips responses that already have a `Cache-Control` header, so explicit `@Header` decorators win and the interceptor only fills in defaults. Verified on a rebuilt dev container: `/sw.js` → `no-cache`, favicon → 7d, pages/API without explicit headers keep the 60s+SWR default.

## Release verification (longevity)

1. **`verify-release.sh`** — runs at the end of `deploy.sh`; asserts the live site serves HTML referencing `?v=<released version>`, the versioned stylesheet, and a version-stamped service worker. Validated against prod (passes for 1.32.1, fails with a clear message for a wrong version). A green deploy now means *the release is verifiably live*, not just "the scripts ran".
2. **`e2e-test` CI job** — runs the Playwright suite (including the 6.3.1 `responsive-overflow` gate, which previously never ran in CI) and gates `tag`/`build`/`deploy`. Full suite passes locally (30/30).

## Tests

- 2 new unit tests (TDD — written first, failed, then fixed): explicit `Cache-Control` is preserved for GET and non-GET.
- Full unit suite: 1189/1189. Playwright: 30/30. Lint + Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)