### PR TITLE
feat: 6.7 card.scryfall_id + granular qty; PR-title versioning; release verification

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -113,4 +113,8 @@ ssh -o StrictHostKeyChecking=no -i private_key ubuntu@$LIGHTSAIL_IP \
 log_info "Cleaning up..."
 rm -f private_key
 
+# Verify the released version is actually being served before declaring success
+log_info "Verifying released version is live at $APP_URL..."
+./.github/scripts/verify-release.sh
+
 log_info "Deployment completed successfully!"

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -22,6 +22,7 @@ log_error() {
 
 # Validate required environment variables
 required_vars=(
+    "RELEASE_VERSION"
     "SSH_PRIVATE_KEY"
     "LIGHTSAIL_IP"
     "GITHUB_TOKEN"
@@ -114,7 +115,7 @@ log_info "Cleaning up..."
 rm -f private_key
 
 # Verify the released version is actually being served before declaring success
-log_info "Verifying released version is live at $APP_URL..."
-./.github/scripts/verify-release.sh
+log_info "Verifying released version $RELEASE_VERSION is live at $APP_URL..."
+./.github/scripts/verify-release.sh "$RELEASE_VERSION"
 
 log_info "Deployment completed successfully!"

--- a/.github/scripts/next-version.sh
+++ b/.github/scripts/next-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Compute the next release version from git tags and the head commit subject.
+#
+# Replaces manual `npm run bump`: with squash merges the head commit subject
+# on main is the PR title, so the PR title decides the bump:
+#   feat: / feat(scope):            -> minor
+#   anything else (fix:, docs:, ..) -> patch
+#   ! before the colon (feat!:) or at the end of the title -> major
+#
+# The current version is the highest existing semver git tag — package.json
+# stays at its 0.0.0-dev placeholder and is stamped at Docker build time.
+#
+# Idempotent: if HEAD is already tagged (e.g. a workflow re-run after the tag
+# job), that tag is reused instead of bumping again.
+#
+# Prints "version=X.Y.Z" (suitable for $GITHUB_OUTPUT).
+set -euo pipefail
+
+semver='^[0-9]+\.[0-9]+\.[0-9]+$'
+
+existing=$(git tag --points-at HEAD | grep -E "$semver" | head -1 || true)
+if [ -n "$existing" ]; then
+    echo "version=$existing"
+    exit 0
+fi
+
+last=$(git tag --list --sort=-v:refname | grep -E "$semver" | head -1 || true)
+last=${last:-0.0.0}
+IFS=. read -r major minor patch <<< "$last"
+
+subject=$(git log -1 --format=%s)
+subject=${subject% (#*)} # strip the " (#123)" suffix GitHub appends on squash merge
+
+major_re='^[a-zA-Z]+(\([^)]*\))?!:'
+minor_re='^feat(\([^)]*\))?:'
+if [[ "$subject" =~ $major_re ]] || [[ "$subject" == *! ]]; then
+    version="$((major + 1)).0.0"
+elif [[ "$subject" =~ $minor_re ]]; then
+    version="$major.$((minor + 1)).0"
+else
+    version="$major.$minor.$((patch + 1))"
+fi
+
+echo "version=$version"

--- a/.github/scripts/verify-release.sh
+++ b/.github/scripts/verify-release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Post-deploy release verification.
+#
+# Asserts the live site actually serves the version that was just released:
+#   1. The app responds (with retries while the container finishes starting).
+#   2. Rendered HTML references assets at ?v=<released version>.
+#   3. The versioned stylesheet at that URL is served and non-trivial.
+#   4. The service worker is stamped with the released version.
+#
+# A green deploy job then means "the release is verifiably live", not just
+# "the scripts ran". Usable locally too:
+#   APP_URL=https://iwantmymtg.net ./.github/scripts/verify-release.sh [version]
+set -euo pipefail
+
+APP_URL="${APP_URL:?APP_URL is required}"
+EXPECTED_VERSION="${1:-$(jq -r .version package.json)}"
+
+fail() {
+    echo "[VERIFY] FAIL: $1" >&2
+    exit 1
+}
+
+pass() {
+    echo "[VERIFY] OK: $1"
+}
+
+echo "[VERIFY] Verifying $APP_URL serves version $EXPECTED_VERSION..."
+
+# 1. Wait for the app to respond after the container swap.
+for i in $(seq 1 12); do
+    if curl -fsS -o /dev/null --max-time 10 "$APP_URL/"; then
+        break
+    fi
+    [ "$i" -eq 12 ] && fail "app did not respond at $APP_URL within 60s"
+    sleep 5
+done
+pass "app is responding"
+
+# 2. Rendered HTML must reference assets at the released version.
+html=$(curl -fsS --max-time 10 "$APP_URL/")
+echo "$html" | grep -q "?v=$EXPECTED_VERSION" \
+    || fail "HTML does not reference assets at ?v=$EXPECTED_VERSION (found: $(echo "$html" | grep -oE '\?v=[0-9a-zA-Z.\-]+' | sort -u | tr '\n' ' '))"
+pass "HTML references ?v=$EXPECTED_VERSION"
+
+# 3. The versioned stylesheet must be served and non-trivial.
+css_bytes=$(curl -fsS --max-time 10 "$APP_URL/public/css/tailwind.css?v=$EXPECTED_VERSION" | wc -c)
+[ "$css_bytes" -gt 1024 ] || fail "tailwind.css?v=$EXPECTED_VERSION is missing or suspiciously small ($css_bytes bytes)"
+pass "tailwind.css?v=$EXPECTED_VERSION served ($css_bytes bytes)"
+
+# 4. The service worker must be stamped with the released version. A unique
+# query param bypasses any CDN-cached copy so we verify origin truth.
+sw=$(curl -fsS --max-time 10 "$APP_URL/sw.js?verify=$(date +%s)")
+echo "$sw" | grep -q "APP_VERSION = '$EXPECTED_VERSION'" \
+    || fail "sw.js is not stamped with $EXPECTED_VERSION (found: $(echo "$sw" | grep -m1 "APP_VERSION = " || echo 'no APP_VERSION line'))"
+pass "sw.js stamped with $EXPECTED_VERSION"
+
+echo "[VERIFY] Release $EXPECTED_VERSION is live and correct."

--- a/.github/scripts/verify-release.sh
+++ b/.github/scripts/verify-release.sh
@@ -9,11 +9,14 @@
 #
 # A green deploy job then means "the release is verifiably live", not just
 # "the scripts ran". Usable locally too:
-#   APP_URL=https://iwantmymtg.net ./.github/scripts/verify-release.sh [version]
+#   APP_URL=https://iwantmymtg.net ./.github/scripts/verify-release.sh <version>
+#
+# The version must be passed explicitly — package.json holds a 0.0.0-dev
+# placeholder; the real version is computed in CI (see next-version.sh).
 set -euo pipefail
 
 APP_URL="${APP_URL:?APP_URL is required}"
-EXPECTED_VERSION="${1:-$(jq -r .version package.json)}"
+EXPECTED_VERSION="${1:?version argument is required (e.g. 1.33.0)}"
 
 fail() {
     echo "[VERIFY] FAIL: $1" >&2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,8 +76,37 @@ jobs:
                   NODE_ENV: test
               run: npx jest --config test/jest-e2e.json --runInBand
 
+    e2e-test:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 22
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
+            - name: Run Playwright E2E tests
+              run: npm run test:pw:full
+
+            - name: Upload Playwright report
+              if: failure()
+              uses: actions/upload-artifact@v6
+              with:
+                  name: playwright-report
+                  path: playwright-report/
+                  retention-days: 7
+
     tag:
-        needs: [test, integration-test]
+        needs: [test, integration-test, e2e-test]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:
@@ -106,7 +135,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     build:
-        needs: [test, integration-test]
+        needs: [test, integration-test, e2e-test]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,8 +105,27 @@ jobs:
                   path: playwright-report/
                   retention-days: 7
 
-    tag:
+    # Version is computed from the squash-merged PR title (= head commit
+    # subject): feat -> minor, ! -> major, anything else -> patch. Git tags
+    # are the source of truth; package.json stays at its 0.0.0-dev placeholder.
+    version:
         needs: [test, integration-test, e2e-test]
+        runs-on: ubuntu-latest
+        if: github.ref == 'refs/heads/main'
+        outputs:
+            version: ${{ steps.next.outputs.version }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+
+            - name: Compute next version from PR title
+              id: next
+              run: ./.github/scripts/next-version.sh >> "$GITHUB_OUTPUT"
+
+    tag:
+        needs: [version]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:
@@ -115,14 +134,10 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
-            - name: Get version from package.json
-              id: version
-              run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
-
             - name: Check if tag exists
               id: check
               run: |
-                  if git ls-remote --tags origin "${{ steps.version.outputs.version }}" | grep -q .; then
+                  if git ls-remote --tags origin "${{ needs.version.outputs.version }}" | grep -q .; then
                     echo "exists=true" >> "$GITHUB_OUTPUT"
                   else
                     echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -130,12 +145,12 @@ jobs:
 
             - name: Create release
               if: steps.check.outputs.exists == 'false'
-              run: gh release create "${{ steps.version.outputs.version }}" --generate-notes --title "${{ steps.version.outputs.version }}"
+              run: gh release create "${{ needs.version.outputs.version }}" --generate-notes --title "${{ needs.version.outputs.version }}"
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     build:
-        needs: [test, integration-test, e2e-test]
+        needs: [version]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         permissions:
@@ -176,10 +191,12 @@ jobs:
                   target: production
                   push: true
                   provenance: false
+                  build-args: |
+                      APP_VERSION=${{ needs.version.outputs.version }}
                   tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/web:latest,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/web:${{ github.sha }}
 
     deploy:
-        needs: build
+        needs: [version, build]
         runs-on: ubuntu-latest
         if: github.ref == 'refs/heads/main'
         environment: production
@@ -193,6 +210,7 @@ jobs:
 
             - name: Deploy to Production
               env:
+                  RELEASE_VERSION: ${{ needs.version.outputs.version }}
                   SSH_PRIVATE_KEY: ${{ secrets.LIGHTSAIL_SSH_PK }}
                   LIGHTSAIL_IP: ${{ secrets.LIGHTSAIL_IP }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,16 +59,17 @@ npm run start:dev                 # Watch mode (builds SW + nest watch)
 ## Production
 
 CI/CD is handled by GitHub Actions (`.github/workflows/deploy.yml`). On push to main:
-1. **test** — Runs unit and integration tests
-2. **tag** — Creates a GitHub release from `package.json` version
-3. **build** — Builds Docker image using the `production` target and pushes to `ghcr.io`
-4. **deploy** — SSH deploy to Lightsail via `.github/scripts/deploy.sh`
+1. **test / integration-test / e2e-test** — Unit, integration, and Playwright E2E tests
+2. **version** — Computes the release version from the squash-merged PR title (`.github/scripts/next-version.sh`)
+3. **tag** — Creates a GitHub release/tag for the computed version
+4. **build** — Builds Docker image using the `production` target (stamped with `APP_VERSION`) and pushes to `ghcr.io`
+5. **deploy** — SSH deploy to Lightsail via `.github/scripts/deploy.sh`, then `verify-release.sh` asserts the live site serves the released version
 
 The production Docker build (`target: production`) runs `npm run build:prod` which produces the final `dist/` directory with compiled TS, minified assets, and versioned service worker. The production stage copies only `dist/` and production dependencies.
 
 ### Service Worker & Cache Busting
 
-The service worker (`src/http/public/sw.js`) uses a `__APP_VERSION__` placeholder that `build:sw` replaces with the version from `package.json`. When the version changes, the new SW activates and purges old caches. To bump the version: `npm run bump` (patch), `bump:minor`, or `bump:major`.
+The service worker (`src/http/public/sw.js`) uses a `__APP_VERSION__` placeholder that `build:sw` replaces with the version from `package.json`. When the version changes, the new SW activates and purges old caches. Versioning is automatic: CI computes the version from the squash-merged PR title (`feat:` → minor, `!` → major, anything else → patch — see `.github/scripts/next-version.sh`) and stamps it into the Docker image at build time. `package.json` stays at the `0.0.0-dev` placeholder; never bump it by hand.
 
 ### Scry ETL on the Production Server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,22 @@ COPY . .
 CMD ["npm", "run", "start:dev"]
 
 # Build stage
+# APP_VERSION is supplied by CI (computed from the PR title — see
+# .github/scripts/next-version.sh); package.json in git is a 0.0.0-dev
+# placeholder. Stamping happens after npm ci so dependency layers stay cached.
 FROM dependencies AS build
 RUN apk add --no-cache bash perl
 COPY . .
+ARG APP_VERSION
+RUN [ -z "$APP_VERSION" ] || npm version "$APP_VERSION" --no-git-tag-version
 RUN npm run build:prod
 
 # Production stage
 FROM base AS production
 COPY package*.json ./
 RUN npm ci --omit=dev
+ARG APP_VERSION
+RUN [ -z "$APP_VERSION" ] || npm version "$APP_VERSION" --no-git-tag-version
 COPY --from=build /app/dist ./dist
 EXPOSE 3000
 CMD ["npm", "run", "start:prod"]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Versions are computed automatically in CI from the squash-merged PR title — no
 | PR title | Bump |
 | --- | --- |
 | `feat: ...` / `feat(scope): ...` | minor |
-| `feat!: ...` or title ending in `!` | major |
+| any type with `!` (`feat!:`, `fix!:`, ...) or title ending in `!` | major |
 | anything else (`fix:`, `docs:`, ...) | patch |
 
 See `.github/scripts/next-version.sh`.

--- a/README.md
+++ b/README.md
@@ -101,14 +101,15 @@ Reports land in `lighthouse-reports/<timestamp>/{mobile,desktop}/`. Requires Chr
 
 ## Versioning
 
-Conventional Commits for messages, manual bumps via npm scripts — include the bump in your PR commit.
+Versions are computed automatically in CI from the squash-merged PR title — no manual bumping. Git tags are the source of truth; `package.json` stays at the `0.0.0-dev` placeholder and is stamped at Docker build time.
 
-```bash
-npm run bump          # Patch: 1.0.0 → 1.0.1
-npm run bump:minor    # Minor: 1.0.0 → 1.1.0
-npm run bump:major    # Major: 1.0.0 → 2.0.0
-npm run bump:dev      # Pre-release: 1.0.0 → 1.0.1-rc.0
-```
+| PR title | Bump |
+| --- | --- |
+| `feat: ...` / `feat(scope): ...` | minor |
+| `feat!: ...` or title ending in `!` | major |
+| anything else (`fix:`, `docs:`, ...) | patch |
+
+See `.github/scripts/next-version.sh`.
 
 ## Troubleshooting
 

--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -108,7 +108,8 @@ CREATE TABLE public.card (
     set_code character varying NOT NULL,
     type character varying NOT NULL,
     tcgplayer_product_id character varying,
-    tcgplayer_etched_product_id character varying
+    tcgplayer_etched_product_id character varying,
+    scryfall_id character varying
 );
 
 
@@ -201,7 +202,8 @@ CREATE TABLE public.granular_price (
     finish character varying NOT NULL,
     condition character varying DEFAULT 'NM'::character varying NOT NULL,
     date date NOT NULL,
-    price numeric NOT NULL
+    price numeric NOT NULL,
+    qty integer
 );
 
 
@@ -217,7 +219,8 @@ CREATE TABLE public.granular_price_history (
     finish character varying NOT NULL,
     condition character varying DEFAULT 'NM'::character varying NOT NULL,
     date date NOT NULL,
-    price numeric NOT NULL
+    price numeric NOT NULL,
+    qty integer
 );
 
 
@@ -603,6 +606,13 @@ CREATE INDEX idx_password_reset_token ON public.password_reset(reset_token);
 --
 
 CREATE INDEX idx_password_reset_expires ON public.password_reset(expires_at);
+
+
+--
+-- Name: idx_card_scryfall_id; Type: INDEX; Schema: public
+--
+
+CREATE UNIQUE INDEX idx_card_scryfall_id ON public.card (scryfall_id);
 
 
 --

--- a/docs/phase6-buylist-handoff.md
+++ b/docs/phase6-buylist-handoff.md
@@ -8,10 +8,12 @@ the best offer per card, and (later) helps users decide who to sell to in bulk.
 Recommendation adopted by the 6.1 spike: **Tier A + Tier B** (both free).
 
 The work spans two repos that share one Postgres DB:
-- **web** (`i-want-my-mtg`, this repo) — branch `spike/6.1-buylist-price-data`
-- **scry** (`/Users/matthewtowles/Projects/scry`, Rust ETL) — branch `feat/scry-14-granular-tier-a`
+- **web** (`i-want-my-mtg`, this repo)
+- **scry** (`/Users/matthewtowles/Projects/scry`, Rust ETL)
 
-Neither branch is merged/deployed yet, so nothing is live in production.
+6.2/6.3 (granular store + card-page display, Tier A) are merged and live.
+6.7 (Tier B, CK-direct) is built on branches `feat/6.7-scryfall-id-granular-qty`
+(web) and `feat/scry-14-tier-b-ck-direct` (scry) — scope on issue #513.
 
 ---
 
@@ -87,7 +89,7 @@ Tests across the scry branch: **106 unit + 7 price integration tests (real PG18)
 
 ---
 
-## Open decision — Tier B card matching (BLOCKS Tier B)
+## ~~Open decision~~ RESOLVED (6.7) — Tier B card matching
 
 Tier B = ingest the **Card Kingdom direct pricelist** for live buylist `qty` + condition.
 The CK feed is confirmed (fetched live): `https://api.cardkingdom.com/api/v2/pricelist`,
@@ -107,8 +109,8 @@ Buylist data we want: `price_buy` + `qty_buying` (+ `is_foil` → finish; condit
 and have **no `scryfall_id` column**. So CK rows can't be matched to our cards directly. (Tier A
 needed no matching because MTGJSON prices share the MTGJSON uuid.)
 
-**Recommendation (pending final confirmation): add `scryfall_id` as a unique indexed column —
-NOT as the primary key.** Reasoning:
+**Decision (implemented in web migration `036` — note: NOT 035, which the granular-PK
+hotfix took): `scryfall_id` is a unique indexed column — NOT the primary key.** Reasoning:
 - Keep `card.id` = MTGJSON uuid as PK: it's what user data (`inventory`, `transaction`), all
   prices, every FK, and the public API already reference. Re-keying = huge, risky migration over
   user data, and would *invert* the matching problem onto MTGJSON (our high-volume daily source).
@@ -125,22 +127,38 @@ Rejected: making scryfall_id the PK (blast radius over user data + API; inverts 
 
 ---
 
-## Remaining work
+## Tier B — BUILT (6.7, 2026-06-10)
 
-### Tier B (once matching approach is confirmed)
-1. **Web**: migration `035` add `card.scryfall_id` (unique index) + init schema.
-2. **scry**: store `scryfall_id` in card ingest (mapper already parses it for `img_src`);
-   one-time backfill from `img_src`; add `scryfall_id` to `tests/fixtures/schema.sql`.
-3. **scry**: stream the CK pricelist (new `HttpClient` method + event processor or chunked
-   serde), build a `scryfall_id → card.id` map, emit `granular_price` buylist rows
-   (`provider='cardkingdom'`, `price_type='buylist'`, finish from `is_foil`, condition `NM`,
-   `price=price_buy`). **Ingest order: MTGJSON first, then CK-direct**, so the
-   CK-direct row overwrites the indicative MTGJSON CK row on the shared key (last-writer-wins is
-   already implemented in `save_granular_prices`). Wire into the ingest pipeline.
-   - **Re-add `qty`** here (the column was dropped in 6.2): add `qty` to both granular tables
-     (migration `035` + init + `tests/fixtures/schema.sql`), the scry `GranularPrice` struct, and
-     the upsert column list, carrying `qty_buying`. Decide its modelling against the
-     across-vendor inconsistency noted in the locked decisions before wiring it in.
+As-built (full scope + decision log on issue #513):
+1. **Web** (branch `feat/6.7-scryfall-id-granular-qty`): migration `036` — `card.scryfall_id`
+   (varchar, nullable, **unique index**, SQL backfill from `img_src` shape-guarded to
+   `{a}/{b}/{uuid}.jpg`; verified 1:1 across all 91,316 cards) + nullable `qty integer` on both
+   granular tables; init-schema parity; ORM entity columns only (no read-path changes);
+   integration spec `test/integration/migration-036.e2e-spec.ts` (9 tests).
+2. **scry** (branch `feat/scry-14-tier-b-ck-direct`):
+   - `Card.scryfall_id` persisted on ingest (Option<String>; mapper already required it).
+   - `src/price/cardkingdom.rs`: streaming `CkPricelistEventProcessor` (actson, same harness as
+     MTGJSON) + `granular_from_ck_products` policy fn. **Only real offers emit**:
+     `price_buy > 0 AND qty_buying > 0` — MTGJSON's buylist already encodes "CK is buying" by
+     row presence, so qty-0 products are skipped, not stored. `qty` carried on real offers
+     (kept for 6.4 quantity caps — user decision).
+   - **Per-series dedupe keeping the best offer** — real-feed finding: etched products report
+     `is_foil=true` and can share a `scryfall_id` with the regular foil, collapsing two CK
+     products onto one `(card, finish)` series; duplicate keys in one multi-row upsert are a
+     Postgres error ("cannot affect row a second time").
+   - `qty = EXCLUDED.qty` (last-writer-wins, NOT COALESCE): MTGJSON writes qty NULL, CK-direct
+     overwrites with live qty in the same run; if CK fails, qty reads NULL ("unknown") rather
+     than stale.
+   - Wired into `update_prices` AFTER the MTGJSON ingest (CK-direct overwrites the indicative
+     CK row); **best-effort** — failure is logged, never blocks the averaged price refresh,
+     surfaces via non-zero exit (same policy as the 5.12.1 hardening).
+3. **Deploy order**: publish scry first (inert), then deploy web — migration 036 runs before
+   `setup-cron.sh` extracts the new binary. One web deploy lands everything.
+4. **CK links deferred to 6.4** (user decision): sell tiles get clickable CK buylist-search
+   URLs (built from card name; CK supports `?partner=` attribution à la Archidekt) with the
+   inventory sell workflow.
+
+## Remaining work
 
 ### Follow-up — **directly after Tier B** (ROADMAP 6.8): normalize the card image
 Once 6.7 adds `card.scryfall_id`, `img_src` is redundant derived data (scry stores exactly

--- a/migrations/036_card_scryfall_id_and_granular_qty.sql
+++ b/migrations/036_card_scryfall_id_and_granular_qty.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+-- Phase 6.7 (Tier B): Card Kingdom direct pricelist ingest. CK identifies
+-- cards by scryfall_id; our cards are keyed by the MTGJSON uuid. Two additive
+-- changes:
+--
+-- 1) card.scryfall_id -- a unique indexed column, NOT the PK. card.id stays
+--    the MTGJSON uuid (it is what all prices, user inventory/transactions,
+--    every FK, and the public API reference). Backfilled from img_src, which
+--    scry builds as '{a}/{b}/{scryfall_id}.jpg' -- a total, reversible
+--    function of scryfall_id (verified 1:1 across all 91,316 cards). The
+--    backfill is shape-guarded so non-conforming img_src values (e.g. test
+--    seeds) stay NULL instead of polluting the unique index; NULLs are
+--    allowed and non-conflicting. scry persists scryfall_id directly for
+--    cards ingested after this.
+--
+-- 2) granular_price / granular_price_history gain a nullable qty column for
+--    CK's live buy quantity (qty_buying). MTGJSON granular rows carry no
+--    quantity; upserts are last-writer-wins (qty = EXCLUDED.qty), so qty is
+--    NULL ("unknown") unless the most recent writer provided it -- a stale
+--    quantity is worse than none for actionable offers.
+
+ALTER TABLE public.card ADD COLUMN IF NOT EXISTS scryfall_id character varying;
+
+UPDATE public.card
+SET scryfall_id = left(split_part(img_src, '/', 3), 36)
+WHERE scryfall_id IS NULL
+  AND img_src ~ '^[0-9a-f]/[0-9a-f]/[0-9a-f-]{36}\.jpg$';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_card_scryfall_id ON public.card (scryfall_id);
+
+ALTER TABLE public.granular_price ADD COLUMN IF NOT EXISTS qty integer;
+ALTER TABLE public.granular_price_history ADD COLUMN IF NOT EXISTS qty integer;
+
+COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.32.1",
+    "version": "0.0.0-dev",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "i-want-my-mtg",
-            "version": "1.32.1",
+            "version": "0.0.0-dev",
             "license": "UNLICENSED",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "i-want-my-mtg",
-    "version": "1.32.1",
+    "version": "0.0.0-dev",
     "description": "MTG Collection Tracker",
     "author": "Matthew Towles",
     "private": true,
@@ -44,11 +44,7 @@
         "gen:openapi-public": "./scripts/gen-openapi-public.sh",
         "etl": "./scripts/etl.sh",
         "lighthouse": "./scripts/lighthouse.sh",
-        "lighthouse:prod": "./scripts/lighthouse.sh --base-url=https://iwantmymtg.net",
-        "bump": "npm version patch --no-git-tag-version",
-        "bump:minor": "npm version minor --no-git-tag-version",
-        "bump:major": "npm version major --no-git-tag-version",
-        "bump:dev": "npm version prerelease --preid=rc --no-git-tag-version"
+        "lighthouse:prod": "./scripts/lighthouse.sh --base-url=https://iwantmymtg.net"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/database/card/card.orm-entity.ts
+++ b/src/database/card/card.orm-entity.ts
@@ -54,6 +54,9 @@ export class CardOrmEntity {
     @Column({ name: 'tcgplayer_etched_product_id', nullable: true })
     tcgplayerEtchedProductId?: string;
 
+    @Column({ name: 'scryfall_id', nullable: true })
+    scryfallId?: string;
+
     @OneToMany(() => PriceOrmEntity, (price) => price.card, { cascade: true })
     prices: PriceOrmEntity[];
 

--- a/src/database/granular-price/granular-price.orm-entity.ts
+++ b/src/database/granular-price/granular-price.orm-entity.ts
@@ -35,4 +35,7 @@ export class GranularPriceOrmEntity {
 
     @Column({ type: 'decimal' })
     price: number;
+
+    @Column({ type: 'int', nullable: true })
+    qty?: number;
 }

--- a/src/http/api/shared/cache-control.interceptor.ts
+++ b/src/http/api/shared/cache-control.interceptor.ts
@@ -21,6 +21,10 @@ export const CacheTTL = (seconds: number) => SetMetadata(CACHE_TTL_KEY, seconds)
  * - Authenticated endpoints (cookie/bearer): no-store
  * - Public GET endpoints: short TTL with stale-while-revalidate
  * - Non-GET requests: no-store
+ *
+ * Registered as a global interceptor, so it runs after every route handler.
+ * Handlers that set Cache-Control explicitly (e.g. @Header on /sw.js) win;
+ * this interceptor only fills in the header when none was set.
  */
 @Injectable()
 export class CacheControlInterceptor implements NestInterceptor {
@@ -35,7 +39,7 @@ export class CacheControlInterceptor implements NestInterceptor {
                 const req = context.switchToHttp().getRequest();
                 const res = context.switchToHttp().getResponse();
 
-                if (res.headersSent) {
+                if (res.headersSent || res.getHeader('Cache-Control')) {
                     return;
                 }
 

--- a/test/http/api/shared/cache-control.interceptor.spec.ts
+++ b/test/http/api/shared/cache-control.interceptor.spec.ts
@@ -3,7 +3,9 @@ import { Reflector } from '@nestjs/core';
 import { of } from 'rxjs';
 import { CacheControlInterceptor } from 'src/http/api/shared/cache-control.interceptor';
 
-function createMockContext(overrides: { method?: string; user?: { id: number } } = {}): {
+function createMockContext(
+    overrides: { method?: string; user?: { id: number }; existingCacheControl?: string } = {}
+): {
     context: ExecutionContext;
     setHeader: jest.Mock;
 } {
@@ -12,7 +14,11 @@ function createMockContext(overrides: { method?: string; user?: { id: number } }
         method: overrides.method ?? 'GET',
         user: overrides.user ?? undefined,
     };
-    const res = { setHeader };
+    const res = {
+        setHeader,
+        getHeader: (name: string) =>
+            name.toLowerCase() === 'cache-control' ? overrides.existingCacheControl : undefined,
+    };
     const context = {
         switchToHttp: () => ({ getRequest: () => req, getResponse: () => res }),
         getHandler: () => ({}),
@@ -80,6 +86,25 @@ describe('CacheControlInterceptor', () => {
                 'Cache-Control',
                 expect.stringContaining('max-age=120')
             );
+            done();
+        });
+    });
+
+    it('should not overwrite a Cache-Control header the route handler already set', (done) => {
+        const { context, setHeader } = createMockContext({ existingCacheControl: 'no-cache' });
+        interceptor.intercept(context, createNext()).subscribe(() => {
+            expect(setHeader).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    it('should not overwrite an explicit Cache-Control header on non-GET requests', (done) => {
+        const { context, setHeader } = createMockContext({
+            method: 'POST',
+            existingCacheControl: 'no-cache',
+        });
+        interceptor.intercept(context, createNext()).subscribe(() => {
+            expect(setHeader).not.toHaveBeenCalled();
             done();
         });
     });

--- a/test/integration/migration-036.e2e-spec.ts
+++ b/test/integration/migration-036.e2e-spec.ts
@@ -1,0 +1,162 @@
+import { INestApplication } from '@nestjs/common';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { DataSource } from 'typeorm';
+import { closeTestApp, createTestApp } from './setup';
+
+const MIGRATION_PATH = join(
+    process.cwd(),
+    'migrations',
+    '036_card_scryfall_id_and_granular_qty.sql'
+);
+
+// Realistic img_src shape ('{a}/{b}/{scryfall_id}.jpg', as scry builds it) vs
+// the non-conforming shape the seed data uses — the backfill must fill the
+// former and leave the latter NULL.
+const MIGRATION_CARD_ID = '00000000-0000-4000-b000-000000000001';
+const MIGRATION_CARD_SCRYFALL_ID = 'ab12cd34-5678-4abc-9def-1234567890ab';
+const MIGRATION_CARD_IMG_SRC = `a/b/${MIGRATION_CARD_SCRYFALL_ID}.jpg`;
+const JUNK_CARD_ID = '00000000-0000-4000-b000-000000000002';
+const JUNK_CARD_IMG_SRC = 'https://example.com/not-a-scryfall-path.jpg';
+
+describe('Migration 036: card.scryfall_id + granular qty (e2e)', () => {
+    let app: INestApplication;
+    let ds: DataSource;
+
+    const insertCard = (id: string, imgSrc: string, number: string) =>
+        ds.query(
+            `INSERT INTO card (id, has_foil, has_non_foil, img_src, is_reserved, name, number, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
+             VALUES ($1, true, true, $2, false, 'Migration Test Card', $3, 'common', 'tst', 'Creature', 'normal', false, $4, true)
+             ON CONFLICT (id) DO NOTHING`,
+            [id, imgSrc, number, number]
+        );
+
+    const deleteTestCards = () =>
+        ds.query('DELETE FROM card WHERE id IN ($1, $2)', [MIGRATION_CARD_ID, JUNK_CARD_ID]);
+
+    beforeAll(async () => {
+        app = await createTestApp();
+        ds = app.get(DataSource);
+        await deleteTestCards();
+    }, 30000);
+
+    afterAll(async () => {
+        try {
+            if (ds?.isInitialized) {
+                await deleteTestCards();
+            }
+        } catch {
+            // best-effort cleanup
+        }
+        await closeTestApp(app);
+    });
+
+    describe('schema (init parity + migration already applied by the harness)', () => {
+        it('card.scryfall_id exists as a nullable varchar column', async () => {
+            const rows = await ds.query(
+                `SELECT data_type, is_nullable FROM information_schema.columns
+                 WHERE table_schema = 'public' AND table_name = 'card' AND column_name = 'scryfall_id'`
+            );
+            expect(rows).toHaveLength(1);
+            expect(rows[0].data_type).toBe('character varying');
+            expect(rows[0].is_nullable).toBe('YES');
+        });
+
+        it('card.scryfall_id has a unique index', async () => {
+            const rows = await ds.query(
+                `SELECT indexdef FROM pg_indexes
+                 WHERE schemaname = 'public' AND tablename = 'card' AND indexname = 'idx_card_scryfall_id'`
+            );
+            expect(rows).toHaveLength(1);
+            expect(rows[0].indexdef).toContain('UNIQUE');
+            expect(rows[0].indexdef).toContain('scryfall_id');
+        });
+
+        it.each(['granular_price', 'granular_price_history'])(
+            '%s.qty exists as a nullable integer column',
+            async (table) => {
+                const rows = await ds.query(
+                    `SELECT data_type, is_nullable FROM information_schema.columns
+                     WHERE table_schema = 'public' AND table_name = $1 AND column_name = 'qty'`,
+                    [table]
+                );
+                expect(rows).toHaveLength(1);
+                expect(rows[0].data_type).toBe('integer');
+                expect(rows[0].is_nullable).toBe('YES');
+            }
+        );
+    });
+
+    describe('backfill (re-running the migration file against fresh rows)', () => {
+        const migrationSql = readFileSync(MIGRATION_PATH, 'utf8');
+
+        beforeEach(async () => {
+            await deleteTestCards();
+            await insertCard(MIGRATION_CARD_ID, MIGRATION_CARD_IMG_SRC, '901');
+            await insertCard(JUNK_CARD_ID, JUNK_CARD_IMG_SRC, '902');
+        });
+
+        it('fills scryfall_id from a conforming img_src and leaves non-conforming NULL', async () => {
+            await ds.query(migrationSql);
+
+            const rows = await ds.query(
+                'SELECT id, scryfall_id FROM card WHERE id IN ($1, $2) ORDER BY id',
+                [MIGRATION_CARD_ID, JUNK_CARD_ID]
+            );
+            expect(rows).toHaveLength(2);
+            expect(rows[0].scryfall_id).toBe(MIGRATION_CARD_SCRYFALL_ID);
+            expect(rows[1].scryfall_id).toBeNull();
+        });
+
+        it('is idempotent: running twice does not error or change values', async () => {
+            await ds.query(migrationSql);
+            await ds.query(migrationSql);
+
+            const rows = await ds.query('SELECT scryfall_id FROM card WHERE id = $1', [
+                MIGRATION_CARD_ID,
+            ]);
+            expect(rows[0].scryfall_id).toBe(MIGRATION_CARD_SCRYFALL_ID);
+        });
+
+        it('does not overwrite an already-set scryfall_id', async () => {
+            await ds.query(
+                `UPDATE card SET scryfall_id = 'preset-value-not-derived' WHERE id = $1`,
+                [MIGRATION_CARD_ID]
+            );
+
+            await ds.query(migrationSql);
+
+            const rows = await ds.query('SELECT scryfall_id FROM card WHERE id = $1', [
+                MIGRATION_CARD_ID,
+            ]);
+            expect(rows[0].scryfall_id).toBe('preset-value-not-derived');
+        });
+    });
+
+    describe('unique index semantics', () => {
+        beforeEach(async () => {
+            await deleteTestCards();
+            await insertCard(MIGRATION_CARD_ID, MIGRATION_CARD_IMG_SRC, '901');
+            await insertCard(JUNK_CARD_ID, JUNK_CARD_IMG_SRC, '902');
+        });
+
+        it('allows multiple NULL scryfall_ids (seed/junk cards coexist)', async () => {
+            const rows = await ds.query('SELECT count(*) AS n FROM card WHERE scryfall_id IS NULL');
+            expect(Number(rows[0].n)).toBeGreaterThanOrEqual(1);
+        });
+
+        it('rejects a duplicate scryfall_id', async () => {
+            await ds.query('UPDATE card SET scryfall_id = $1 WHERE id = $2', [
+                MIGRATION_CARD_SCRYFALL_ID,
+                MIGRATION_CARD_ID,
+            ]);
+
+            await expect(
+                ds.query('UPDATE card SET scryfall_id = $1 WHERE id = $2', [
+                    MIGRATION_CARD_SCRYFALL_ID,
+                    JUNK_CARD_ID,
+                ])
+            ).rejects.toThrow(/duplicate key|unique/i);
+        });
+    });
+});


### PR DESCRIPTION
## 6.7: card.scryfall_id + granular qty (issue #513)

- Migration 036: `card.scryfall_id` (nullable varchar) backfilled from `img_src` (shape-guarded), unique index; nullable `qty` on `granular_price` + `granular_price_history`. Idempotent throughout; init-schema parity.
- ORM entity sync only (`CardOrmEntity.scryfallId`, `GranularPriceOrmEntity.qty`) — no read-path changes; qty display lands with 6.4.
- Integration spec: schema assertions, backfill, idempotency, no-overwrite, unique-index semantics (9 tests).

## Release correctness (supersedes #521 — merged into this branch)

- `CacheControlInterceptor` no longer overwrites explicitly-set `Cache-Control` headers (`/sw.js` was shipping `max-age=60` instead of `no-cache` and CloudFront cached it; favicon's 7d header was clobbered to 60s).
- `verify-release.sh` runs at the end of `deploy.sh`: asserts the live site serves HTML referencing `?v=<released version>`, the versioned stylesheet, and a version-stamped service worker.
- New `e2e-test` CI job (Playwright incl. the responsive-overflow gate) now gates tag/build/deploy.

## Automatic versioning (drops manual `npm run bump`)

- `next-version.sh` computes the release version in CI from the squash-merged PR title: `feat:` → minor, `feat!:` / trailing `!` → major, anything else → patch. Source of truth is the highest semver git tag; idempotent on workflow re-runs.
- Dockerfile stamps `APP_VERSION` (build-arg) into the build stage (service worker) and production stage (runtime `package.json` that `assetVersion` reads). `package.json` pinned at `0.0.0-dev`; bump scripts removed.
- A forgotten version bump can no longer ship a release without cache busting — this branch originally had exactly that mistake.

## Verification

- Unit 1189/1189; Playwright 30/30; bump-rule sandbox tests 9/9.
- Production Docker image built with `APP_VERSION=9.9.9`: runtime package.json and sw.js both stamped correctly; no-arg build stays `0.0.0-dev`.
- `verify-release.sh` validated against live prod (passes for 1.32.1, fails clearly on mismatch).

Note: this PR title starts with `feat:` so the release will bump minor (→ 1.33.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)