### PR TITLE
fix: restore card price tile polish, buylist show/hide toggle, verify-release pipefail fix

### DIFF
--- a/.github/scripts/verify-release.sh
+++ b/.github/scripts/verify-release.sh
@@ -57,7 +57,7 @@ pass "tailwind.css?v=$EXPECTED_VERSION served ($css_bytes bytes)"
 # query param bypasses any CDN-cached copy so we verify origin truth.
 sw=$(curl -fsS --max-time 10 "$APP_URL/sw.js?verify=$(date +%s)")
 [[ "$sw" == *"APP_VERSION = '$EXPECTED_VERSION'"* ]] \
-    || fail "sw.js is not stamped with $EXPECTED_VERSION (found: $(echo "$sw" | grep -m1 "APP_VERSION = " || echo 'no APP_VERSION line'))"
+    || fail "sw.js is not stamped with $EXPECTED_VERSION (found: $(grep -m1 "APP_VERSION = " <<<"$sw" || echo 'no APP_VERSION line'))"
 pass "sw.js stamped with $EXPECTED_VERSION"
 
 echo "[VERIFY] Release $EXPECTED_VERSION is live and correct."

--- a/.github/scripts/verify-release.sh
+++ b/.github/scripts/verify-release.sh
@@ -40,8 +40,11 @@ done
 pass "app is responding"
 
 # 2. Rendered HTML must reference assets at the released version.
+# Substring match instead of `echo | grep -q`: grep -q exits at the first
+# match, and under pipefail the echo's resulting EPIPE fails the pipeline
+# even when the version IS present.
 html=$(curl -fsS --max-time 10 "$APP_URL/")
-echo "$html" | grep -q "?v=$EXPECTED_VERSION" \
+[[ "$html" == *"?v=$EXPECTED_VERSION"* ]] \
     || fail "HTML does not reference assets at ?v=$EXPECTED_VERSION (found: $(echo "$html" | grep -oE '\?v=[0-9a-zA-Z.\-]+' | sort -u | tr '\n' ' '))"
 pass "HTML references ?v=$EXPECTED_VERSION"
 
@@ -53,7 +56,7 @@ pass "tailwind.css?v=$EXPECTED_VERSION served ($css_bytes bytes)"
 # 4. The service worker must be stamped with the released version. A unique
 # query param bypasses any CDN-cached copy so we verify origin truth.
 sw=$(curl -fsS --max-time 10 "$APP_URL/sw.js?verify=$(date +%s)")
-echo "$sw" | grep -q "APP_VERSION = '$EXPECTED_VERSION'" \
+[[ "$sw" == *"APP_VERSION = '$EXPECTED_VERSION'"* ]] \
     || fail "sw.js is not stamped with $EXPECTED_VERSION (found: $(echo "$sw" | grep -m1 "APP_VERSION = " || echo 'no APP_VERSION line'))"
 pass "sw.js stamped with $EXPECTED_VERSION"
 

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -1595,11 +1595,6 @@ img,
   border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
 }
 
-.border-emerald-300 {
-  --tw-border-opacity: 1;
-  border-color: rgb(110 231 183 / var(--tw-border-opacity, 1));
-}
-
 .border-gray-100 {
   --tw-border-opacity: 1;
   border-color: rgb(243 244 246 / var(--tw-border-opacity, 1));
@@ -1673,11 +1668,6 @@ img,
 .bg-blue-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(239 246 255 / var(--tw-bg-opacity, 1));
-}
-
-.bg-emerald-50 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(236 253 245 / var(--tw-bg-opacity, 1));
 }
 
 .bg-gray-100 {
@@ -2147,16 +2137,6 @@ img,
 .text-blue-800 {
   --tw-text-opacity: 1;
   color: rgb(30 64 175 / var(--tw-text-opacity, 1));
-}
-
-.text-emerald-700 {
-  --tw-text-opacity: 1;
-  color: rgb(4 120 87 / var(--tw-text-opacity, 1));
-}
-
-.text-emerald-900 {
-  --tw-text-opacity: 1;
-  color: rgb(6 78 59 / var(--tw-text-opacity, 1));
 }
 
 .text-gray-100 {
@@ -5962,6 +5942,23 @@ img,
   font-weight: 700;
 }
 
+/* Compact variant for the card-page Buy/Sell tiles: tighter padding, quieter value */
+
+.price-tile-compact {
+  padding: 0.375rem;
+}
+
+@media (min-width: 768px) {
+  .price-tile-compact {
+    padding: 0.5rem;
+  }
+}
+
+.price-tile-value-compact {
+  font-size: clamp(0.875rem, 2vw, 1.125rem);
+  font-weight: 600;
+}
+
 /* Buy / Sell group labels in the card price section */
 
 .price-group-label {
@@ -5972,12 +5969,12 @@ img,
   text-transform: uppercase;
   letter-spacing: 0.05em;
   --tw-text-opacity: 1;
-  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
 }
 
 .price-group-label:is(.dark *) {
   --tw-text-opacity: 1;
-  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
 }
 
 .price-group-label-note {
@@ -5990,6 +5987,25 @@ img,
 .price-group-label-note:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+/* Collapsed-by-default Sell disclosure: the group label doubles as the toggle,
+   swapping between "Show buylist" and "Hide buylist" with the open state */
+
+.price-group-toggle {
+  cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+}
+
+.buylist-section .buylist-toggle-hide,
+.buylist-section[open] .buylist-toggle-show {
+  display: none;
+}
+
+.buylist-section[open] .buylist-toggle-hide {
+  display: inline;
 }
 
 /* Per-vendor buylist disclosure */
@@ -7966,11 +7982,6 @@ img,
   border-color: rgb(180 83 9 / 0.5);
 }
 
-.dark\:border-emerald-600:is(.dark *) {
-  --tw-border-opacity: 1;
-  border-color: rgb(5 150 105 / var(--tw-border-opacity, 1));
-}
-
 .dark\:border-gray-700:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(55 65 81 / var(--tw-border-opacity, 1));
@@ -8027,10 +8038,6 @@ img,
 
 .dark\:bg-blue-900\/30:is(.dark *) {
   background-color: rgb(30 58 138 / 0.3);
-}
-
-.dark\:bg-emerald-950\/30:is(.dark *) {
-  background-color: rgb(2 44 34 / 0.3);
 }
 
 .dark\:bg-gray-800:is(.dark *) {
@@ -8155,16 +8162,6 @@ img,
 .dark\:text-blue-200:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(191 219 254 / var(--tw-text-opacity, 1));
-}
-
-.dark\:text-emerald-200:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(167 243 208 / var(--tw-text-opacity, 1));
-}
-
-.dark\:text-emerald-300:is(.dark *) {
-  --tw-text-opacity: 1;
-  color: rgb(110 231 183 / var(--tw-text-opacity, 1));
 }
 
 .dark\:text-gray-100:is(.dark *) {

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -1240,13 +1240,38 @@
     @apply font-bold;
 }
 
+/* Compact variant for the card-page Buy/Sell tiles: tighter padding, quieter value */
+.price-tile-compact {
+    @apply p-1.5 md:p-2;
+}
+
+.price-tile-value-compact {
+    font-size: clamp(0.875rem, 2vw, 1.125rem);
+    @apply font-semibold;
+}
+
 /* Buy / Sell group labels in the card price section */
 .price-group-label {
-    @apply text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2;
+    @apply text-xs font-semibold uppercase tracking-wider text-gray-700 dark:text-gray-300 mb-2;
 }
 
 .price-group-label-note {
     @apply normal-case font-normal text-gray-400 dark:text-gray-500;
+}
+
+/* Collapsed-by-default Sell disclosure: the group label doubles as the toggle,
+   swapping between "Show buylist" and "Hide buylist" with the open state */
+.price-group-toggle {
+    @apply cursor-pointer select-none;
+}
+
+.buylist-section .buylist-toggle-hide,
+.buylist-section[open] .buylist-toggle-show {
+    display: none;
+}
+
+.buylist-section[open] .buylist-toggle-hide {
+    display: inline;
 }
 
 /* Per-vendor buylist disclosure */

--- a/src/http/views/card.hbs
+++ b/src/http/views/card.hbs
@@ -71,9 +71,9 @@
                 <h3 class="price-group-label">Buy <span class="price-group-label-note">retail</span></h3>
                 <div class="grid {{#if card.hasNormal}}{{#if card.hasFoil}}grid-cols-2{{else}}grid-cols-1{{/if}}{{else}}grid-cols-1{{/if}} gap-2 mb-3">
                     {{#if card.hasNormal}}
-                    <div class="price-tile border-teal-300 dark:border-teal-600 bg-white dark:bg-midnight-800">
+                    <div class="price-tile price-tile-compact border-teal-300 dark:border-teal-600 bg-white dark:bg-midnight-800">
                         <h4 class="font-semibold text-teal-700 dark:text-teal-300 text-xs uppercase tracking-wide mb-1">Normal</h4>
-                        <div class="price-tile-value font-bold text-gray-900 dark:text-gray-100 font-mono">
+                        <div class="price-tile-value price-tile-value-compact text-gray-900 dark:text-gray-100 font-mono">
                             {{card.normalPrice}}
                         </div>
                         {{#if card.priceChangeWeekly}}
@@ -82,9 +82,9 @@
                     </div>
                     {{/if}}
                     {{#if card.hasFoil}}
-                    <div class="price-tile border-purple-300 dark:border-purple-600 bg-purple-50 dark:bg-purple-950/30">
+                    <div class="price-tile price-tile-compact border-purple-300 dark:border-purple-600 bg-purple-50 dark:bg-purple-950/30">
                         <h4 class="font-semibold text-purple-700 dark:text-purple-300 text-xs uppercase tracking-wide mb-1">Foil</h4>
-                        <div class="price-tile-value font-bold text-purple-900 dark:text-purple-200 font-mono">
+                        <div class="price-tile-value price-tile-value-compact text-purple-900 dark:text-purple-200 font-mono">
                             {{card.foilPrice}}
                         </div>
                         {{#if card.foilPriceChangeWeekly}}
@@ -100,15 +100,15 @@
                 {{>buyOnTcgplayer url=card.purchaseUrlTcgplayerEtched label="Buy Etched on TCGPlayer"}}
                 {{/if}}
 
-                {{!-- Sell: best buylist offer per finish as emerald tiles; vendors behind a disclosure --}}
+                {{!-- Sell: best buylist offer per finish, themed like the Buy tiles; collapsed behind a disclosure --}}
                 {{#if buylist.hasAny}}
-                <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
-                    <h3 class="price-group-label">Sell <span class="price-group-label-note">buylist · NM</span></h3>
+                <details class="buylist-section mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <summary class="price-group-toggle"><h3 class="price-group-label inline-block"><span class="buylist-toggle-show">Show buylist</span><span class="buylist-toggle-hide">Hide buylist</span> <span class="price-group-label-note">sell · NM</span></h3></summary>
                     <div class="grid {{#if (gt buylist.finishes.length 1)}}grid-cols-2{{else}}grid-cols-1{{/if}} gap-2">
                         {{#each buylist.finishes}}
-                        <div class="price-tile border-emerald-300 dark:border-emerald-600 bg-emerald-50 dark:bg-emerald-950/30">
-                            <h4 class="font-semibold text-emerald-700 dark:text-emerald-300 text-xs uppercase tracking-wide mb-1">{{this.finish}}</h4>
-                            <div class="price-tile-value font-bold text-emerald-900 dark:text-emerald-200 font-mono">
+                        <div class="price-tile price-tile-compact {{#if (eq this.finish "Normal")}}border-teal-300 dark:border-teal-600 bg-white dark:bg-midnight-800{{else}}border-purple-300 dark:border-purple-600 bg-purple-50 dark:bg-purple-950/30{{/if}}">
+                            <h4 class="font-semibold {{#if (eq this.finish "Normal")}}text-teal-700 dark:text-teal-300{{else}}text-purple-700 dark:text-purple-300{{/if}} text-xs uppercase tracking-wide mb-1">{{this.finish}}</h4>
+                            <div class="price-tile-value price-tile-value-compact {{#if (eq this.finish "Normal")}}text-gray-900 dark:text-gray-100{{else}}text-purple-900 dark:text-purple-200{{/if}} font-mono">
                                 {{this.best.price}}
                             </div>
                             <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{this.best.vendor}}</div>
@@ -117,7 +117,7 @@
                                 <summary class="buylist-compare-summary">compare vendors</summary>
                                 <ul class="mt-1 space-y-1">
                                     {{#each this.offers}}
-                                    <li class="buylist-offer flex items-center justify-between text-xs {{#if this.isBest}}buylist-best text-emerald-700 dark:text-emerald-300 font-semibold{{else}}text-gray-500 dark:text-gray-400{{/if}}">
+                                    <li class="buylist-offer flex items-center justify-between text-xs {{#if this.isBest}}buylist-best text-gray-900 dark:text-gray-100 font-semibold{{else}}text-gray-500 dark:text-gray-400{{/if}}">
                                         <span class="min-w-0 truncate">{{this.vendor}}</span>
                                         <span class="font-mono flex-shrink-0">{{this.price}}</span>
                                     </li>
@@ -128,7 +128,7 @@
                         </div>
                         {{/each}}
                     </div>
-                </div>
+                </details>
                 {{/if}}
                 <section class="inventory-info">
                     {{>invStepper card=card}}

--- a/test/integration/public.e2e-spec.ts
+++ b/test/integration/public.e2e-spec.ts
@@ -80,6 +80,11 @@ describe('Public endpoints (e2e)', () => {
             // Stale CK row (2.00) lives only in granular_price_history, not the
             // current table the card page reads; retail row not shown as buylist
             expect(res.text).not.toContain('$2.00');
+            // Sell section is a disclosure, collapsed by default, with
+            // show/hide labels swapped via CSS on the open state
+            expect(res.text).toMatch(/<details class="buylist-section[^"]*">/);
+            expect(res.text).toContain('Show buylist');
+            expect(res.text).toContain('Hide buylist');
         });
 
         it('GET /card/:cardId/price-history returns JSON', async () => {


### PR DESCRIPTION
## Summary

- **Recovers the stashed card-price-section-polish work** (was in `stash@{0}`, never committed — its branch was deleted): compact Buy/Sell price tiles with tighter padding and quieter values, more prominent group labels, and buylist tiles themed like the retail tiles (teal Normal / purple Foil instead of emerald).
- **Buylist is now collapsed by default** behind a `<details>` disclosure. The clickable label toggles between **Show buylist** and **Hide buylist** via CSS on the `details[open]` state — no JS.
- **Fixes the red deploy on main**: `verify-release.sh` falsely failed a healthy release because `echo "$html" | grep -q` races under `set -o pipefail` — `grep -q` exits at the first match, `echo` gets EPIPE, and the pipeline fails even though the version was found. Replaced the pipes with bash substring matches (also fixed the same latent bug in the sw.js check).

## Testing

- Integration test extended: asserts the Sell section renders as a collapsed `details.buylist-section` with both Show/Hide labels. Full `public` suite passes 17/17.
- Fixed `verify-release.sh` run locally against prod: all four checks pass for the live 1.33.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)