### PR TITLE
refactor: derive card image tail from scryfall_id (6.8a)

### DIFF
--- a/src/database/card/card.mapper.ts
+++ b/src/database/card/card.mapper.ts
@@ -1,6 +1,7 @@
 import { Card } from 'src/core/card/card.entity';
 import { PriceMapper } from 'src/database/price/price.mapper';
 import { SetMapper } from 'src/database/set/set.mapper';
+import { cardImageTail } from 'src/shared/utils/scryfall-image.util';
 import { CardOrmEntity } from './card.orm-entity';
 import { LegalityMapper } from './legality.mapper';
 
@@ -12,7 +13,7 @@ export class CardMapper {
             flavorName: ormCard.flavorName,
             hasFoil: ormCard.hasFoil,
             hasNonFoil: ormCard.hasNonFoil,
-            imgSrc: ormCard.imgSrc,
+            imgSrc: cardImageTail(ormCard.scryfallId, ormCard.imgSrc),
             inMain: ormCard.inMain,
             isAlternative: ormCard.isAlternative,
             isReserved: ormCard.isReserved,

--- a/src/database/transaction/transaction.repository.ts
+++ b/src/database/transaction/transaction.repository.ts
@@ -8,6 +8,7 @@ import {
     TransactionRepositoryPort,
 } from 'src/core/transaction/ports/transaction.repository.port';
 import { getLogger } from 'src/logger/global-app-logger';
+import { cardImageTail } from 'src/shared/utils/scryfall-image.util';
 import { Repository } from 'typeorm';
 import { QueryBuilderHelper } from '../query/query-builder.helper';
 import { TransactionMapper } from './transaction.mapper';
@@ -149,7 +150,7 @@ export class TransactionRepository implements TransactionRepositoryPort {
                 (core as any).cardName = orm.card.name;
                 (core as any).cardSetCode = orm.card.setCode;
                 (core as any).cardNumber = orm.card.number;
-                (core as any).cardImgSrc = orm.card.imgSrc;
+                (core as any).cardImgSrc = cardImageTail(orm.card.scryfallId, orm.card.imgSrc);
             }
             return core;
         });

--- a/src/shared/utils/scryfall-image.util.ts
+++ b/src/shared/utils/scryfall-image.util.ts
@@ -1,0 +1,21 @@
+/**
+ * Builds the Scryfall image path tail `{a}/{b}/{scryfallId}.jpg` from a
+ * Scryfall id, where `a`/`b` are its first two characters. TS mirror of scry's
+ * `Card::build_scryfall_image_path` (src/card/domain/card.rs); the two must
+ * agree, since the web renders `${BASE_IMAGE_URL}/${size}/front/${tail}` and
+ * this is exactly the value scry stored in `card.img_src`.
+ */
+export function buildScryfallImagePath(scryfallId: string): string {
+    return `${scryfallId[0]}/${scryfallId[1]}/${scryfallId}.jpg`;
+}
+
+/**
+ * Resolves a card's image path tail, deriving it from `scryfallId` and falling
+ * back to a stored `imgSrc` only while a row still lacks a scryfall_id (cards
+ * ingested by the pre-6.7 scry binary, until the next full ingest backfills
+ * them). Once scryfall_id is guaranteed populated, the `img_src` column - and
+ * this fallback - are removed (ROADMAP 6.8b).
+ */
+export function cardImageTail(scryfallId?: string | null, imgSrc?: string | null): string {
+    return scryfallId ? buildScryfallImagePath(scryfallId) : (imgSrc ?? '');
+}

--- a/test/shared/utils/scryfall-image.util.spec.ts
+++ b/test/shared/utils/scryfall-image.util.spec.ts
@@ -1,0 +1,29 @@
+import { buildScryfallImagePath, cardImageTail } from 'src/shared/utils/scryfall-image.util';
+
+describe('scryfall-image.util', () => {
+    const scryfallId = 'a363bc91-8278-448e-9d5c-564e4b51eb62';
+    // What scry stored in card.img_src for this id: {a}/{b}/{id}.jpg
+    const expectedTail = 'a/3/a363bc91-8278-448e-9d5c-564e4b51eb62.jpg';
+
+    describe('buildScryfallImagePath', () => {
+        it('builds {a}/{b}/{id}.jpg from the first two characters', () => {
+            expect(buildScryfallImagePath(scryfallId)).toBe(expectedTail);
+        });
+    });
+
+    describe('cardImageTail', () => {
+        it('derives from scryfallId, ignoring any stored imgSrc', () => {
+            expect(cardImageTail(scryfallId, 'stale/x/value.jpg')).toBe(expectedTail);
+        });
+
+        it('falls back to imgSrc when scryfallId is missing', () => {
+            expect(cardImageTail(undefined, 'a/b/legacy.jpg')).toBe('a/b/legacy.jpg');
+            expect(cardImageTail(null, 'a/b/legacy.jpg')).toBe('a/b/legacy.jpg');
+        });
+
+        it('returns an empty string when neither is available', () => {
+            expect(cardImageTail(undefined, undefined)).toBe('');
+            expect(cardImageTail(null, null)).toBe('');
+        });
+    });
+});


### PR DESCRIPTION
## What

Source the card image path tail from `card.scryfall_id` instead of reading the stored `img_src` column, so the web read layer stops depending on `img_src`. Prerequisite for dropping the column (6.8b).

- New `src/shared/utils/scryfall-image.util.ts`:
  - `buildScryfallImagePath(scryfallId)` - TS mirror of scry's `Card::build_scryfall_image_path` (`{a}/{b}/{id}.jpg`).
  - `cardImageTail(scryfallId, imgSrc)` - derives from `scryfallId`, falls back to `imgSrc` only while a row's `scryfall_id` is still NULL (cards ingested by the pre-6.7 scry binary, until the next full ingest backfills them).
- Wired into `card.mapper` (covers all domain-`Card` reads) and the one custom read in `transaction.repository`.

The derived value is byte-identical to what scry stored in `img_src`, so there is **no visual change**. No migration; the column stays until 6.8b.

## Note on the json-ld bullet

The roadmap's 6.8 json-ld item is stale: the HBS card view's `imgSrc` is already a full URL (`card.presenter.buildImgSrc`), so `schema.image` is already absolute. No change made there.

## Test plan

- New unit test for the helper (derive + fallback + empty).
- `tsc --noEmit` clean; Prettier clean.
- Full unit suite green (1219 + 4 new).
- Integration seeds set `img_src` but not `scryfall_id`, so e2e exercises the fallback path unchanged.