### PR TITLE
chore: make card.img_src nullable (6.8b step 1)

### DIFF
--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -97,7 +97,7 @@ CREATE TABLE public.card (
     flavor_name character varying,
     has_foil boolean NOT NULL,
     has_non_foil boolean NOT NULL,
-    img_src character varying NOT NULL,
+    img_src character varying,
     is_reserved boolean DEFAULT false NOT NULL,
     mana_cost character varying,
     name character varying NOT NULL,

--- a/migrations/037_card_img_src_nullable.sql
+++ b/migrations/037_card_img_src_nullable.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+-- Phase 6.8b (step 1 of 2): make card.img_src nullable.
+--
+-- img_src is redundant derived data on its way out: scry stored it as
+-- '{a}/{b}/{scryfall_id}.jpg', and the web now derives that path from
+-- card.scryfall_id at read time (6.8a) instead of reading this column. The
+-- column is dropped in a later migration, but only after scry has stopped
+-- writing it and that binary is live in prod (the drop can't precede the
+-- binary, or the still-writing card upsert would fail on a missing column).
+--
+-- Relaxing NOT NULL first is the prerequisite for that scry change: it lets
+-- scry's card upsert omit img_src without violating the constraint. Safe and
+-- inert on its own - scry keeps writing img_src until its next release.
+
+ALTER TABLE public.card ALTER COLUMN img_src DROP NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
First of the 6.8b column-drop sequence. Relaxes `card.img_src`'s `NOT NULL` constraint so scry can later stop writing the column.

The web no longer reads `img_src` for the card image - it derives `{a}/{b}/{scryfall_id}.jpg` from `card.scryfall_id` at read time (#525, 6.8a). `img_src` is now redundant derived data on its way out.

**Why nullable first:** dropping the column can't precede scry's no-img_src binary (the still-writing card upsert would fail on a missing column). Relaxing `NOT NULL` is the prerequisite that lets scry's upsert omit the column without violating the constraint. Safe and inert on its own - scry keeps writing `img_src` until its next release.

- `migrations/037_card_img_src_nullable.sql`
- `001_complete_schema.sql` kept in sync

**Deploy order:** merge after #525 (6.8a) is live. Then scry stops writing `img_src`, and a final migration drops the column once that binary is live.

Verified: 001 + migration 037 apply cleanly against PG18; `img_src` ends nullable.