### PR TITLE
chore: drop card.img_src column (6.8b)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -150,9 +150,9 @@ against your buy list"). Build that first; the multi-vendor consolidation optimi
 - [ ] Mirror via MCP ([iwantmymtg-mcp#9](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/9))
 - [ ] **Gated on 6.9 (≥2 buylist sources):** best net outcome per vendor; favor consolidating into a single vendor/bulk transaction where it wins
 
-### 6.6 Condition Vocabulary Normalization (follow-up, after 6.2/6.3)
+### 6.6 Condition Vocabulary Normalization — **skipped (single grade)** ⏭️
 
-Open question deferred from 6.2 — not blocking, since every row in 6.2/6.3 is `NM`. Revisit only when a source actually delivers multi-grade prices (likely Tier C, or a future CK-retail-by-grade ingest).
+**Closed without building (#512).** Every row in 6.2–6.7 is `NM` and buylist is single-source (Card Kingdom), so there is no multi-grade data to normalize. Revisit only when a source actually delivers multi-grade prices (Tier C, or a future CK-retail-by-grade ingest — CK's `condition_values` already exposes nm/ex/vg/g **retail**). The notes below are kept as the design starting point.
 
 - [ ] Decide the canonical **raw-condition** representation and the per-vendor converters. Candidate (from scoping): a normalized numeric rank so "best condition" / offer-matching are cheap comparisons. Caveat: CK (NM/EX/VG/G, 4 grades) and TCGplayer (NM/LP/MP/HP/DMG, 5 grades) don't map 1:1, so any shared scale is lossy cross-vendor — keep the source grade where fidelity matters
 - [ ] Keep **professional grading a separate dimension** (grading company + numeric grade, allowing half-grades like BGS 9.5) rather than overloading the raw-condition column — a slabbed PSA 9 is a distinct product/market from a raw NM, and a different `tcgplayerProductId`
@@ -166,15 +166,17 @@ Adds Card Kingdom's free direct pricelist (`api.cardkingdom.com/api/v2/pricelist
 - [x] Stream the CK pricelist in scry (`CkPricelistEventProcessor`), `scryfall_id → card.id` map, emit `granular_price` + `granular_price_history` buylist rows (`provider='cardkingdom'`, finish from `is_foil`, condition `NM`); only real offers emit (`price_buy > 0 AND qty_buying > 0`); per-series dedupe keeps the best offer; best-effort (never blocks the averaged price refresh)
 - [x] Buy-quantity re-introduced: nullable `qty` on both granular tables; `qty = EXCLUDED.qty` (last-writer-wins, not COALESCE) so a failed CK fetch reads NULL ("unknown") rather than stale. Surfacing qty deferred to 6.4
 
-### 6.8 Normalize card image: derive from `scryfall_id`, drop `img_src` — **directly after 6.7**
+### 6.8 Normalize card image: derive from `scryfall_id`, drop `img_src` ✅
 
-`img_src` is pure derived data: scry stores exactly `{a}/{b}/{scryfall_id}.jpg` and the web renders `${BASE_IMAGE_URL}/${size}/front/${img_src}` — a total, reversible function of `scryfall_id`. Once 6.7 adds the `scryfall_id` column, storing `img_src` too is denormalized (same fact, two columns), and `scryfall_id` is strictly more useful (it also drives CK matching + Scryfall API interop). Do this **immediately after Tier B**, while it's fresh.
+`img_src` was pure derived data: scry stored exactly `{a}/{b}/{scryfall_id}.jpg` and the web renders `${BASE_IMAGE_URL}/${size}/front/${img_src}` — a total, reversible function of `scryfall_id`. Once 6.7 added the `scryfall_id` column, storing `img_src` too was denormalized (same fact, two columns). Shipped as a coupled web+scry deploy sequence so the column drop could never precede the no-`img_src` binary:
 
-- [ ] Drop the stored `card.img_src` column; scry persists `scryfall_id` only (stop computing/storing the path).
-- [ ] Derive the image at read time via a shared helper (TS mirror of `Card::build_scryfall_image_path`): `${BASE_IMAGE_URL}/${size}/front/${a}/${b}/${scryfall_id}.jpg`.
-- [ ] **Keep the external contract:** the `imgSrc` field stays in the JSON API DTOs (`card-api`, `inventory-api`), MCP output schemas, and HBS views — computed from `scryfall_id` in the presenter, not read from a column (~6–8 read sites).
-- [ ] Fix `json-ld.util.ts` to emit an **absolute** image URL (it currently sets `schema.image` to the raw `{a}/{b}/{id}.jpg` tail — an already-broken link).
-- [ ] Front-face only is preserved (the scheme always serves `/front/`); back/DFC images remain a separate future feature.
+- [x] **6.8a** (web #525): web derives the image tail from `card.scryfall_id` at read time via `buildScryfallImagePath` (`src/shared/utils/scryfall-image.util.ts`, TS mirror of `Card::build_scryfall_image_path`), wired into `card.mapper` + `transaction.repository`. No visual change.
+- [x] **6.8b step 1** (web #526, migration `037`): make `img_src` nullable (prerequisite for scry to stop writing it).
+- [x] **6.8b step 2** (scry #18, released 5.13.1): scry stops computing/writing `img_src`; persists `scryfall_id` only.
+- [x] **6.8b step 3** (web, migration `038`): drop the `card.img_src` column. Migrations `036`/`037` guarded with column-existence `DO` blocks (untracked migrations replay every deploy). The drop runs before `setup-cron.sh` extracts `scry:latest`, so the column and a still-writing binary never coexist.
+- [x] **Kept the external contract:** the `imgSrc` field stays in the JSON API DTOs (`card-api`, `inventory-api`), MCP output schemas, and HBS views — derived from `scryfall_id` in `card.mapper`, not read from a column.
+- [x] ~~Fix `json-ld.util.ts` to emit an absolute image URL~~ **Stale (no change):** the HBS card view's `imgSrc` is already a full URL via `card.presenter.buildImgSrc`, so `schema.image` is already absolute (#525).
+- [x] Front-face only is preserved (the scheme always serves `/front/`); back/DFC images remain a separate future feature.
 
 ### 6.9 Tier C: Broaden Buylist Vendor Coverage (find more buylist sources)
 
@@ -182,10 +184,12 @@ Promoted from "deferred" by a live-ingest finding (scry#14 Tier A), then **confi
 
 **Researched (2026-06-09, full findings on #515): no free, legitimate, multi-vendor buylist API exists.** TCGplayer shut down its buylist program (July 2024); Cardsphere is peer-to-peer and absent from the MTGJSON feed; the remaining buylist vendors (Star City Games, CoolStuffInc, ABU Games, Troll & Toad) publish no APIs — reachable only via go-mtgban scrapers (free, but ToS-gray, AGPL, a Go sidecar next to the Rust ETL, perpetual breakage maintenance) or the mtgban BAN API at $1,000/mo. **Decision: proceed single-source.** 6.4 ships framed as vendor-neutral **market sell value**; 6.5 is re-scoped to the cash-vs-credit decision; the multi-vendor pieces stay gated here.
 
+**Skipped (single source) — #515 closed.** Proceeding single-source is the final decision; the multi-vendor pieces stay gated below and are revisited only on demand + revenue.
+
 - [x] Evaluate additional buylist sources — done; no viable free/legitimate option (see findings on #515)
 - [x] Re-sequence decision: 6.4/6.5 do **not** wait for broader coverage — built single-source with vendor-neutral framing; the per-vendor comparison + consolidation optimizer are gated on this item
-- [ ] scry cleanup: drop `cardsphere` from `GRANULAR_PROVIDERS` (confirmed absent upstream; yields nothing today)
-- [ ] Revisit go-mtgban / a paid aggregator only when **both** hold: (a) 6.4 has shipped and sell-flow engagement shows demand for vendor comparison; (b) revenue can absorb the scraper ops burden or an aggregator fee
+- [x] scry cleanup: drop the dead `cardsphere` provider (confirmed absent upstream; yields nothing). *Correction:* `cardsphere` was never in `GRANULAR_PROVIDERS` (`tcgplayer, cardkingdom, manapool`) — it lingered in `AVERAGE_PROVIDERS`, which derives the averaged `price`. Removed there (scry PR #19); output-identical since it never carried a retail value upstream.
+- [ ] **Gated:** revisit go-mtgban / a paid aggregator only when **both** hold: (a) 6.4 has shipped and sell-flow engagement shows demand for vendor comparison; (b) revenue can absorb the scraper ops burden or an aggregator fee
 
 Extend the product's surface area so newcomers can use it where they expect to — phone first. Recurring feedback is that people expect a mobile app to try the product at all, so platform expansion is sequenced ahead of the go-to-market push (Phase 8): drive adoption onto surfaces newcomers can actually use before the marketing spend lands.
 

--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -97,7 +97,6 @@ CREATE TABLE public.card (
     flavor_name character varying,
     has_foil boolean NOT NULL,
     has_non_foil boolean NOT NULL,
-    img_src character varying,
     is_reserved boolean DEFAULT false NOT NULL,
     mana_cost character varying,
     name character varying NOT NULL,

--- a/docs/phase6-buylist-handoff.md
+++ b/docs/phase6-buylist-handoff.md
@@ -12,7 +12,14 @@ The work spans two repos that share one Postgres DB:
 - **scry** (`/Users/matthewtowles/Projects/scry`, Rust ETL)
 
 6.2/6.3 (granular store + card-page display, Tier A) are merged and live.
+6.4 (inventory market sell value + CSV export) is **merged** (web PR #524).
 6.7 (Tier B, CK-direct) is **merged** (web PR #522 + the scry branch) — scope on issue #513.
+6.8 (normalize card image; drop `img_src`) is **merged** — see Done below.
+
+**Single-source is final.** 6.6 (condition vocab, #512) and 6.9 Tier C (broader vendor
+coverage, #515) are **closed/skipped**: buylist is upstream single-vendor (Card Kingdom)
+and every row is `NM`, so there is nothing to normalize across grades or compare across
+vendors. Revisit only if a multi-grade / multi-vendor source ever lands.
 
 **Framing decision (2026-06-11):** user-facing copy for the sell features uses vendor-neutral
 **"market sell value"** terminology — no named-vendor pitch (we are not partnered with Card
@@ -167,30 +174,40 @@ As-built (full scope + decision log on issue #513):
 
 ## Remaining work
 
-### Follow-up — **directly after Tier B** (ROADMAP 6.8): normalize the card image
-Once 6.7 adds `card.scryfall_id`, `img_src` is redundant derived data (scry stores exactly
-`{a}/{b}/{scryfall_id}.jpg`; web renders `${BASE_IMAGE_URL}/${size}/front/${img_src}` — a total,
-reversible function of scryfall_id). Drop the stored column and derive the image from scryfall_id:
-- **scry**: persist `scryfall_id` only (stop computing/storing the path); drop `img_src` from the
-  card upsert + `tests/fixtures/schema.sql` + the `Card` domain.
-- **web**: a shared helper (TS mirror of `Card::build_scryfall_image_path`) builds the URL at
-  render. **Keep the `imgSrc` field** in the JSON API DTOs (`card-api`, `inventory-api`), MCP
-  output schemas, and HBS views — computed from `scryfall_id`, not read from a column (~6–8 sites).
-- Fix `json-ld.util.ts` to emit an **absolute** image URL (currently sets `schema.image` to the raw
-  `{a}/{b}/{id}.jpg` tail — an already-broken link). Front-face only is preserved (scheme always
-  serves `/front/`); back/DFC images stay a separate future feature.
+### 6.8 — normalize the card image; drop `img_src` ✅ (DONE)
+Shipped as a coupled web+scry deploy sequence so the column drop never preceded the
+no-`img_src` binary:
+- **6.8a** (web #525): web derives the image tail from `card.scryfall_id` via
+  `buildScryfallImagePath` (`src/shared/utils/scryfall-image.util.ts`, TS mirror of scry's
+  `Card::build_scryfall_image_path`), wired into `card.mapper` + `transaction.repository`. No
+  visual change. The **`imgSrc` field stays** in JSON API DTOs / MCP / HBS — derived, not a column.
+- **6.8b step 1** (web #526, migration `037`): `img_src` made nullable.
+- **6.8b step 2** (scry #18, released 5.13.1): scry persists `scryfall_id` only; stops writing
+  `img_src` (dropped from the card upsert + `Card` domain + `tests/fixtures/schema.sql`).
+- **6.8b step 3** (web, migration `038`): drop the `card.img_src` column. Migrations `036`/`037`
+  guarded with column-existence `DO` blocks because `run_migrations.sh` replays every `*.sql`
+  on every deploy (untracked); `001_complete_schema.sql` dropped the column. The migration runs
+  before `setup-cron.sh` extracts `scry:latest`, so column + still-writing binary never coexist.
+- **json-ld:** the roadmap bullet was stale — the HBS `imgSrc` is already a full URL
+  (`card.presenter.buildImgSrc`), so `schema.image` was already absolute. No change.
+
+### Closed / skipped (single source)
+- **6.6 condition vocab (#512):** every row is `NM`; no multi-grade source. Closed.
+- **6.9 Tier C (#515):** no free/legitimate multi-vendor buylist API exists; proceeding
+  single-source is final. The only cleanup — dropping the dead `cardsphere` provider — shipped in
+  scry PR #19 (it lived in `AVERAGE_PROVIDERS`, *not* `GRANULAR_PROVIDERS` as the roadmap said;
+  output-identical since cardsphere is absent upstream). go-mtgban / paid aggregator stay gated.
 
 ### Later
 - ~~6.3 remainder: buylist on the **set page + binder overlay**~~ **Descoped in 6.3.1** — buylist
   lives only on the card page; the set-list "sell $X" rows and binder "Buylist $X" overlay were
   removed (clutter + mobile overflow). The batched `findCurrentBuylistByCardIds` read is kept for 6.4.
-- 6.4 inventory **market sell value** (vendor-neutral copy; best offer per item, qty-capped
-  payout totals, group-by-vendor kept as structure, plain buylist links, CSV export); 6.5
-  re-scoped to **cash vs. store credit** first (needs DB `vendor` table), multi-vendor
-  consolidation gated on 6.9.
+- ~~6.4 inventory **market sell value**~~ **Shipped (PR #524).** Best offer per item, qty-capped
+  payout totals, group-by-vendor kept as structure, plain buylist links, CSV export.
+- **6.5 (next, not started):** re-scoped to **cash vs. store credit** first (needs DB `vendor`
+  table); multi-vendor consolidation gated on 6.9 (which is closed single-source).
 - Possible: currency column → then Cardmarket (only if non-USD is ever wanted; currently out).
-- ROADMAP 6.6: condition grade vocabulary (when a multi-grade source lands; note CK's
-  `condition_values` already exposes nm/ex/vg/g **retail** — a future source for that).
+- ~~ROADMAP 6.6: condition grade vocabulary~~ **Closed (#512)** — single grade (`NM`) only.
 
 ---
 

--- a/migrations/036_card_scryfall_id_and_granular_qty.sql
+++ b/migrations/036_card_scryfall_id_and_granular_qty.sql
@@ -22,10 +22,21 @@ BEGIN;
 
 ALTER TABLE public.card ADD COLUMN IF NOT EXISTS scryfall_id character varying;
 
-UPDATE public.card
-SET scryfall_id = left(split_part(img_src, '/', 3), 36)
-WHERE scryfall_id IS NULL
-  AND img_src ~ '^[0-9a-f]/[0-9a-f]/[0-9a-f-]{36}\.jpg$';
+-- Guarded so this stays re-runnable after migration 038 drops img_src (the
+-- migration set is replayed every deploy). While img_src exists this is the
+-- original backfill; once dropped it is a clean no-op.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'card' AND column_name = 'img_src'
+    ) THEN
+        UPDATE public.card
+        SET scryfall_id = left(split_part(img_src, '/', 3), 36)
+        WHERE scryfall_id IS NULL
+          AND img_src ~ '^[0-9a-f]/[0-9a-f]/[0-9a-f-]{36}\.jpg$';
+    END IF;
+END $$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_card_scryfall_id ON public.card (scryfall_id);
 

--- a/migrations/037_card_img_src_nullable.sql
+++ b/migrations/037_card_img_src_nullable.sql
@@ -13,6 +13,17 @@ BEGIN;
 -- scry's card upsert omit img_src without violating the constraint. Safe and
 -- inert on its own - scry keeps writing img_src until its next release.
 
-ALTER TABLE public.card ALTER COLUMN img_src DROP NOT NULL;
+-- Guarded so this stays re-runnable after migration 038 drops img_src (the
+-- migration set is replayed every deploy; there is no IF EXISTS form for
+-- ALTER COLUMN). No-op once the column is gone.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'card' AND column_name = 'img_src'
+    ) THEN
+        ALTER TABLE public.card ALTER COLUMN img_src DROP NOT NULL;
+    END IF;
+END $$;
 
 COMMIT;

--- a/migrations/038_card_drop_img_src.sql
+++ b/migrations/038_card_drop_img_src.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+-- Phase 6.8b: drop card.img_src (final step of the 6.8 sequence).
+--
+-- img_src was redundant derived data: scry stored it as
+-- '{a}/{b}/{scryfall_id}.jpg', and the web now derives that path from
+-- card.scryfall_id at read time (6.8a) instead of reading this column.
+-- Migration 037 made the column nullable; scry then stopped writing it (scry
+-- 5.13.1, the no-img_src binary). This drop is the last step.
+--
+-- Safe ordering: a web deploy runs migrations BEFORE setup-cron.sh extracts the
+-- scry binary, and scry:latest is the no-img_src binary, so the column and a
+-- still-writing binary never coexist. IF EXISTS keeps this re-runnable (the
+-- migration set is replayed on every deploy and in integration tests).
+--
+-- Migrations 036 (img_src -> scryfall_id backfill) and 037 (ALTER COLUMN
+-- img_src) are guarded with column-existence checks so they no-op cleanly once
+-- this drop has run.
+
+ALTER TABLE public.card DROP COLUMN IF EXISTS img_src;
+
+COMMIT;

--- a/src/database/card/card.mapper.ts
+++ b/src/database/card/card.mapper.ts
@@ -1,7 +1,7 @@
 import { Card } from 'src/core/card/card.entity';
 import { PriceMapper } from 'src/database/price/price.mapper';
 import { SetMapper } from 'src/database/set/set.mapper';
-import { cardImageTail } from 'src/shared/utils/scryfall-image.util';
+import { buildScryfallImagePath } from 'src/shared/utils/scryfall-image.util';
 import { CardOrmEntity } from './card.orm-entity';
 import { LegalityMapper } from './legality.mapper';
 
@@ -13,7 +13,7 @@ export class CardMapper {
             flavorName: ormCard.flavorName,
             hasFoil: ormCard.hasFoil,
             hasNonFoil: ormCard.hasNonFoil,
-            imgSrc: cardImageTail(ormCard.scryfallId, ormCard.imgSrc),
+            imgSrc: buildScryfallImagePath(ormCard.scryfallId),
             inMain: ormCard.inMain,
             isAlternative: ormCard.isAlternative,
             isReserved: ormCard.isReserved,
@@ -43,7 +43,6 @@ export class CardMapper {
         ormEntity.flavorName = coreCard.flavorName;
         ormEntity.hasFoil = coreCard.hasFoil;
         ormEntity.hasNonFoil = coreCard.hasNonFoil;
-        ormEntity.imgSrc = coreCard.imgSrc;
         ormEntity.inMain = coreCard.inMain;
         ormEntity.isAlternative = coreCard.isAlternative;
         ormEntity.isReserved = coreCard.isReserved;

--- a/src/database/card/card.orm-entity.ts
+++ b/src/database/card/card.orm-entity.ts
@@ -21,9 +21,6 @@ export class CardOrmEntity {
     @Column({ name: 'has_non_foil' })
     hasNonFoil: boolean;
 
-    @Column({ name: 'img_src' })
-    imgSrc: string;
-
     @Column({ name: 'in_main' })
     inMain: boolean;
 

--- a/src/database/transaction/transaction.repository.ts
+++ b/src/database/transaction/transaction.repository.ts
@@ -8,7 +8,7 @@ import {
     TransactionRepositoryPort,
 } from 'src/core/transaction/ports/transaction.repository.port';
 import { getLogger } from 'src/logger/global-app-logger';
-import { cardImageTail } from 'src/shared/utils/scryfall-image.util';
+import { buildScryfallImagePath } from 'src/shared/utils/scryfall-image.util';
 import { Repository } from 'typeorm';
 import { QueryBuilderHelper } from '../query/query-builder.helper';
 import { TransactionMapper } from './transaction.mapper';
@@ -150,7 +150,7 @@ export class TransactionRepository implements TransactionRepositoryPort {
                 (core as any).cardName = orm.card.name;
                 (core as any).cardSetCode = orm.card.setCode;
                 (core as any).cardNumber = orm.card.number;
-                (core as any).cardImgSrc = cardImageTail(orm.card.scryfallId, orm.card.imgSrc);
+                (core as any).cardImgSrc = buildScryfallImagePath(orm.card.scryfallId);
             }
             return core;
         });

--- a/src/shared/utils/scryfall-image.util.ts
+++ b/src/shared/utils/scryfall-image.util.ts
@@ -3,19 +3,12 @@
  * Scryfall id, where `a`/`b` are its first two characters. TS mirror of scry's
  * `Card::build_scryfall_image_path` (src/card/domain/card.rs); the two must
  * agree, since the web renders `${BASE_IMAGE_URL}/${size}/front/${tail}` and
- * this is exactly the value scry stored in `card.img_src`.
+ * this is the path scry once stored in the (now dropped) `card.img_src` column.
+ *
+ * Returns `''` for a missing id (every card has a scryfall_id in practice -
+ * migration 036 backfilled all rows and scry persists it - but the column is
+ * typed nullable).
  */
-export function buildScryfallImagePath(scryfallId: string): string {
-    return `${scryfallId[0]}/${scryfallId[1]}/${scryfallId}.jpg`;
-}
-
-/**
- * Resolves a card's image path tail, deriving it from `scryfallId` and falling
- * back to a stored `imgSrc` only while a row still lacks a scryfall_id (cards
- * ingested by the pre-6.7 scry binary, until the next full ingest backfills
- * them). Once scryfall_id is guaranteed populated, the `img_src` column - and
- * this fallback - are removed (ROADMAP 6.8b).
- */
-export function cardImageTail(scryfallId?: string | null, imgSrc?: string | null): string {
-    return scryfallId ? buildScryfallImagePath(scryfallId) : (imgSrc ?? '');
+export function buildScryfallImagePath(scryfallId?: string | null): string {
+    return scryfallId ? `${scryfallId[0]}/${scryfallId[1]}/${scryfallId}.jpg` : '';
 }

--- a/test/integration/freemium-gates.e2e-spec.ts
+++ b/test/integration/freemium-gates.e2e-spec.ts
@@ -75,9 +75,9 @@ describe('Freemium gates (e2e)', () => {
 
         // Seed a 5th card so we can build up to the 5-alert free-tier cap
         await ds.query(
-            `INSERT INTO card (id, artist, has_foil, has_non_foil, img_src, is_reserved, mana_cost,
+            `INSERT INTO card (id, artist, has_foil, has_non_foil, is_reserved, mana_cost,
                 name, number, oracle_text, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
-             VALUES ($1, 'Test Artist', true, true, 'https://example.com/card5.jpg', false, '{G}',
+             VALUES ($1, 'Test Artist', true, true, false, '{G}',
                 'Test Hydra', '5', 'Trample', 'rare', $2, 'Creature - Hydra', 'normal', false, '005', true)
              ON CONFLICT (id) DO NOTHING`,
             [EXTRA_CARD_ID, TEST_SET_CODE]
@@ -253,9 +253,9 @@ describe('Freemium gates (e2e)', () => {
             // Need a 6th distinct card id; reuse the EXTRA_CARD_ID is already alerted, so insert another.
             const sixthCardId = '00000000-0000-4000-a000-000000000006';
             await ds.query(
-                `INSERT INTO card (id, artist, has_foil, has_non_foil, img_src, is_reserved, mana_cost,
+                `INSERT INTO card (id, artist, has_foil, has_non_foil, is_reserved, mana_cost,
                     name, number, oracle_text, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
-                 VALUES ($1, 'Test Artist', true, true, 'https://example.com/card6.jpg', false, '{U}',
+                 VALUES ($1, 'Test Artist', true, true, false, '{U}',
                     'Test Drake', '6', 'Flying', 'common', $2, 'Creature - Drake', 'normal', false, '006', true)
                  ON CONFLICT (id) DO NOTHING`,
                 [sixthCardId, TEST_SET_CODE]

--- a/test/integration/migration-036.e2e-spec.ts
+++ b/test/integration/migration-036.e2e-spec.ts
@@ -1,38 +1,31 @@
 import { INestApplication } from '@nestjs/common';
-import { readFileSync } from 'fs';
-import { join } from 'path';
 import { DataSource } from 'typeorm';
 import { closeTestApp, createTestApp } from './setup';
 
-const MIGRATION_PATH = join(
-    process.cwd(),
-    'migrations',
-    '036_card_scryfall_id_and_granular_qty.sql'
-);
-
-// Realistic img_src shape ('{a}/{b}/{scryfall_id}.jpg', as scry builds it) vs
-// the non-conforming shape the seed data uses — the backfill must fill the
-// former and leave the latter NULL.
-const MIGRATION_CARD_ID = '00000000-0000-4000-b000-000000000001';
-const MIGRATION_CARD_SCRYFALL_ID = 'ab12cd34-5678-4abc-9def-1234567890ab';
-const MIGRATION_CARD_IMG_SRC = `a/b/${MIGRATION_CARD_SCRYFALL_ID}.jpg`;
+// Covers the card-image schema produced by the 6.7/6.8 migration sequence:
+// 036 added card.scryfall_id (+ granular qty), 037/038 made img_src nullable
+// then dropped it. The img_src -> scryfall_id backfill (036) is intentionally
+// not exercised here: 038 drops img_src on the harness DB, so there is no
+// column to backfill from. The backfill ran once in prod and is now a guarded
+// no-op (see migrations 036/037).
+const CARD_ID = '00000000-0000-4000-b000-000000000001';
+const CARD_SCRYFALL_ID = 'ab12cd34-5678-4abc-9def-1234567890ab';
 const JUNK_CARD_ID = '00000000-0000-4000-b000-000000000002';
-const JUNK_CARD_IMG_SRC = 'https://example.com/not-a-scryfall-path.jpg';
 
-describe('Migration 036: card.scryfall_id + granular qty (e2e)', () => {
+describe('Card image schema: scryfall_id + img_src drop (6.7/6.8) (e2e)', () => {
     let app: INestApplication;
     let ds: DataSource;
 
-    const insertCard = (id: string, imgSrc: string, number: string) =>
+    const insertCard = (id: string, number: string) =>
         ds.query(
-            `INSERT INTO card (id, has_foil, has_non_foil, img_src, is_reserved, name, number, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
-             VALUES ($1, true, true, $2, false, 'Migration Test Card', $3, 'common', 'tst', 'Creature', 'normal', false, $4, true)
+            `INSERT INTO card (id, has_foil, has_non_foil, is_reserved, name, number, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
+             VALUES ($1, true, true, false, 'Schema Test Card', $2, 'common', 'tst', 'Creature', 'normal', false, $3, true)
              ON CONFLICT (id) DO NOTHING`,
-            [id, imgSrc, number, number]
+            [id, number, number]
         );
 
     const deleteTestCards = () =>
-        ds.query('DELETE FROM card WHERE id IN ($1, $2)', [MIGRATION_CARD_ID, JUNK_CARD_ID]);
+        ds.query('DELETE FROM card WHERE id IN ($1, $2)', [CARD_ID, JUNK_CARD_ID]);
 
     beforeAll(async () => {
         app = await createTestApp();
@@ -51,7 +44,7 @@ describe('Migration 036: card.scryfall_id + granular qty (e2e)', () => {
         await closeTestApp(app);
     });
 
-    describe('schema (init parity + migration already applied by the harness)', () => {
+    describe('schema', () => {
         it('card.scryfall_id exists as a nullable varchar column', async () => {
             const rows = await ds.query(
                 `SELECT data_type, is_nullable FROM information_schema.columns
@@ -72,6 +65,14 @@ describe('Migration 036: card.scryfall_id + granular qty (e2e)', () => {
             expect(rows[0].indexdef).toContain('scryfall_id');
         });
 
+        it('card.img_src has been dropped (6.8b)', async () => {
+            const rows = await ds.query(
+                `SELECT 1 FROM information_schema.columns
+                 WHERE table_schema = 'public' AND table_name = 'card' AND column_name = 'img_src'`
+            );
+            expect(rows).toHaveLength(0);
+        });
+
         it.each(['granular_price', 'granular_price_history'])(
             '%s.qty exists as a nullable integer column',
             async (table) => {
@@ -87,57 +88,11 @@ describe('Migration 036: card.scryfall_id + granular qty (e2e)', () => {
         );
     });
 
-    describe('backfill (re-running the migration file against fresh rows)', () => {
-        const migrationSql = readFileSync(MIGRATION_PATH, 'utf8');
-
-        beforeEach(async () => {
-            await deleteTestCards();
-            await insertCard(MIGRATION_CARD_ID, MIGRATION_CARD_IMG_SRC, '901');
-            await insertCard(JUNK_CARD_ID, JUNK_CARD_IMG_SRC, '902');
-        });
-
-        it('fills scryfall_id from a conforming img_src and leaves non-conforming NULL', async () => {
-            await ds.query(migrationSql);
-
-            const rows = await ds.query(
-                'SELECT id, scryfall_id FROM card WHERE id IN ($1, $2) ORDER BY id',
-                [MIGRATION_CARD_ID, JUNK_CARD_ID]
-            );
-            expect(rows).toHaveLength(2);
-            expect(rows[0].scryfall_id).toBe(MIGRATION_CARD_SCRYFALL_ID);
-            expect(rows[1].scryfall_id).toBeNull();
-        });
-
-        it('is idempotent: running twice does not error or change values', async () => {
-            await ds.query(migrationSql);
-            await ds.query(migrationSql);
-
-            const rows = await ds.query('SELECT scryfall_id FROM card WHERE id = $1', [
-                MIGRATION_CARD_ID,
-            ]);
-            expect(rows[0].scryfall_id).toBe(MIGRATION_CARD_SCRYFALL_ID);
-        });
-
-        it('does not overwrite an already-set scryfall_id', async () => {
-            await ds.query(
-                `UPDATE card SET scryfall_id = 'preset-value-not-derived' WHERE id = $1`,
-                [MIGRATION_CARD_ID]
-            );
-
-            await ds.query(migrationSql);
-
-            const rows = await ds.query('SELECT scryfall_id FROM card WHERE id = $1', [
-                MIGRATION_CARD_ID,
-            ]);
-            expect(rows[0].scryfall_id).toBe('preset-value-not-derived');
-        });
-    });
-
     describe('unique index semantics', () => {
         beforeEach(async () => {
             await deleteTestCards();
-            await insertCard(MIGRATION_CARD_ID, MIGRATION_CARD_IMG_SRC, '901');
-            await insertCard(JUNK_CARD_ID, JUNK_CARD_IMG_SRC, '902');
+            await insertCard(CARD_ID, '901');
+            await insertCard(JUNK_CARD_ID, '902');
         });
 
         it('allows multiple NULL scryfall_ids (seed/junk cards coexist)', async () => {
@@ -147,13 +102,13 @@ describe('Migration 036: card.scryfall_id + granular qty (e2e)', () => {
 
         it('rejects a duplicate scryfall_id', async () => {
             await ds.query('UPDATE card SET scryfall_id = $1 WHERE id = $2', [
-                MIGRATION_CARD_SCRYFALL_ID,
-                MIGRATION_CARD_ID,
+                CARD_SCRYFALL_ID,
+                CARD_ID,
             ]);
 
             await expect(
                 ds.query('UPDATE card SET scryfall_id = $1 WHERE id = $2', [
-                    MIGRATION_CARD_SCRYFALL_ID,
+                    CARD_SCRYFALL_ID,
                     JUNK_CARD_ID,
                 ])
             ).rejects.toThrow(/duplicate key|unique/i);

--- a/test/integration/seed.sql
+++ b/test/integration/seed.sql
@@ -7,12 +7,14 @@ VALUES ('tst', 4, 4, NULL, 'tst', 'Test Set', NULL, '2024-01-01', 'expansion', t
 ON CONFLICT (code) DO NOTHING;
 
 -- Test cards in the set
-INSERT INTO card (id, artist, has_foil, has_non_foil, img_src, is_reserved, mana_cost, name, number, oracle_text, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
+-- scryfall_id (not img_src) drives the card image now (6.8b): the web derives
+-- the path tail '{a}/{b}/{scryfall_id}.jpg' from it at read time.
+INSERT INTO card (id, artist, has_foil, has_non_foil, scryfall_id, is_reserved, mana_cost, name, number, oracle_text, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
 VALUES
-    ('00000000-0000-4000-a000-000000000001', 'Test Artist', true, true, 'https://example.com/card1.jpg', false, '{2}{W}', 'Test Angel', '1', 'Flying', 'rare', 'tst', 'Creature - Angel', 'normal', false, '001', true),
-    ('00000000-0000-4000-a000-000000000002', 'Test Artist', true, true, 'https://example.com/card2.jpg', false, '{1}{U}', 'Test Sphinx', '2', 'Draw a card.', 'uncommon', 'tst', 'Creature - Sphinx', 'normal', false, '002', true),
-    ('00000000-0000-4000-a000-000000000003', 'Test Artist', false, true, 'https://example.com/card3.jpg', false, '{B}', 'Test Zombie', '3', 'Deathtouch', 'common', 'tst', 'Creature - Zombie', 'normal', false, '003', true),
-    ('00000000-0000-4000-a000-000000000004', 'Test Artist', true, true, 'https://example.com/card4.jpg', false, '{R}', 'Test Dragon', '4', 'Haste', 'mythic', 'tst', 'Creature - Dragon', 'normal', false, '004', true)
+    ('00000000-0000-4000-a000-000000000001', 'Test Artist', true, true, '11111111-1111-4111-a111-111111111111', false, '{2}{W}', 'Test Angel', '1', 'Flying', 'rare', 'tst', 'Creature - Angel', 'normal', false, '001', true),
+    ('00000000-0000-4000-a000-000000000002', 'Test Artist', true, true, '22222222-2222-4222-a222-222222222222', false, '{1}{U}', 'Test Sphinx', '2', 'Draw a card.', 'uncommon', 'tst', 'Creature - Sphinx', 'normal', false, '002', true),
+    ('00000000-0000-4000-a000-000000000003', 'Test Artist', false, true, '33333333-3333-4333-a333-333333333333', false, '{B}', 'Test Zombie', '3', 'Deathtouch', 'common', 'tst', 'Creature - Zombie', 'normal', false, '003', true),
+    ('00000000-0000-4000-a000-000000000004', 'Test Artist', true, true, '44444444-4444-4444-a444-444444444444', false, '{R}', 'Test Dragon', '4', 'Haste', 'mythic', 'tst', 'Creature - Dragon', 'normal', false, '004', true)
 ON CONFLICT (id) DO NOTHING;
 
 -- Prices for test cards

--- a/test/shared/utils/scryfall-image.util.spec.ts
+++ b/test/shared/utils/scryfall-image.util.spec.ts
@@ -1,29 +1,19 @@
-import { buildScryfallImagePath, cardImageTail } from 'src/shared/utils/scryfall-image.util';
+import { buildScryfallImagePath } from 'src/shared/utils/scryfall-image.util';
 
 describe('scryfall-image.util', () => {
     const scryfallId = 'a363bc91-8278-448e-9d5c-564e4b51eb62';
-    // What scry stored in card.img_src for this id: {a}/{b}/{id}.jpg
+    // What scry once stored in card.img_src for this id: {a}/{b}/{id}.jpg
     const expectedTail = 'a/3/a363bc91-8278-448e-9d5c-564e4b51eb62.jpg';
 
     describe('buildScryfallImagePath', () => {
         it('builds {a}/{b}/{id}.jpg from the first two characters', () => {
             expect(buildScryfallImagePath(scryfallId)).toBe(expectedTail);
         });
-    });
 
-    describe('cardImageTail', () => {
-        it('derives from scryfallId, ignoring any stored imgSrc', () => {
-            expect(cardImageTail(scryfallId, 'stale/x/value.jpg')).toBe(expectedTail);
-        });
-
-        it('falls back to imgSrc when scryfallId is missing', () => {
-            expect(cardImageTail(undefined, 'a/b/legacy.jpg')).toBe('a/b/legacy.jpg');
-            expect(cardImageTail(null, 'a/b/legacy.jpg')).toBe('a/b/legacy.jpg');
-        });
-
-        it('returns an empty string when neither is available', () => {
-            expect(cardImageTail(undefined, undefined)).toBe('');
-            expect(cardImageTail(null, null)).toBe('');
+        it('returns an empty string when the id is missing', () => {
+            expect(buildScryfallImagePath(undefined)).toBe('');
+            expect(buildScryfallImagePath(null)).toBe('');
+            expect(buildScryfallImagePath('')).toBe('');
         });
     });
 });


### PR DESCRIPTION
Final step of the **6.8** card-image normalization sequence. Drops the denormalized `card.img_src` column; the image path is derived from `card.scryfall_id` at read time.

## Sequence recap
- **6.8a** (#525) — web derives the image tail from `scryfall_id`. ✅
- **6.8b step 1** (#526, migration `037`) — `img_src` made nullable. ✅
- **6.8b step 2** (scry #18, released **5.13.1**) — scry stops writing `img_src`. ✅
- **6.8b step 3 — this PR** (migration `038`) — drop the column.

## Changes
- `migrations/038_card_drop_img_src.sql`: `ALTER TABLE card DROP COLUMN IF EXISTS img_src`.
- **Guard migrations `036`/`037`** with column-existence `DO` blocks. `run_migrations.sh` is untracked and replays every `*.sql` on every deploy, so once `038` drops the column, `036`'s `img_src → scryfall_id` backfill and `037`'s `ALTER COLUMN img_src` must no-op cleanly. Behavior is unchanged while the column exists.
- `001_complete_schema.sql`: drop the column.
- `card.orm-entity` / `card.mapper` / `transaction.repository`: stop reading the column; derive `imgSrc` from `scryfall_id` via `buildScryfallImagePath`. The **external `imgSrc` field** (JSON API DTOs, MCP schemas, HBS) is unchanged — only its source.
- `scryfall-image.util`: drop the now-dead `cardImageTail` `img_src` fallback (every card has a `scryfall_id`); `buildScryfallImagePath` is null-safe.
- Integration `seed.sql` + specs: seed `scryfall_id` (not `img_src`); the card-image-schema e2e is refocused on the resulting invariants (incl. asserting `img_src` is dropped); `freemium-gates` card inserts no longer set `img_src`.

## json-ld note
The roadmap's 6.8 json-ld bullet was stale: the HBS `imgSrc` is already a full URL (`card.presenter.buildImgSrc`), so `schema.image` is already absolute. No change.

## Deploy safety
The migration runs **before** `setup-cron.sh` extracts `scry:latest` (5.13.1, the no-`img_src` binary), so the dropped column and a still-writing binary never coexist. Independent of scry PR #19 (cardsphere cleanup).

## Test
- Unit **1217**, frontend **101**, integration **243** green.
- `tsc --noEmit` clean; Prettier clean on changed files.

Closes #514.

🤖 Generated with [Claude Code](https://claude.com/claude-code)