### PR TITLE
feat: buy-list (want-list) entity + CRUD + page + bulk import (6.5)

### DIFF
--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -856,6 +856,27 @@ CREATE INDEX idx_price_notification_unread ON public.price_notification (user_id
 
 
 --
+-- Name: buy_list; Type: TABLE; Schema: public
+--
+
+CREATE TABLE public.buy_list (
+    user_id integer NOT NULL,
+    card_id character varying NOT NULL,
+    foil boolean NOT NULL DEFAULT false,
+    quantity integer NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    CONSTRAINT buy_list_pkey PRIMARY KEY (user_id, card_id, foil),
+    CONSTRAINT fk_buy_list_user FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_buy_list_card FOREIGN KEY (card_id)
+        REFERENCES public.card(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_buy_list_user_id ON public.buy_list (user_id);
+CREATE INDEX idx_buy_list_card_id ON public.buy_list (card_id);
+
+
+--
 -- Name: sealed_product; Type: TABLE; Schema: public
 --
 

--- a/migrations/039_buy_list.sql
+++ b/migrations/039_buy_list.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- Phase 6.5: per-user buy-list (want-list). A user's list of cards they intend
+-- to buy, used on its own (/buy-list) and by the cash-vs-store-credit optimizer
+-- (PR2): store credit applied against this list at retail.
+--
+-- Grain mirrors inventory exactly (card + finish + quantity, owned by a user),
+-- so the optimizer can price normal vs foil and match against inventory cleanly.
+-- Composite natural key (user_id, card_id, foil) — no surrogate id, like
+-- inventory. created_at orders the list newest-first.
+
+CREATE TABLE IF NOT EXISTS public.buy_list (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    card_id CHARACTER VARYING NOT NULL REFERENCES card(id) ON DELETE CASCADE,
+    foil BOOLEAN NOT NULL DEFAULT false,
+    quantity INTEGER NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, card_id, foil)
+);
+
+CREATE INDEX IF NOT EXISTS idx_buy_list_user_id ON buy_list (user_id);
+CREATE INDEX IF NOT EXISTS idx_buy_list_card_id ON buy_list (card_id);
+
+COMMIT;

--- a/src/core/buy-list/buy-list-item.entity.ts
+++ b/src/core/buy-list/buy-list-item.entity.ts
@@ -1,0 +1,27 @@
+import { Card } from 'src/core/card/card.entity';
+import { validateInit } from 'src/core/validation.util';
+
+/**
+ * A card a user intends to buy (Phase 6.5). Grain mirrors inventory exactly
+ * (card + finish + quantity, owned by a user) so the cash-vs-credit optimizer
+ * can price normal vs foil and match against inventory.
+ */
+export class BuyListItem {
+    readonly userId: number;
+    readonly cardId: string;
+    readonly isFoil: boolean;
+    readonly quantity: number;
+    // For read operations only
+    readonly createdAt?: Date;
+    readonly card?: Card;
+
+    constructor(init: Partial<BuyListItem>) {
+        validateInit(init, ['cardId', 'userId', 'isFoil', 'quantity']);
+        this.userId = init.userId;
+        this.cardId = init.cardId;
+        this.isFoil = init.isFoil;
+        this.quantity = init.quantity;
+        this.createdAt = init.createdAt;
+        this.card = init.card;
+    }
+}

--- a/src/core/buy-list/buy-list.module.ts
+++ b/src/core/buy-list/buy-list.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { ImportModule } from 'src/core/import/import.module';
+import { DatabaseModule } from 'src/database/database.module';
+import { getLogger } from 'src/logger/global-app-logger';
+import { BuyListService } from './buy-list.service';
+
+@Module({
+    imports: [DatabaseModule, ImportModule],
+    providers: [BuyListService],
+    exports: [BuyListService],
+})
+export class BuyListModule {
+    private readonly LOGGER = getLogger(BuyListModule.name);
+
+    constructor() {
+        this.LOGGER.log('Initialized');
+    }
+}

--- a/src/core/buy-list/buy-list.service.ts
+++ b/src/core/buy-list/buy-list.service.ts
@@ -1,0 +1,122 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { CardImportResolver } from 'src/core/import/card-import-resolver';
+import { MAX_IMPORT_ROWS } from 'src/core/import/import.constants';
+import { ImportError, ImportResult } from 'src/core/import/import.types';
+import { CardImportRow } from 'src/core/inventory/import/inventory-import.types';
+import { getLogger } from 'src/logger/global-app-logger';
+import { BuyListItem } from './buy-list-item.entity';
+import { BuyListRepositoryPort } from './ports/buy-list.repository.port';
+
+@Injectable()
+export class BuyListService {
+    private readonly LOGGER = getLogger(BuyListService.name);
+
+    constructor(
+        @Inject(BuyListRepositoryPort) private readonly repository: BuyListRepositoryPort,
+        @Inject(CardImportResolver) private readonly cardResolver: CardImportResolver
+    ) {}
+
+    /** All of a user's buy-list items (with card data), newest first. */
+    async list(userId: number): Promise<BuyListItem[]> {
+        this.LOGGER.debug(`list buy-list for user ${userId}.`);
+        return userId ? await this.repository.findByUser(userId) : [];
+    }
+
+    async count(userId: number): Promise<number> {
+        return userId ? await this.repository.countByUser(userId) : 0;
+    }
+
+    /** Add to the buy-list: increment the quantity, creating the row if absent. */
+    async add(userId: number, cardId: string, isFoil: boolean, quantity = 1): Promise<void> {
+        this.LOGGER.debug(`add ${quantity} of ${cardId} (foil=${isFoil}) for user ${userId}.`);
+        if (quantity <= 0) return;
+        await this.repository.increment(userId, cardId, isFoil, quantity);
+    }
+
+    /** Set the absolute quantity; quantity <= 0 removes the item. */
+    async setQuantity(
+        userId: number,
+        cardId: string,
+        isFoil: boolean,
+        quantity: number
+    ): Promise<void> {
+        this.LOGGER.debug(`setQuantity ${quantity} of ${cardId} (foil=${isFoil}) for ${userId}.`);
+        if (quantity <= 0) {
+            await this.repository.delete(userId, cardId, isFoil);
+            return;
+        }
+        await this.repository.save(new BuyListItem({ userId, cardId, isFoil, quantity }));
+    }
+
+    async remove(userId: number, cardId: string, isFoil: boolean): Promise<void> {
+        this.LOGGER.debug(`remove ${cardId} (foil=${isFoil}) for user ${userId}.`);
+        await this.repository.delete(userId, cardId, isFoil);
+    }
+
+    async clear(userId: number): Promise<void> {
+        this.LOGGER.debug(`clear buy-list for user ${userId}.`);
+        await this.repository.clear(userId);
+    }
+
+    /**
+     * Bulk-add parsed CSV rows. Resolves each via CardImportResolver (same
+     * identifier rules as inventory import: id, set_code+number, or
+     * name+set_code) and increments the quantity; unresolved rows are reported
+     * as errors. Row numbers are CSV line numbers (header is line 1).
+     */
+    async bulkAdd(rows: CardImportRow[], userId: number): Promise<ImportResult> {
+        this.LOGGER.debug(`bulkAdd ${rows.length} rows for user ${userId}.`);
+        const errors: ImportError[] = [];
+        let saved = 0;
+
+        const cappedRows = rows.slice(0, MAX_IMPORT_ROWS);
+        if (rows.length > MAX_IMPORT_ROWS) {
+            errors.push({
+                row: MAX_IMPORT_ROWS + 2,
+                error: `List exceeds ${MAX_IMPORT_ROWS} row limit; only first ${MAX_IMPORT_ROWS} processed`,
+            });
+        }
+
+        for (let i = 0; i < cappedRows.length; i++) {
+            const row = cappedRows[i];
+            const rowNum = i + 2;
+
+            const { card, error } = await this.cardResolver.resolveCard({
+                id: row.id,
+                name: row.name,
+                set_code: row.set_code,
+                set_name: row.set_name,
+                number: row.number,
+            });
+            if (error || !card) {
+                errors.push({ row: rowNum, name: row.name, error: error ?? 'Card not found' });
+                continue;
+            }
+
+            const isFoil = this.cardResolver.resolveFoil(row.foil, card);
+            if (isFoil === null) {
+                errors.push({
+                    row: rowNum,
+                    name: row.name ?? card.name,
+                    error: 'Card has no non-foil printing and foil=false was specified',
+                });
+                continue;
+            }
+
+            const qty = row.quantity ? parseInt(row.quantity, 10) : 1;
+            if (isNaN(qty) || qty < 1) {
+                errors.push({
+                    row: rowNum,
+                    name: row.name ?? card.name,
+                    error: 'Invalid quantity',
+                });
+                continue;
+            }
+
+            await this.repository.increment(userId, card.id, isFoil, qty);
+            saved++;
+        }
+
+        return { saved, skipped: 0, deleted: 0, errors };
+    }
+}

--- a/src/core/buy-list/ports/buy-list.repository.port.ts
+++ b/src/core/buy-list/ports/buy-list.repository.port.ts
@@ -1,0 +1,33 @@
+import { BuyListItem } from '../buy-list-item.entity';
+
+export const BuyListRepositoryPort = 'BuyListRepositoryPort';
+
+/**
+ * Persistence for the per-user buy-list (Phase 6.5). Natural key is
+ * (userId, cardId, isFoil) — one row per card+finish per user.
+ */
+export interface BuyListRepositoryPort {
+    /** All of a user's buy-list items, with card data, newest first. */
+    findByUser(userId: number): Promise<BuyListItem[]>;
+
+    /** A single item by its natural key, or null. */
+    findOne(userId: number, cardId: string, isFoil: boolean): Promise<BuyListItem | null>;
+
+    /** Set the absolute quantity, creating the row if absent. */
+    save(item: BuyListItem): Promise<BuyListItem>;
+
+    /**
+     * Atomically add `delta` to the quantity, creating the row at `delta` if
+     * absent (INSERT ... ON CONFLICT DO UPDATE). Returns the resulting quantity.
+     */
+    increment(userId: number, cardId: string, isFoil: boolean, delta: number): Promise<number>;
+
+    /** Remove one item. */
+    delete(userId: number, cardId: string, isFoil: boolean): Promise<void>;
+
+    /** Remove all of a user's items. */
+    clear(userId: number): Promise<void>;
+
+    /** Count of a user's items. */
+    countByUser(userId: number): Promise<number>;
+}

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -4,6 +4,7 @@ import { ApiTierModule } from './api-tier/api-tier.module';
 import { AuthModule } from './auth/auth.module';
 import { BillingModule } from './billing/billing.module';
 import { BlogModule } from './blog/blog.module';
+import { BuyListModule } from './buy-list/buy-list.module';
 import { CardModule } from './card/card.module';
 import { EmailModule } from './email/email.module';
 import { ImportModule } from './import/import.module';
@@ -23,6 +24,7 @@ import { UserModule } from './user/user.module';
         AuthModule,
         BillingModule,
         BlogModule,
+        BuyListModule,
         CardModule,
         EmailModule,
         ImportModule,
@@ -41,6 +43,7 @@ import { UserModule } from './user/user.module';
         AuthModule,
         BillingModule,
         BlogModule,
+        BuyListModule,
         CardModule,
         EmailModule,
         ImportModule,

--- a/src/database/buy-list/buy-list.mapper.ts
+++ b/src/database/buy-list/buy-list.mapper.ts
@@ -1,0 +1,25 @@
+import { BuyListItem } from 'src/core/buy-list/buy-list-item.entity';
+import { CardMapper } from 'src/database/card/card.mapper';
+import { BuyListOrmEntity } from './buy-list.orm-entity';
+
+export class BuyListMapper {
+    static toCore(orm: BuyListOrmEntity): BuyListItem {
+        return new BuyListItem({
+            userId: orm.userId,
+            cardId: orm.cardId,
+            isFoil: orm.isFoil,
+            quantity: orm.quantity,
+            createdAt: orm.createdAt,
+            card: orm.card ? CardMapper.toCore(orm.card) : undefined,
+        });
+    }
+
+    static toOrmEntity(item: BuyListItem): BuyListOrmEntity {
+        const orm = new BuyListOrmEntity();
+        orm.userId = item.userId;
+        orm.cardId = item.cardId;
+        orm.isFoil = item.isFoil;
+        orm.quantity = item.quantity;
+        return orm;
+    }
+}

--- a/src/database/buy-list/buy-list.orm-entity.ts
+++ b/src/database/buy-list/buy-list.orm-entity.ts
@@ -1,0 +1,37 @@
+import { CardOrmEntity } from 'src/database/card/card.orm-entity';
+import { UserOrmEntity } from 'src/database/user/user.orm-entity';
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+
+@Entity('buy_list')
+export class BuyListOrmEntity {
+    @PrimaryColumn({ name: 'user_id' })
+    userId: number;
+
+    @PrimaryColumn({ name: 'card_id' })
+    cardId: string;
+
+    @PrimaryColumn({ name: 'foil', type: 'boolean' })
+    isFoil: boolean;
+
+    @Column({ type: 'int', default: 1 })
+    quantity: number;
+
+    @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+    createdAt: Date;
+
+    @ManyToOne(() => CardOrmEntity, { onDelete: 'CASCADE' })
+    @JoinColumn({
+        name: 'card_id',
+        referencedColumnName: 'id',
+        foreignKeyConstraintName: 'fk_buy_list_card',
+    })
+    card: CardOrmEntity;
+
+    @ManyToOne(() => UserOrmEntity, { onDelete: 'CASCADE' })
+    @JoinColumn({
+        name: 'user_id',
+        referencedColumnName: 'id',
+        foreignKeyConstraintName: 'fk_buy_list_user',
+    })
+    user: UserOrmEntity;
+}

--- a/src/database/buy-list/buy-list.repository.ts
+++ b/src/database/buy-list/buy-list.repository.ts
@@ -18,8 +18,8 @@ export class BuyListRepository implements BuyListRepositoryPort {
 
     async findByUser(userId: number): Promise<BuyListItem[]> {
         this.LOGGER.debug(`findByUser ${userId}.`);
-        // Join the card, its latest price row (so the page shows prices), and
-        // its set (keyrune code), mirroring the inventory read.
+        // Join the card, its latest price row (for display + the 6.5 optimizer's
+        // retail total), and its set (keyrune code), mirroring the inventory read.
         const items = await this.repository
             .createQueryBuilder('bl')
             .leftJoinAndSelect('bl.card', 'card')

--- a/src/database/buy-list/buy-list.repository.ts
+++ b/src/database/buy-list/buy-list.repository.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { BuyListItem } from 'src/core/buy-list/buy-list-item.entity';
+import { BuyListRepositoryPort } from 'src/core/buy-list/ports/buy-list.repository.port';
+import { getLogger } from 'src/logger/global-app-logger';
+import { Repository } from 'typeorm';
+import { BuyListMapper } from './buy-list.mapper';
+import { BuyListOrmEntity } from './buy-list.orm-entity';
+
+@Injectable()
+export class BuyListRepository implements BuyListRepositoryPort {
+    private readonly LOGGER = getLogger(BuyListRepository.name);
+
+    constructor(
+        @InjectRepository(BuyListOrmEntity)
+        private readonly repository: Repository<BuyListOrmEntity>
+    ) {}
+
+    async findByUser(userId: number): Promise<BuyListItem[]> {
+        this.LOGGER.debug(`findByUser ${userId}.`);
+        const items = await this.repository.find({
+            where: { userId },
+            relations: { card: true },
+            order: { createdAt: 'DESC' },
+        });
+        return items.map((i) => BuyListMapper.toCore(i));
+    }
+
+    async findOne(userId: number, cardId: string, isFoil: boolean): Promise<BuyListItem | null> {
+        const item = await this.repository.findOne({ where: { userId, cardId, isFoil } });
+        return item ? BuyListMapper.toCore(item) : null;
+    }
+
+    async save(item: BuyListItem): Promise<BuyListItem> {
+        const saved = await this.repository.save(BuyListMapper.toOrmEntity(item));
+        return BuyListMapper.toCore(saved);
+    }
+
+    async increment(
+        userId: number,
+        cardId: string,
+        isFoil: boolean,
+        delta: number
+    ): Promise<number> {
+        const rows = await this.repository.query(
+            `INSERT INTO buy_list (user_id, card_id, foil, quantity)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (user_id, card_id, foil)
+             DO UPDATE SET quantity = buy_list.quantity + EXCLUDED.quantity
+             RETURNING quantity`,
+            [userId, cardId, isFoil, delta]
+        );
+        return Number(rows[0]?.quantity ?? delta);
+    }
+
+    async delete(userId: number, cardId: string, isFoil: boolean): Promise<void> {
+        await this.repository.delete({ userId, cardId, isFoil });
+    }
+
+    async clear(userId: number): Promise<void> {
+        await this.repository.delete({ userId });
+    }
+
+    async countByUser(userId: number): Promise<number> {
+        return await this.repository.count({ where: { userId } });
+    }
+}

--- a/src/database/buy-list/buy-list.repository.ts
+++ b/src/database/buy-list/buy-list.repository.ts
@@ -18,11 +18,20 @@ export class BuyListRepository implements BuyListRepositoryPort {
 
     async findByUser(userId: number): Promise<BuyListItem[]> {
         this.LOGGER.debug(`findByUser ${userId}.`);
-        const items = await this.repository.find({
-            where: { userId },
-            relations: { card: true },
-            order: { createdAt: 'DESC' },
-        });
+        // Join the card, its latest price row (so the page shows prices), and
+        // its set (keyrune code), mirroring the inventory read.
+        const items = await this.repository
+            .createQueryBuilder('bl')
+            .leftJoinAndSelect('bl.card', 'card')
+            .leftJoinAndSelect(
+                'card.prices',
+                'prices',
+                'prices.date = (SELECT MAX(p2.date) FROM price p2 WHERE p2.card_id = card.id)'
+            )
+            .leftJoinAndSelect('card.set', 'set')
+            .where('bl.userId = :userId', { userId })
+            .orderBy('bl.createdAt', 'DESC')
+            .getMany();
         return items.map((i) => BuyListMapper.toCore(i));
     }
 

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -4,6 +4,7 @@ import { CardRepositoryPort } from 'src/core/card/ports/card.repository.port';
 import { GranularPriceRepositoryPort } from 'src/core/card/ports/granular-price.repository.port';
 import { PriceHistoryRepositoryPort } from 'src/core/card/ports/price-history.repository.port';
 import { InventoryRepositoryPort } from 'src/core/inventory/ports/inventory.repository.port';
+import { BuyListRepositoryPort } from 'src/core/buy-list/ports/buy-list.repository.port';
 import { PasswordResetRepositoryPort } from 'src/core/password-reset/ports/password-reset.repository.port';
 import { SetPriceHistoryRepositoryPort } from 'src/core/set/ports/set-price-history.repository.port';
 import { SetRepositoryPort } from 'src/core/set/ports/set.repository.port';
@@ -23,6 +24,8 @@ import { CardRepository } from './card/card.repository';
 import { LegalityOrmEntity } from './card/legality.orm-entity';
 import { InventoryOrmEntity } from './inventory/inventory.orm-entity';
 import { InventoryRepository } from './inventory/inventory.repository';
+import { BuyListOrmEntity } from './buy-list/buy-list.orm-entity';
+import { BuyListRepository } from './buy-list/buy-list.repository';
 import { PasswordResetOrmEntity } from './password-reset/password-reset.orm-entity';
 import { PasswordResetRepository } from './password-reset/password-reset.repository';
 import { GranularPriceOrmEntity } from './granular-price/granular-price.orm-entity';
@@ -75,6 +78,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         TypeOrmModule.forFeature([
             CardOrmEntity,
             InventoryOrmEntity,
+            BuyListOrmEntity,
             LegalityOrmEntity,
             PasswordResetOrmEntity,
             GranularPriceOrmEntity,
@@ -106,6 +110,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         { provide: GranularPriceRepositoryPort, useClass: GranularPriceRepository },
         { provide: PriceHistoryRepositoryPort, useClass: PriceHistoryRepository },
         { provide: InventoryRepositoryPort, useClass: InventoryRepository },
+        { provide: BuyListRepositoryPort, useClass: BuyListRepository },
         { provide: PasswordResetRepositoryPort, useClass: PasswordResetRepository },
         { provide: SetPriceHistoryRepositoryPort, useClass: SetPriceHistoryRepository },
         { provide: SetRepositoryPort, useClass: SetRepository },
@@ -132,6 +137,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         GranularPriceRepositoryPort,
         PriceHistoryRepositoryPort,
         InventoryRepositoryPort,
+        BuyListRepositoryPort,
         PasswordResetRepositoryPort,
         SetPriceHistoryRepositoryPort,
         SetRepositoryPort,

--- a/src/http/api/api.module.ts
+++ b/src/http/api/api.module.ts
@@ -6,6 +6,7 @@ import { ApiKeyApiController } from './api-tier/api-key-api.controller';
 import { AuthApiController } from './auth/auth-api.controller';
 import { BillingApiController } from './billing/billing-api.controller';
 import { StripeWebhookController } from './billing/stripe-webhook.controller';
+import { BuyListApiController } from './buy-list/buy-list-api.controller';
 import { CardApiController } from './card/card-api.controller';
 import { InventoryApiController } from './inventory/inventory-api.controller';
 import { PortfolioApiController } from './portfolio/portfolio-api.controller';
@@ -29,6 +30,7 @@ import { RapidApiProxyGuard } from './shared/rapidapi-proxy.guard';
         AuthApiController,
         BillingApiController,
         StripeWebhookController,
+        BuyListApiController,
         CardApiController,
         InventoryApiController,
         PortfolioApiController,
@@ -51,11 +53,6 @@ import { RapidApiProxyGuard } from './shared/rapidapi-proxy.guard';
     // instances — sharing in-memory burst state and the per-key daily quota.
     // The two route guards pull in these deps transitively, so they must be
     // exported too for resolution in the importing module.
-    exports: [
-        OptionalAuthOrApiKeyGuard,
-        ApiRateLimitGuard,
-        ApiKeyAuthGuard,
-        RapidApiProxyGuard,
-    ],
+    exports: [OptionalAuthOrApiKeyGuard, ApiRateLimitGuard, ApiKeyAuthGuard, RapidApiProxyGuard],
 })
 export class ApiModule {}

--- a/src/http/api/buy-list/buy-list-api.controller.ts
+++ b/src/http/api/buy-list/buy-list-api.controller.ts
@@ -1,0 +1,120 @@
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Inject,
+    Patch,
+    Post,
+    Req,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { BuyListService } from 'src/core/buy-list/buy-list.service';
+import { parseCardImport } from 'src/core/import/parsers/card-import-dispatch';
+import { ApiResponseDto } from 'src/http/base/api-response.dto';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { JwtOrApiKeyGuard } from '../shared/jwt-or-api-key.guard';
+import { BuyListApiPresenter } from './buy-list-api.presenter';
+import {
+    BuyListAddApiDto,
+    BuyListImportApiDto,
+    BuyListRemoveApiDto,
+    BuyListSetQuantityApiDto,
+} from './dto/buy-list-request-api.dto';
+import { BuyListImportResponseDto, BuyListItemApiDto } from './dto/buy-list-response.dto';
+
+@ApiTags('Buy List')
+@ApiBearerAuth()
+@Controller('api/v1/buy-list')
+@UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
+export class BuyListApiController {
+    constructor(@Inject(BuyListService) private readonly buyListService: BuyListService) {}
+
+    @Get()
+    @ApiOperation({ summary: "List the authenticated user's buy-list" })
+    @ApiResponse({ status: 200, description: 'Buy-list items' })
+    async list(@Req() req: AuthenticatedRequest): Promise<ApiResponseDto<BuyListItemApiDto[]>> {
+        const items = await this.buyListService.list(req.user.id);
+        return ApiResponseDto.ok(items.map((i) => BuyListApiPresenter.toItem(i)));
+    }
+
+    @Post()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Add a card to the buy-list (increments quantity)' })
+    @ApiResponse({ status: 200, description: 'Added' })
+    async add(
+        @Body() dto: BuyListAddApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ added: boolean }>> {
+        await this.buyListService.add(
+            req.user.id,
+            dto.cardId,
+            dto.isFoil ?? false,
+            dto.quantity ?? 1
+        );
+        return ApiResponseDto.ok({ added: true });
+    }
+
+    @Patch()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Set the absolute quantity for a buy-list item (0 removes it)' })
+    @ApiResponse({ status: 200, description: 'Updated' })
+    async setQuantity(
+        @Body() dto: BuyListSetQuantityApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ updated: boolean }>> {
+        await this.buyListService.setQuantity(req.user.id, dto.cardId, dto.isFoil, dto.quantity);
+        return ApiResponseDto.ok({ updated: true });
+    }
+
+    @Delete()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Remove a card from the buy-list' })
+    @ApiResponse({ status: 200, description: 'Removed' })
+    async remove(
+        @Body() dto: BuyListRemoveApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ deleted: boolean }>> {
+        await this.buyListService.remove(req.user.id, dto.cardId, dto.isFoil);
+        return ApiResponseDto.ok({ deleted: true });
+    }
+
+    @Post('import')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Bulk-add cards to the buy-list from pasted CSV text',
+        description:
+            'Paste CSV rows with a header (name,set_code,number[,quantity][,foil]) — the same ' +
+            'native format as inventory import; external exports (Moxfield, Archidekt, Deckbox, ' +
+            'TCGPlayer) are auto-detected. Returns counts and per-row errors.',
+    })
+    @ApiResponse({ status: 200, description: 'Import result', type: BuyListImportResponseDto })
+    @ApiResponse({ status: 400, description: 'Invalid CSV text' })
+    async import(
+        @Body() dto: BuyListImportApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<BuyListImportResponseDto>> {
+        let rows: ReturnType<typeof parseCardImport>['rows'];
+        try {
+            ({ rows } = parseCardImport(Buffer.from(dto.text ?? '')));
+        } catch (err) {
+            throw new BadRequestException(err instanceof Error ? err.message : 'Invalid CSV text');
+        }
+        const result = await this.buyListService.bulkAdd(rows, req.user.id);
+        return ApiResponseDto.ok(
+            new BuyListImportResponseDto({
+                saved: result.saved,
+                errors: result.errors.map((e) => ({
+                    row: e.row,
+                    name: typeof e.name === 'string' ? e.name : undefined,
+                    error: e.error,
+                })),
+            })
+        );
+    }
+}

--- a/src/http/api/buy-list/buy-list-api.presenter.ts
+++ b/src/http/api/buy-list/buy-list-api.presenter.ts
@@ -1,0 +1,29 @@
+import { BuyListItem } from 'src/core/buy-list/buy-list-item.entity';
+import { BASE_IMAGE_URL, buildCardUrl } from 'src/http/base/http.util';
+import { BuyListItemApiDto } from './dto/buy-list-response.dto';
+
+export class BuyListApiPresenter {
+    static toItem(item: BuyListItem): BuyListItemApiDto {
+        if (!item.card) {
+            return { cardId: item.cardId, quantity: item.quantity, isFoil: item.isFoil };
+        }
+        const card = item.card;
+        const price = card.prices?.[0];
+        return {
+            cardId: item.cardId,
+            quantity: item.quantity,
+            isFoil: item.isFoil,
+            cardName: card.name,
+            setCode: card.setCode,
+            cardNumber: card.number,
+            imgSrc: `${BASE_IMAGE_URL}/normal/front/${card.imgSrc}`,
+            rarity: card.rarity?.toLowerCase(),
+            keyruneCode: card.set?.keyruneCode ?? card.setCode,
+            priceNormal: price?.normal != null ? Number(price.normal) : null,
+            priceFoil: price?.foil != null ? Number(price.foil) : null,
+            hasNonFoil: card.hasNonFoil,
+            hasFoil: card.hasFoil,
+            url: buildCardUrl(card.setCode, card.number),
+        };
+    }
+}

--- a/src/http/api/buy-list/dto/buy-list-request-api.dto.ts
+++ b/src/http/api/buy-list/dto/buy-list-request-api.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+/** Add to the buy-list: increments the quantity for (card, finish). */
+export class BuyListAddApiDto {
+    @ApiProperty()
+    @IsUUID()
+    readonly cardId: string;
+
+    @ApiPropertyOptional({ default: false })
+    @IsOptional()
+    @IsBoolean()
+    readonly isFoil?: boolean;
+
+    @ApiPropertyOptional({ default: 1, minimum: 1 })
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    readonly quantity?: number;
+}
+
+/** Set the absolute quantity for (card, finish); 0 removes it. */
+export class BuyListSetQuantityApiDto {
+    @ApiProperty()
+    @IsUUID()
+    readonly cardId: string;
+
+    @ApiProperty({ default: false })
+    @IsBoolean()
+    readonly isFoil: boolean;
+
+    @ApiProperty({ minimum: 0 })
+    @IsInt()
+    @Min(0)
+    readonly quantity: number;
+}
+
+export class BuyListRemoveApiDto {
+    @ApiProperty()
+    @IsUUID()
+    readonly cardId: string;
+
+    @ApiProperty({ default: false })
+    @IsBoolean()
+    readonly isFoil: boolean;
+}
+
+/** Bulk paste: CSV rows with a header (name,set_code,number[,quantity][,foil]). */
+export class BuyListImportApiDto {
+    @ApiProperty({
+        description:
+            'Pasted CSV with a header row (native: name,set_code,number,quantity,foil). ' +
+            'External exports (Moxfield, Archidekt, Deckbox, TCGPlayer) are auto-detected.',
+    })
+    @IsString()
+    readonly text: string;
+}

--- a/src/http/api/buy-list/dto/buy-list-response.dto.ts
+++ b/src/http/api/buy-list/dto/buy-list-response.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class BuyListItemApiDto {
+    @ApiProperty()
+    readonly cardId: string;
+
+    @ApiProperty()
+    readonly quantity: number;
+
+    @ApiProperty()
+    readonly isFoil: boolean;
+
+    @ApiPropertyOptional()
+    readonly cardName?: string;
+
+    @ApiPropertyOptional()
+    readonly setCode?: string;
+
+    @ApiPropertyOptional()
+    readonly cardNumber?: string;
+
+    @ApiPropertyOptional()
+    readonly imgSrc?: string;
+
+    @ApiPropertyOptional()
+    readonly rarity?: string;
+
+    @ApiPropertyOptional()
+    readonly keyruneCode?: string;
+
+    @ApiPropertyOptional()
+    readonly priceNormal?: number | null;
+
+    @ApiPropertyOptional()
+    readonly priceFoil?: number | null;
+
+    @ApiPropertyOptional()
+    readonly hasNonFoil?: boolean;
+
+    @ApiPropertyOptional()
+    readonly hasFoil?: boolean;
+
+    @ApiPropertyOptional()
+    readonly url?: string;
+}
+
+export class BuyListImportResponseDto {
+    @ApiProperty()
+    readonly saved: number;
+
+    @ApiProperty()
+    readonly errors: Array<{ row: number; name?: string; error: string }>;
+
+    constructor(init: BuyListImportResponseDto) {
+        this.saved = init.saved;
+        this.errors = init.errors;
+    }
+}

--- a/src/http/hbs/buy-list/buy-list-page.controller.ts
+++ b/src/http/hbs/buy-list/buy-list-page.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Inject, Render, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { BuyListViewDto } from './dto/buy-list.view.dto';
+import { BuyListPageOrchestrator } from './buy-list-page.orchestrator';
+
+@Controller('buy-list')
+export class BuyListPageController {
+    constructor(
+        @Inject(BuyListPageOrchestrator) private readonly orchestrator: BuyListPageOrchestrator
+    ) {}
+
+    @UseGuards(JwtAuthGuard)
+    @Get()
+    @Render('buyList')
+    async list(@Req() req: AuthenticatedRequest): Promise<BuyListViewDto> {
+        return await this.orchestrator.buildListView(req);
+    }
+}

--- a/src/http/hbs/buy-list/buy-list-page.orchestrator.ts
+++ b/src/http/hbs/buy-list/buy-list-page.orchestrator.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { BuyListService } from 'src/core/buy-list/buy-list.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { HttpErrorHandler } from 'src/http/http.error.handler';
+import { getLogger } from 'src/logger/global-app-logger';
+import { BuyListViewDto } from './dto/buy-list.view.dto';
+
+@Injectable()
+export class BuyListPageOrchestrator {
+    private readonly LOGGER = getLogger(BuyListPageOrchestrator.name);
+
+    constructor(@Inject(BuyListService) private readonly buyListService: BuyListService) {
+        this.LOGGER.debug('Initialized');
+    }
+
+    async buildListView(req: AuthenticatedRequest): Promise<BuyListViewDto> {
+        try {
+            HttpErrorHandler.validateAuthenticatedRequest(req);
+            const count = await this.buyListService.count(req.user.id);
+
+            return new BuyListViewDto({
+                authenticated: true,
+                hasItems: count > 0,
+                title: 'Buy List - I Want My MTG',
+                breadcrumbs: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Buy List', url: '/buy-list' },
+                ],
+            });
+        } catch (error) {
+            this.LOGGER.debug(`Error building buy-list view: ${error?.message}`);
+            return HttpErrorHandler.toHttpException(error, 'buildListView');
+        }
+    }
+}

--- a/src/http/hbs/buy-list/dto/buy-list.view.dto.ts
+++ b/src/http/hbs/buy-list/dto/buy-list.view.dto.ts
@@ -1,0 +1,10 @@
+import { BaseViewDto } from 'src/http/base/base.view.dto';
+
+export class BuyListViewDto extends BaseViewDto {
+    readonly hasItems: boolean;
+
+    constructor(init: Partial<BuyListViewDto>) {
+        super(init);
+        this.hasItems = init.hasItems || false;
+    }
+}

--- a/src/http/hbs/hbs.module.ts
+++ b/src/http/hbs/hbs.module.ts
@@ -9,6 +9,8 @@ import { AuthOrchestrator } from './auth/auth.orchestrator';
 import { BillingController } from './billing/billing.controller';
 import { BillingOrchestrator } from './billing/billing.orchestrator';
 import { BlogController } from './blog/blog.controller';
+import { BuyListPageController } from './buy-list/buy-list-page.controller';
+import { BuyListPageOrchestrator } from './buy-list/buy-list-page.orchestrator';
 import { PricingController } from './billing/pricing.controller';
 import { PricingOrchestrator } from './billing/pricing.orchestrator';
 import { SubscriptionViewInterceptor } from './shared/subscription-view.interceptor';
@@ -46,6 +48,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         BillingController,
         PricingController,
         BlogController,
+        BuyListPageController,
         CardController,
         HomeController,
         InventoryController,
@@ -66,6 +69,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         BillingOrchestrator,
         PricingOrchestrator,
         { provide: APP_INTERCEPTOR, useClass: SubscriptionViewInterceptor },
+        BuyListPageOrchestrator,
         CardOrchestrator,
         InventoryOrchestrator,
         NotificationPageOrchestrator,
@@ -81,6 +85,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         AuthOrchestrator,
         BillingOrchestrator,
         PricingOrchestrator,
+        BuyListPageOrchestrator,
         CardOrchestrator,
         InventoryOrchestrator,
         NotificationPageOrchestrator,

--- a/src/http/public/js/buyList.js
+++ b/src/http/public/js/buyList.js
@@ -1,0 +1,167 @@
+/**
+ * Buy-list page (Phase 6.5). Fetches the user's buy-list from
+ * /api/v1/buy-list and renders editable rows (quantity stepper + remove),
+ * plus a bulk-paste import. Mutations go back through the JSON API.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    var container = document.getElementById('buy-list-ajax');
+    if (!container) return;
+
+    var API = '/api/v1/buy-list';
+
+    function jsonHeaders() {
+        return { 'Content-Type': 'application/json' };
+    }
+
+    function load() {
+        AjaxUtils.showSpinner(container);
+        AjaxUtils.fetchWithGate(API, { headers: { Accept: 'application/json' } })
+            .then(function (res) {
+                if (res.gated) return;
+                if (!res.ok || !res.body || !res.body.data) {
+                    AjaxUtils.showError(container, 'Failed to load your buy list.');
+                    return;
+                }
+                render(res.body.data);
+            })
+            .catch(function () {
+                AjaxUtils.showError(container, 'Failed to load your buy list.');
+            });
+    }
+
+    function render(items) {
+        if (!items || items.length === 0) {
+            container.innerHTML =
+                '<div class="text-center py-16">' +
+                '<i class="fas fa-cart-plus text-5xl text-teal-300 dark:text-teal-600 mb-4" aria-hidden="true"></i>' +
+                '<h3 class="page-title mt-4">Your buy list is empty</h3>' +
+                '<p class="text-gray-500 dark:text-gray-400 mt-2 max-w-md mx-auto">' +
+                'Add cards from any card page, or paste a list above.</p>' +
+                '<div class="flex justify-center gap-2 mt-6"><a href="/sets" class="btn btn-primary">Browse Sets</a></div>' +
+                '</div>';
+            return;
+        }
+
+        var rows = items.map(renderRow).join('');
+        container.innerHTML =
+            '<table class="w-full text-sm"><thead><tr class="text-left text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-midnight-700">' +
+            '<th class="py-2">Card</th><th class="py-2">Finish</th><th class="py-2">Price</th>' +
+            '<th class="py-2">Qty</th><th class="py-2"></th></tr></thead><tbody>' +
+            rows +
+            '</tbody></table>';
+    }
+
+    function renderRow(item) {
+        var price = item.isFoil ? item.priceFoil : item.priceNormal;
+        var name = AjaxUtils.escapeHtml(item.cardName || item.cardId);
+        var link = item.url
+            ? '<a href="' +
+              item.url +
+              '" class="text-teal-600 dark:text-teal-400 hover:underline">' +
+              name +
+              '</a>'
+            : name;
+        return (
+            '<tr data-card-id="' +
+            item.cardId +
+            '" data-foil="' +
+            item.isFoil +
+            '" ' +
+            'class="border-b border-gray-100 dark:border-midnight-800">' +
+            '<td class="py-2">' +
+            link +
+            '<span class="text-gray-400 ml-1">' +
+            AjaxUtils.escapeHtml((item.setCode || '').toUpperCase()) +
+            '</span></td>' +
+            '<td class="py-2">' +
+            (item.isFoil ? 'Foil' : 'Normal') +
+            '</td>' +
+            '<td class="py-2">' +
+            (price != null ? AjaxUtils.toDollar(price) : '&mdash;') +
+            '</td>' +
+            '<td class="py-2"><div class="inline-flex items-center gap-2">' +
+            '<button type="button" class="btn-qty bl-dec" aria-label="Decrease quantity">&minus;</button>' +
+            '<span class="bl-qty w-8 text-center inline-block">' +
+            item.quantity +
+            '</span>' +
+            '<button type="button" class="btn-qty bl-inc" aria-label="Increase quantity">+</button>' +
+            '</div></td>' +
+            '<td class="py-2 text-right"><button type="button" class="bl-remove text-red-500 hover:text-red-700" aria-label="Remove">' +
+            '<i class="fas fa-trash" aria-hidden="true"></i></button></td>' +
+            '</tr>'
+        );
+    }
+
+    function setQuantity(cardId, isFoil, quantity) {
+        return AjaxUtils.fetchWithGate(API, {
+            method: 'PATCH',
+            headers: jsonHeaders(),
+            body: JSON.stringify({ cardId: cardId, isFoil: isFoil, quantity: quantity }),
+        }).then(function (res) {
+            if (!res.ok && !res.gated) throw new Error('update failed');
+            load();
+        });
+    }
+
+    function removeItem(cardId, isFoil) {
+        return AjaxUtils.fetchWithGate(API, {
+            method: 'DELETE',
+            headers: jsonHeaders(),
+            body: JSON.stringify({ cardId: cardId, isFoil: isFoil }),
+        }).then(function (res) {
+            if (!res.ok && !res.gated) throw new Error('remove failed');
+            load();
+        });
+    }
+
+    container.addEventListener('click', function (e) {
+        var row = e.target.closest('tr[data-card-id]');
+        if (!row) return;
+        var cardId = row.getAttribute('data-card-id');
+        var isFoil = row.getAttribute('data-foil') === 'true';
+        var qty = parseInt(row.querySelector('.bl-qty').textContent, 10) || 1;
+
+        if (e.target.closest('.bl-inc')) setQuantity(cardId, isFoil, qty + 1);
+        else if (e.target.closest('.bl-dec')) setQuantity(cardId, isFoil, qty - 1);
+        else if (e.target.closest('.bl-remove')) removeItem(cardId, isFoil);
+    });
+
+    // Bulk paste import
+    var importBtn = document.getElementById('buy-list-import-btn');
+    var importText = document.getElementById('buy-list-import-text');
+    var importResult = document.getElementById('buy-list-import-result');
+    if (importBtn && importText) {
+        importBtn.addEventListener('click', function () {
+            var text = importText.value.trim();
+            if (!text) return;
+            importBtn.disabled = true;
+            AjaxUtils.fetchWithGate(API + '/import', {
+                method: 'POST',
+                headers: jsonHeaders(),
+                body: JSON.stringify({ text: text }),
+            })
+                .then(function (res) {
+                    importBtn.disabled = false;
+                    if (res.gated) return;
+                    if (!res.ok || !res.body || !res.body.data) {
+                        if (importResult) importResult.textContent = 'Import failed.';
+                        return;
+                    }
+                    var d = res.body.data;
+                    var msg = 'Added ' + d.saved + ' card' + (d.saved === 1 ? '' : 's') + '.';
+                    if (d.errors && d.errors.length) {
+                        msg += ' ' + d.errors.length + ' could not be matched.';
+                    }
+                    if (importResult) importResult.textContent = msg;
+                    importText.value = '';
+                    load();
+                })
+                .catch(function () {
+                    importBtn.disabled = false;
+                    if (importResult) importResult.textContent = 'Import failed.';
+                });
+        });
+    }
+
+    load();
+});

--- a/src/http/public/js/buyListAdd.js
+++ b/src/http/public/js/buyListAdd.js
@@ -1,0 +1,41 @@
+/**
+ * "Add to buy list" control (Phase 6.5). Used on the card page: POSTs the
+ * card + chosen finish to /api/v1/buy-list (increments quantity). Finish comes
+ * from the optional Normal/Foil select, else the card's only available finish.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    var btn = document.getElementById('buy-list-add-btn');
+    if (!btn || typeof AjaxUtils === 'undefined') return;
+    var result = document.getElementById('buy-list-add-result');
+    var finishSelect = document.getElementById('buy-list-finish');
+
+    function chosenFoil() {
+        if (finishSelect) return finishSelect.value === 'true';
+        // Single-finish card: foil only when it has no normal printing.
+        return btn.getAttribute('data-has-normal') !== 'true';
+    }
+
+    btn.addEventListener('click', function () {
+        var cardId = btn.getAttribute('data-card-id');
+        if (!cardId) return;
+        btn.disabled = true;
+        AjaxUtils.fetchWithGate('/api/v1/buy-list', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cardId: cardId, isFoil: chosenFoil(), quantity: 1 }),
+        })
+            .then(function (res) {
+                btn.disabled = false;
+                if (res.gated) return;
+                if (!res.ok) {
+                    if (result) result.textContent = 'Could not add.';
+                    return;
+                }
+                if (result) result.textContent = 'Added to your buy list.';
+            })
+            .catch(function () {
+                btn.disabled = false;
+                if (result) result.textContent = 'Could not add.';
+            });
+    });
+});

--- a/src/http/views/buyList.hbs
+++ b/src/http/views/buyList.hbs
@@ -1,0 +1,42 @@
+<section class="border border-gray-200 dark:border-midnight-700 rounded-xl sm:m-0 md:m-4">
+    <section class="text-center bg-teal-50 dark:bg-midnight-900 mb-4 rounded-t-lg py-4">
+        <h1 class="page-title">Buy List</h1>
+        <p class="text-gray-500 dark:text-gray-400 text-sm mt-1 max-w-md mx-auto">
+            Track cards you want to buy. Used by the cash-vs-store-credit planner to show
+            whether a store-credit offer is worth more than cash for your list.
+        </p>
+    </section>
+
+    <div class="content-wrapper">
+        {{!-- Bulk paste import --}}
+        <details class="mb-4 border border-gray-200 dark:border-midnight-700 rounded-lg">
+            <summary class="cursor-pointer px-4 py-3 font-medium">
+                <i class="fas fa-paste mr-2" aria-hidden="true"></i>Add cards in bulk
+            </summary>
+            <div class="px-4 pb-4">
+                <label for="buy-list-import-text" class="block text-sm text-gray-500 dark:text-gray-400 mb-2">
+                    Paste CSV rows with a header &mdash; <code>name,set_code,number,quantity</code>
+                    (the same format as <a href="/guides/getting-started" class="text-teal-600 dark:text-teal-400 hover:underline">inventory import</a>).
+                    Moxfield, Archidekt, Deckbox, and TCGPlayer exports are auto-detected.
+                </label>
+                <textarea id="buy-list-import-text" rows="6"
+                    class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 p-2 text-sm font-mono"
+                    placeholder="name,set_code,number,quantity&#10;Sol Ring,cmd,220,2&#10;Counterspell,mh2,267,1"></textarea>
+                <div class="flex items-center gap-3 mt-2">
+                    <button id="buy-list-import-btn" type="button" class="btn btn-primary">Add to buy list</button>
+                    <span id="buy-list-import-result" class="text-sm" role="status" aria-live="polite"></span>
+                </div>
+            </div>
+        </details>
+
+        {{!-- Client-rendered list (buyList.js fetches /api/v1/buy-list) --}}
+        <div id="buy-list-ajax" data-has-items="{{hasItems}}">
+            <div class="text-center py-16">
+                <i class="fas fa-spinner fa-spin text-4xl text-teal-500" aria-hidden="true"></i>
+            </div>
+        </div>
+    </div>
+</section>
+
+<script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>
+<script src="/public/js/buyList.js?v={{assetVersion}}" defer></script>

--- a/src/http/views/card.hbs
+++ b/src/http/views/card.hbs
@@ -178,6 +178,23 @@
                 {{>transactionForm}}
                 {{>priceAlertForm}}
 
+                {{#if authenticated}}
+                <div class="mt-3 flex items-center gap-2" id="buy-list-add">
+                    {{#if card.hasNormal}}{{#if card.hasFoil}}
+                    <select id="buy-list-finish" class="rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 text-sm py-1.5" aria-label="Finish to add to buy list">
+                        <option value="false">Normal</option>
+                        <option value="true">Foil</option>
+                    </select>
+                    {{/if}}{{/if}}
+                    <button type="button" id="buy-list-add-btn" class="btn btn-secondary btn--sm"
+                            data-card-id="{{card.cardId}}"
+                            data-has-foil="{{card.hasFoil}}" data-has-normal="{{card.hasNormal}}">
+                        <i class="fas fa-cart-plus mr-1" aria-hidden="true"></i> Add to buy list
+                    </button>
+                    <span id="buy-list-add-result" class="text-sm text-teal-600 dark:text-teal-400" role="status" aria-live="polite"></span>
+                </div>
+                {{/if}}
+
                 <div class="mt-4" id="price-history-chart" data-card-id="{{card.cardId}}" data-chart-src="/public/js/priceHistoryChart.js?v={{assetVersion}}">
                     <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
                         <h3 class="text-sm font-semibold text-gray-700 dark:text-gray-300">Price History</h3>
@@ -243,6 +260,8 @@
 </section>
 
 
+<script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>
+<script src="/public/js/buyListAdd.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/updateInventory.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/chartLoader.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/transactionForm.js?v={{assetVersion}}" defer></script>

--- a/src/http/views/partials/navbar.hbs
+++ b/src/http/views/partials/navbar.hbs
@@ -178,37 +178,37 @@
 
     {{#if authenticated}}
         <div class="iwm-drawer-section-label">My Collection</div>
-        <a href="/inventory"     class="iwm-drawer-link">
+        <a href="/inventory" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="1" y="4" width="6" height="5" rx="0.5"/><rect x="9" y="4" width="6" height="5" rx="0.5"/><rect x="1" y="11" width="6" height="4" rx="0.5"/><rect x="9" y="11" width="6" height="4" rx="0.5"/></svg>
             My Inventory
         </a>
-        <a href="/portfolio"     class="iwm-drawer-link">
+        <a href="/portfolio" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 12l3-4 3 2 3-5 3 3" stroke-linecap="round" stroke-linejoin="round"/></svg>
             Portfolio
         </a>
-        <a href="/transactions"  class="iwm-drawer-link">
+        <a href="/transactions" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 5h12M2 8h7M2 11h4" stroke-linecap="round"/></svg>
             Transactions
         </a>
-        <a href="/price-alerts"  class="iwm-drawer-link">
+        <a href="/price-alerts" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 2a4.5 4.5 0 00-4.5 4.5c0 2-1 2.5-1 2.5h11s-1-.5-1-2.5A4.5 4.5 0 008 2zM7 13h2" stroke-linecap="round"/></svg>
             Price Alerts
         </a>
-        <a href="/buy-list"  class="iwm-drawer-link">
+        <a href="/buy-list" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 2h2l1.5 8.5h7L14 5H5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.5" cy="13.5" r="1"/><circle cx="12.5" cy="13.5" r="1"/></svg>
             Buy List
         </a>
 
         <div class="iwm-drawer-section-label">Explore</div>
-        <a href="/sets"     class="iwm-drawer-link">
+        <a href="/sets" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="2" y="3" width="12" height="10" rx="1"/><path d="M5 3V2h6v1"/></svg>
             Sets
         </a>
-        <a href="/spoilers"  class="iwm-drawer-link">
+        <a href="/spoilers" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="8" cy="8" r="6"/><path d="M8 5.5v3M8 10.5v.2" stroke-linecap="round"/></svg>
             Spoilers
         </a>
-        <a href="/blog"      class="iwm-drawer-link">
+        <a href="/blog" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M3 2h7l3 3v9a1 1 0 01-1 1H3a1 1 0 01-1-1V3a1 1 0 011-1z"/><path d="M10 2v3h3M5 8h6M5 10.5h6M5 13h4" stroke-linecap="round"/></svg>
             Blog
         </a>
@@ -228,7 +228,7 @@
         {{/if}}
 
         <div class="iwm-drawer-section-label">Account</div>
-        <a href="/user"    class="iwm-drawer-link">
+        <a href="/user" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="8" cy="5" r="2.5"/><path d="M2.5 14c0-3 2.4-5 5.5-5s5.5 2 5.5 5" stroke-linecap="round"/></svg>
             My Account
         </a>
@@ -253,30 +253,30 @@
     {{else}}
 
         <div class="iwm-drawer-section-label">Explore</div>
-        <a href="/"        class="iwm-drawer-link">
+        <a href="/" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M1 6l7-5 7 5v8H10V9H6v5H1z" stroke-linejoin="round"/></svg>
             Home
         </a>
-        <a href="/sets"     class="iwm-drawer-link">
+        <a href="/sets" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="2" y="3" width="12" height="10" rx="1"/><path d="M5 3V2h6v1"/></svg>
             Sets
         </a>
-        <a href="/spoilers"  class="iwm-drawer-link">
+        <a href="/spoilers" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="8" cy="8" r="6"/><path d="M8 5.5v3M8 10.5v.2" stroke-linecap="round"/></svg>
             Spoilers
         </a>
-        <a href="/pricing"   class="iwm-drawer-link">
+        <a href="/pricing" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="8" cy="8" r="6"/><path d="M8 4.5v1m0 5v1M5.5 8h4" stroke-linecap="round"/></svg>
             Pricing
         </a>
-        <a href="/blog"      class="iwm-drawer-link">
+        <a href="/blog" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M3 2h7l3 3v9a1 1 0 01-1 1H3a1 1 0 01-1-1V3a1 1 0 011-1z"/><path d="M10 2v3h3M5 8h6M5 10.5h6M5 13h4" stroke-linecap="round"/></svg>
             Blog
         </a>
 
         <div class="iwm-drawer-divider"></div>
 
-        <a href="/auth/login"  class="iwm-drawer-link navbar-login-link">
+        <a href="/auth/login" class="iwm-drawer-link navbar-login-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M6 11l-4-3 4-3m-4 3h11m-4-7h3a1 1 0 011 1v10a1 1 0 01-1 1h-3" stroke-linecap="round"/></svg>
             Sign In
         </a>

--- a/src/http/views/partials/navbar.hbs
+++ b/src/http/views/partials/navbar.hbs
@@ -48,6 +48,10 @@
                             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 2a4.5 4.5 0 00-4.5 4.5c0 2-1 2.5-1 2.5h11s-1-.5-1-2.5A4.5 4.5 0 008 2zM7 13h2" stroke-linecap="round"/></svg>
                             Price Alerts
                         </a>
+                        <a href="/buy-list" class="iwm-dropdown-item" role="menuitem">
+                            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 2h2l1.5 8.5h7L14 5H5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.5" cy="13.5" r="1"/><circle cx="12.5" cy="13.5" r="1"/></svg>
+                            Buy List
+                        </a>
                     </div>
                 </div>
                 <a href="/sets" class="iwm-nav-link">
@@ -189,6 +193,10 @@
         <a href="/price-alerts"  class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 2a4.5 4.5 0 00-4.5 4.5c0 2-1 2.5-1 2.5h11s-1-.5-1-2.5A4.5 4.5 0 008 2zM7 13h2" stroke-linecap="round"/></svg>
             Price Alerts
+        </a>
+        <a href="/buy-list"  class="iwm-drawer-link">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 2h2l1.5 8.5h7L14 5H5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.5" cy="13.5" r="1"/><circle cx="12.5" cy="13.5" r="1"/></svg>
+            Buy List
         </a>
 
         <div class="iwm-drawer-section-label">Explore</div>

--- a/test/core/buy-list/buy-list.service.spec.ts
+++ b/test/core/buy-list/buy-list.service.spec.ts
@@ -1,0 +1,139 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BuyListService } from 'src/core/buy-list/buy-list.service';
+import { BuyListRepositoryPort } from 'src/core/buy-list/ports/buy-list.repository.port';
+import { Card } from 'src/core/card/card.entity';
+import { CardImportResolver } from 'src/core/import/card-import-resolver';
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+    return new Card({
+        id: 'card-1',
+        imgSrc: 'a/b/card-1.jpg',
+        name: 'Sol Ring',
+        number: '1',
+        rarity: 'uncommon' as Card['rarity'],
+        setCode: 'cmd',
+        sortNumber: '1',
+        type: 'Artifact',
+        legalities: [],
+        hasFoil: true,
+        hasNonFoil: true,
+        ...overrides,
+    });
+}
+
+describe('BuyListService', () => {
+    let service: BuyListService;
+    let repo: jest.Mocked<BuyListRepositoryPort>;
+    let resolver: jest.Mocked<Pick<CardImportResolver, 'resolveCard' | 'resolveFoil'>>;
+
+    const mockRepo = {
+        findByUser: jest.fn(),
+        findOne: jest.fn(),
+        save: jest.fn(),
+        increment: jest.fn(),
+        delete: jest.fn(),
+        clear: jest.fn(),
+        countByUser: jest.fn(),
+    };
+    const mockResolver = { resolveCard: jest.fn(), resolveFoil: jest.fn() };
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BuyListService,
+                { provide: BuyListRepositoryPort, useValue: mockRepo },
+                { provide: CardImportResolver, useValue: mockResolver },
+            ],
+        }).compile();
+        service = module.get(BuyListService);
+        repo = module.get(BuyListRepositoryPort);
+        resolver = module.get(CardImportResolver);
+    });
+
+    describe('add', () => {
+        it('increments the quantity', async () => {
+            repo.increment.mockResolvedValue(3);
+            await service.add(7, 'card-1', false, 2);
+            expect(repo.increment).toHaveBeenCalledWith(7, 'card-1', false, 2);
+        });
+
+        it('is a no-op for quantity <= 0', async () => {
+            await service.add(7, 'card-1', false, 0);
+            expect(repo.increment).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('setQuantity', () => {
+        it('saves the absolute quantity when > 0', async () => {
+            repo.save.mockResolvedValue({} as never);
+            await service.setQuantity(7, 'card-1', true, 4);
+            expect(repo.save).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 7, cardId: 'card-1', isFoil: true, quantity: 4 })
+            );
+            expect(repo.delete).not.toHaveBeenCalled();
+        });
+
+        it('deletes the item when quantity <= 0', async () => {
+            await service.setQuantity(7, 'card-1', true, 0);
+            expect(repo.delete).toHaveBeenCalledWith(7, 'card-1', true);
+            expect(repo.save).not.toHaveBeenCalled();
+        });
+    });
+
+    it('remove delegates to repo.delete', async () => {
+        await service.remove(7, 'card-1', false);
+        expect(repo.delete).toHaveBeenCalledWith(7, 'card-1', false);
+    });
+
+    it('list returns [] for a falsy user', async () => {
+        const result = await service.list(0 as never);
+        expect(result).toEqual([]);
+        expect(repo.findByUser).not.toHaveBeenCalled();
+    });
+
+    describe('bulkAdd', () => {
+        it('resolves each row and increments; reports unresolved rows', async () => {
+            const card = makeCard();
+            resolver.resolveCard
+                .mockResolvedValueOnce({ card, error: null })
+                .mockResolvedValueOnce({ card: null, error: 'Card not found' });
+            resolver.resolveFoil.mockReturnValue(false);
+            repo.increment.mockResolvedValue(1);
+
+            const result = await service.bulkAdd(
+                [{ name: 'Sol Ring', quantity: '2' }, { name: 'Nonexistent' }],
+                7
+            );
+
+            expect(repo.increment).toHaveBeenCalledTimes(1);
+            expect(repo.increment).toHaveBeenCalledWith(7, 'card-1', false, 2);
+            expect(result.saved).toBe(1);
+            // CSV row numbers (header = line 1): the 2nd data row is line 3.
+            expect(result.errors).toEqual([
+                { row: 3, name: 'Nonexistent', error: 'Card not found' },
+            ]);
+        });
+
+        it('errors when the requested foil finish is unavailable', async () => {
+            resolver.resolveCard.mockResolvedValue({ card: makeCard(), error: null });
+            resolver.resolveFoil.mockReturnValue(null);
+
+            const result = await service.bulkAdd([{ name: 'Sol Ring', foil: 'false' }], 7);
+
+            expect(repo.increment).not.toHaveBeenCalled();
+            expect(result.saved).toBe(0);
+            expect(result.errors).toHaveLength(1);
+        });
+
+        it('defaults missing quantity to 1', async () => {
+            resolver.resolveCard.mockResolvedValue({ card: makeCard(), error: null });
+            resolver.resolveFoil.mockReturnValue(false);
+            repo.increment.mockResolvedValue(1);
+
+            await service.bulkAdd([{ name: 'Sol Ring' }], 7);
+
+            expect(repo.increment).toHaveBeenCalledWith(7, 'card-1', false, 1);
+        });
+    });
+});

--- a/test/http/api/buy-list/buy-list-api.presenter.spec.ts
+++ b/test/http/api/buy-list/buy-list-api.presenter.spec.ts
@@ -1,0 +1,66 @@
+import { BuyListItem } from 'src/core/buy-list/buy-list-item.entity';
+import { Card } from 'src/core/card/card.entity';
+import { Price } from 'src/core/card/price.entity';
+import { Set } from 'src/core/set/set.entity';
+import { BuyListApiPresenter } from 'src/http/api/buy-list/buy-list-api.presenter';
+
+function makeCard(): Card {
+    return new Card({
+        id: 'card-1',
+        imgSrc: 'a/b/card-1.jpg',
+        name: 'Sol Ring',
+        number: '1',
+        rarity: 'uncommon' as Card['rarity'],
+        setCode: 'cmd',
+        sortNumber: '1',
+        type: 'Artifact',
+        legalities: [],
+        hasFoil: true,
+        hasNonFoil: true,
+        prices: [new Price({ cardId: 'card-1', normal: 2.5, foil: 6, date: new Date() })],
+        set: new Set({
+            code: 'cmd',
+            name: 'Commander',
+            keyruneCode: 'cmd',
+            type: 'commander',
+            block: 'commander',
+            releaseDate: '2011-06-17',
+            baseSize: 1,
+            totalSize: 1,
+            isMain: true,
+        }),
+    });
+}
+
+describe('BuyListApiPresenter', () => {
+    it('maps an item with card data, picking the finish price', () => {
+        const item = new BuyListItem({
+            userId: 7,
+            cardId: 'card-1',
+            isFoil: true,
+            quantity: 2,
+            card: makeCard(),
+        });
+        const dto = BuyListApiPresenter.toItem(item);
+        expect(dto).toMatchObject({
+            cardId: 'card-1',
+            quantity: 2,
+            isFoil: true,
+            cardName: 'Sol Ring',
+            setCode: 'cmd',
+            cardNumber: '1',
+            priceNormal: 2.5,
+            priceFoil: 6,
+            hasFoil: true,
+            hasNonFoil: true,
+        });
+        expect(dto.imgSrc).toContain('a/b/card-1.jpg');
+        expect(dto.url).toBeTruthy();
+    });
+
+    it('returns a minimal dto when card data is absent', () => {
+        const item = new BuyListItem({ userId: 7, cardId: 'card-1', isFoil: false, quantity: 1 });
+        const dto = BuyListApiPresenter.toItem(item);
+        expect(dto).toEqual({ cardId: 'card-1', quantity: 1, isFoil: false });
+    });
+});

--- a/test/integration/buy-list.e2e-spec.ts
+++ b/test/integration/buy-list.e2e-spec.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm';
 import {
     closeTestApp,
     createTestApp,
+    getTestUserId,
     loginTestUserApi,
     TEST_CARD_ID,
     TEST_SET_CODE,
@@ -12,17 +13,19 @@ import {
 describe('Buy List API (e2e)', () => {
     let app: INestApplication;
     let bearerToken: string;
+    let userId: number;
 
     const clearBuyList = async () => {
         const ds = app.get(DataSource);
         if (ds?.isInitialized) {
-            await ds.query(`DELETE FROM buy_list WHERE user_id = 1`);
+            await ds.query(`DELETE FROM buy_list WHERE user_id = $1`, [userId]);
         }
     };
 
     beforeAll(async () => {
         app = await createTestApp();
         bearerToken = await loginTestUserApi(app);
+        userId = await getTestUserId(app);
     }, 30000);
 
     afterEach(async () => {
@@ -73,6 +76,8 @@ describe('Buy List API (e2e)', () => {
                 quantity: 5,
             });
             expect(res.body.data[0].cardName).toBeDefined();
+            // findByUser joins the latest price, so the list carries prices.
+            expect(res.body.data[0].priceNormal).toBe(5);
         });
 
         it('PATCH sets an absolute quantity; quantity 0 removes the item', async () => {

--- a/test/integration/buy-list.e2e-spec.ts
+++ b/test/integration/buy-list.e2e-spec.ts
@@ -1,0 +1,180 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import {
+    closeTestApp,
+    createTestApp,
+    loginTestUserApi,
+    TEST_CARD_ID,
+    TEST_SET_CODE,
+} from './setup';
+
+describe('Buy List API (e2e)', () => {
+    let app: INestApplication;
+    let bearerToken: string;
+
+    const clearBuyList = async () => {
+        const ds = app.get(DataSource);
+        if (ds?.isInitialized) {
+            await ds.query(`DELETE FROM buy_list WHERE user_id = 1`);
+        }
+    };
+
+    beforeAll(async () => {
+        app = await createTestApp();
+        bearerToken = await loginTestUserApi(app);
+    }, 30000);
+
+    afterEach(async () => {
+        await clearBuyList();
+    });
+
+    afterAll(async () => {
+        try {
+            await clearBuyList();
+        } catch {
+            // best-effort
+        }
+        await closeTestApp(app);
+    });
+
+    describe('Auth guard', () => {
+        it('GET without auth returns 401', async () => {
+            const res = await request(app.getHttpServer()).get('/api/v1/buy-list').expect(401);
+            expect(res.body.success).toBe(false);
+        });
+    });
+
+    describe('CRUD', () => {
+        it('POST adds a card (increments on repeat) and GET lists it', async () => {
+            await request(app.getHttpServer())
+                .post('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: false, quantity: 2 })
+                .expect(200);
+
+            // Second add of the same (card, finish) increments rather than duplicating.
+            await request(app.getHttpServer())
+                .post('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: false, quantity: 3 })
+                .expect(200);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data).toHaveLength(1);
+            expect(res.body.data[0]).toMatchObject({
+                cardId: TEST_CARD_ID,
+                isFoil: false,
+                quantity: 5,
+            });
+            expect(res.body.data[0].cardName).toBeDefined();
+        });
+
+        it('PATCH sets an absolute quantity; quantity 0 removes the item', async () => {
+            await request(app.getHttpServer())
+                .post('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: true, quantity: 1 })
+                .expect(200);
+
+            await request(app.getHttpServer())
+                .patch('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: true, quantity: 4 })
+                .expect(200);
+
+            let res = await request(app.getHttpServer())
+                .get('/api/v1/buy-list')
+                .set('Authorization', bearerToken);
+            expect(res.body.data[0].quantity).toBe(4);
+
+            await request(app.getHttpServer())
+                .patch('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: true, quantity: 0 })
+                .expect(200);
+
+            res = await request(app.getHttpServer())
+                .get('/api/v1/buy-list')
+                .set('Authorization', bearerToken);
+            expect(res.body.data).toHaveLength(0);
+        });
+
+        it('DELETE removes a card', async () => {
+            await request(app.getHttpServer())
+                .post('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: false })
+                .expect(200);
+
+            await request(app.getHttpServer())
+                .delete('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: false })
+                .expect(200);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/buy-list')
+                .set('Authorization', bearerToken);
+            expect(res.body.data).toHaveLength(0);
+        });
+
+        it('normal and foil of the same card are distinct rows', async () => {
+            await request(app.getHttpServer())
+                .post('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: false, quantity: 1 })
+                .expect(200);
+            await request(app.getHttpServer())
+                .post('/api/v1/buy-list')
+                .set('Authorization', bearerToken)
+                .send({ cardId: TEST_CARD_ID, isFoil: true, quantity: 1 })
+                .expect(200);
+
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/buy-list')
+                .set('Authorization', bearerToken);
+            expect(res.body.data).toHaveLength(2);
+        });
+    });
+
+    describe('Bulk import', () => {
+        it('adds resolvable CSV rows and reports unmatched ones', async () => {
+            // Native CSV: header + a resolvable seed card (set+number) + a bogus row.
+            const csv = [
+                'name,set_code,number,quantity',
+                `Test Angel,${TEST_SET_CODE},1,2`,
+                'Definitely Not A Real Card,zzz,999,1',
+            ].join('\n');
+
+            const res = await request(app.getHttpServer())
+                .post('/api/v1/buy-list/import')
+                .set('Authorization', bearerToken)
+                .send({ text: csv })
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data.saved).toBe(1);
+            expect(res.body.data.errors).toHaveLength(1);
+
+            const list = await request(app.getHttpServer())
+                .get('/api/v1/buy-list')
+                .set('Authorization', bearerToken);
+            expect(list.body.data).toHaveLength(1);
+            expect(list.body.data[0].quantity).toBe(2);
+        });
+
+        it('rejects CSV with unknown columns as 400', async () => {
+            await request(app.getHttpServer())
+                .post('/api/v1/buy-list/import')
+                .set('Authorization', bearerToken)
+                .send({ text: 'name,bogus_column\nFoo,1' })
+                .expect(400);
+        });
+    });
+});


### PR DESCRIPTION
First of two PRs for **Roadmap 6.5**. Adds a per-user **buy-list (want-list)** — the cards a user intends to buy. Useful on its own; it also feeds the **cash-vs-store-credit optimizer** (PR2).

## Why
6.5 was re-scoped after #515: buylist is single-source upstream, so the vendor-comparison optimizer has no decision to make — but **cash vs. store credit** does (a store-credit bonus % applied against cards you want to buy). That needs a buy-list, which doesn't exist yet. This PR builds it.

## Data model
Mirrors **inventory** exactly (card + finish + quantity, owned by a user) so the optimizer can price normal vs foil and match against inventory:
- `migration 039`: `buy_list (user_id, card_id, foil, quantity, created_at)`, composite PK `(user_id, card_id, foil)`, FKs cascade. `001_complete_schema.sql` synced.

## Layers (mirroring inventory / price-alert)
- **core**: `BuyListItem` entity, `BuyListRepositoryPort`, `BuyListService` (`add`=increment, `setQuantity`=absolute/0-removes, `remove`, `list`, `bulkAdd`), `BuyListModule`.
- **database**: orm-entity + mapper + repository (atomic increment via `INSERT … ON CONFLICT`), bound in `DatabaseModule`.
- **API** `/api/v1/buy-list`: `GET` / `POST` (add) / `PATCH` (set qty) / `DELETE` + `POST import`; presenter + DTOs.
- **HBS** `/buy-list`: client-rendered shell (like price-alerts) + orchestrator + view; `buyList.js` (list / qty stepper / remove / bulk import via the API). **"Add to buy list"** control on the card page (`buyListAdd.js`) + navbar/drawer links.

## Bulk import
Reuses the existing native CSV parser + `CardImportResolver` — paste CSV rows (`name,set_code,number[,quantity][,foil]`); Moxfield/Archidekt/Deckbox/TCGPlayer exports auto-detected. Name-only paste is **not** supported on purpose: a bare card name is printing-ambiguous and the resolver requires `id` / `set_code+number` / `name+set_code`.

## Notes
- Free-tier feature (`JwtAuthGuard` / `JwtOrApiKeyGuard`, no subscription gate).
- Public JS isn't in the project's `eslint` scope (`**/*.ts` only), consistent with sibling AJAX scripts.

## Test
- `BuyListService` unit, API presenter unit, `buy-list.e2e` (CRUD, unique-key increment, normal/foil distinct rows, bulk import + 400 on unknown columns).
- **unit 1228, frontend 101, integration 250 green**; `tsc` + Prettier + TS lint clean.

## Next (PR2)
Cash-vs-credit optimizer page (editable bonus %), CSV export, MCP mirror. Closes #503 + epic #498 when PR2 lands.

Refs #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)