### PR TITLE
feat: expose buylist pricing, sell value & optimizer as JSON API (#530)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,15 @@ Small leftover items from otherwise-shipped sections (Phases 1–4.3). Mostly ma
 
 ---
 
-## Phase 6: Buylist Pricing & Vendor Selling Tools
+## Phase 6: Buylist Pricing & Vendor Selling Tools ✅
+
+**Complete — epic #498 closed 2026-06-13.** All sub-issues (6.1–6.9) shipped or closed. Buylist
+proved **upstream single-source (Card Kingdom only)** — confirmed against the raw MTGJSON feed — so
+the multi-vendor pieces (the per-vendor consolidation optimizer in 6.5, the Tier C coverage in 6.9)
+are **gated on a second free buylist source** that the 6.9 research found does not currently exist;
+they reopen only on demand + revenue. One non-gated follow-up remains: expose buylist pricing,
+sell value, and the optimizer as JSON API (#530 — today they're HBS pages + CSV only), which in
+turn unblocks mirroring them via MCP ([iwantmymtg-mcp#9](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/9)).
 
 Surface buylist (sell-to-vendor) prices alongside retail, highlight the best buylist offer per card, and help users decide *who to sell to* — especially in bulk. The value lands on a user's inventory: what is my collection worth to *sell*, and which vendor pays most? Prioritized ahead of platform expansion and go-to-market because it's net-new differentiating value (not a re-surfacing of existing features) and it strengthens the core product before we invest in new surfaces and marketing.
 
@@ -136,7 +144,7 @@ client-side. CSV: `name,set_code,number,finish,owned_qty,vendor,offer,sellable_q
 - [x] Sell rows link out to the vendor's buylist page for the card (plain links, no partner attribution — deferred from 6.7)
 - [x] CSV export of the sell list (per-item offer, qty, payout) honoring the selection
 
-### 6.5 Sell/Buy List Optimizer (re-scoped: cash vs. credit first)
+### 6.5 Sell/Buy List Optimizer (re-scoped: cash vs. credit first) ✅
 
 Re-scoped after the 6.9 research: with buylist effectively single-source upstream, the
 *vendor-comparison* optimizer has no decision to make — but **cash vs. store credit** is a real

--- a/docs/phase6-buylist-handoff.md
+++ b/docs/phase6-buylist-handoff.md
@@ -204,8 +204,11 @@ no-`img_src` binary:
   removed (clutter + mobile overflow). The batched `findCurrentBuylistByCardIds` read is kept for 6.4.
 - ~~6.4 inventory **market sell value**~~ **Shipped (PR #524).** Best offer per item, qty-capped
   payout totals, group-by-vendor kept as structure, plain buylist links, CSV export.
-- **6.5 (next, not started):** re-scoped to **cash vs. store credit** first (needs DB `vendor`
-  table); multi-vendor consolidation gated on 6.9 (which is closed single-source).
+- ~~6.5 cash-vs-credit optimizer~~ **Shipped (PR #528 buy-list, #529 optimizer).** Per-user `buy_list` (migration
+  `039`) + `/buy-list` page; pure `cash-vs-credit.policy.ts`; `/optimizer` page with editable
+  bonus-% and `GET /optimizer/export.csv`. No DB `vendor` table was needed — the bonus default
+  stays the `cardkingdom` code constant. Multi-vendor consolidation stays gated on 6.9
+  (closed single-source). MCP mirror is the only open follow-up (iwantmymtg-mcp#9).
 - Possible: currency column → then Cardmarket (only if non-USD is ever wanted; currently out).
 - ~~ROADMAP 6.6: condition grade vocabulary~~ **Closed (#512)** — single grade (`NM`) only.
 

--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -61,6 +61,9 @@ export class CardService {
     }
 
     async findBySetCodeAndNumber(code: string, number: string): Promise<Card | null> {
+        // Set codes are stored lowercase and the repo query is case-sensitive,
+        // so normalize here (one place for every caller — REST/MCP/HBS).
+        code = code?.trim().toLowerCase();
         this.LOGGER.debug(`Find card no. ${number} in set ${code}.`);
         try {
             const card = await this.repository.findBySetCodeAndNumber(code, number, [

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -9,6 +9,7 @@ import { CardModule } from './card/card.module';
 import { EmailModule } from './email/email.module';
 import { ImportModule } from './import/import.module';
 import { InventoryModule } from './inventory/inventory.module';
+import { OptimizerModule } from './optimizer/optimizer.module';
 import { PasswordResetModule } from './password-reset/password-reset.module';
 import { PriceAlertModule } from './price-alert/price-alert.module';
 import { SearchModule } from './search/search.module';
@@ -29,6 +30,7 @@ import { UserModule } from './user/user.module';
         EmailModule,
         ImportModule,
         InventoryModule,
+        OptimizerModule,
         PasswordResetModule,
         PriceAlertModule,
         PortfolioModule,
@@ -48,6 +50,7 @@ import { UserModule } from './user/user.module';
         EmailModule,
         ImportModule,
         InventoryModule,
+        OptimizerModule,
         PasswordResetModule,
         PriceAlertModule,
         PortfolioModule,

--- a/src/core/optimizer/optimizer.module.ts
+++ b/src/core/optimizer/optimizer.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { BuyListModule } from 'src/core/buy-list/buy-list.module';
+import { InventoryModule } from 'src/core/inventory/inventory.module';
+import { SellOptimizerService } from './sell-optimizer.service';
+
+@Module({
+    imports: [InventoryModule, BuyListModule],
+    providers: [SellOptimizerService],
+    exports: [SellOptimizerService],
+})
+export class OptimizerModule {}

--- a/src/core/optimizer/optimizer.types.ts
+++ b/src/core/optimizer/optimizer.types.ts
@@ -1,0 +1,32 @@
+import { CashVsCreditResult } from 'src/core/pricing/cash-vs-credit.policy';
+
+/** One buy-list card priced for the optimizer. `unitPrice`/`lineTotal` are null when no price is known. */
+export interface OptimizerBuyLine {
+    name: string;
+    setCode: string;
+    number: string;
+    finish: 'normal' | 'foil';
+    quantity: number;
+    unitPrice: number | null;
+    lineTotal: number | null;
+}
+
+/**
+ * Neutral optimizer result shared by the HBS page and the JSON API (6.5).
+ * Combines the sell-side cash value (single vendor today), the buy-list retail,
+ * and the cash-vs-credit decision so both surfaces present the same numbers.
+ */
+export interface OptimizerPlan {
+    vendorKey: string;
+    vendorName: string;
+    /** Buylist cash payout for the sell list (the single CK vendor group). */
+    cashValue: number;
+    sellItemCount: number;
+    /** Retail cost of priced buy-list lines. */
+    buyListRetail: number;
+    buyLines: OptimizerBuyLine[];
+    /** Buy-list lines with no current price (excluded from retail). */
+    itemsWithoutPrice: number;
+    bonusPct: number;
+    result: CashVsCreditResult;
+}

--- a/src/core/optimizer/sell-optimizer.service.ts
+++ b/src/core/optimizer/sell-optimizer.service.ts
@@ -1,0 +1,78 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { BuyListService } from 'src/core/buy-list/buy-list.service';
+import { InventoryService } from 'src/core/inventory/inventory.service';
+import { computeCashVsCredit } from 'src/core/pricing/cash-vs-credit.policy';
+import { DEFAULT_STORE_CREDIT_BONUS, vendorDisplayName } from 'src/core/pricing/vendor';
+import { OptimizerBuyLine, OptimizerPlan } from './optimizer.types';
+
+/** The single sell-to vendor today (see ROADMAP 6.9 — single-source). */
+const VENDOR_KEY = 'cardkingdom';
+
+/** Server clamp for the store-credit bonus; matches the optimizer UI input cap (200%). */
+const MAX_BONUS = 2;
+
+/**
+ * Cash-vs-credit optimizer data (6.5), shared by the HBS page and the JSON API.
+ * Gathers the user's sell plan (6.4) + buy list, prices the buy list, and runs
+ * the pure cash-vs-credit policy — so both surfaces read the same backend.
+ */
+@Injectable()
+export class SellOptimizerService {
+    constructor(
+        @Inject(InventoryService) private readonly inventoryService: InventoryService,
+        @Inject(BuyListService) private readonly buyListService: BuyListService
+    ) {}
+
+    /** Clamp a bonus query param (fraction, e.g. 0.3) to [0, 2]; default on bad input. */
+    static parseBonus(raw?: string): number {
+        if (raw === undefined || raw === '') return DEFAULT_STORE_CREDIT_BONUS;
+        const n = Number(raw);
+        if (!Number.isFinite(n) || n < 0) return DEFAULT_STORE_CREDIT_BONUS;
+        return Math.min(n, MAX_BONUS);
+    }
+
+    async buildPlan(userId: number, bonusPct: number): Promise<OptimizerPlan> {
+        const [sellPlan, buyList] = await Promise.all([
+            this.inventoryService.sellPlanForUser(userId),
+            this.buyListService.list(userId),
+        ]);
+
+        const vendorGroup = sellPlan.groups.find((g) => g.provider === VENDOR_KEY);
+        const cashValue = vendorGroup?.payout ?? 0;
+        const sellItemCount = vendorGroup?.items.length ?? 0;
+
+        let buyListRetail = 0;
+        let itemsWithoutPrice = 0;
+        const buyLines: OptimizerBuyLine[] = buyList.map((item) => {
+            const price = item.card?.prices?.[0];
+            const unit = item.isFoil ? price?.foil : price?.normal;
+            const unitPrice = unit != null ? Number(unit) : null;
+            const lineTotal = unitPrice != null ? unitPrice * item.quantity : null;
+            if (lineTotal != null) buyListRetail += lineTotal;
+            else itemsWithoutPrice++;
+            return {
+                name: item.card?.name ?? item.cardId,
+                setCode: (item.card?.setCode ?? '').toUpperCase(),
+                number: item.card?.number ?? '',
+                finish: item.isFoil ? 'foil' : 'normal',
+                quantity: item.quantity,
+                unitPrice,
+                lineTotal,
+            };
+        });
+
+        const result = computeCashVsCredit({ cashValue, buyListRetail, bonusPct });
+
+        return {
+            vendorKey: VENDOR_KEY,
+            vendorName: vendorDisplayName(VENDOR_KEY),
+            cashValue,
+            sellItemCount,
+            buyListRetail,
+            buyLines,
+            itemsWithoutPrice,
+            bonusPct,
+            result,
+        };
+    }
+}

--- a/src/core/pricing/buylist.policy.ts
+++ b/src/core/pricing/buylist.policy.ts
@@ -17,3 +17,42 @@ export function bestBuylistOffer(offers: GranularPrice[]): GranularPrice | null 
             null
         );
 }
+
+/** One vendor's usable NM offer for a finish; `isBest` marks the highest for that finish. */
+export interface BuylistFinishOffer {
+    readonly provider: string;
+    readonly price: number;
+    readonly isBest: boolean;
+}
+
+/** Usable NM offers for one finish, highest first. */
+export interface BuylistFinishGroup {
+    readonly finish: string; // raw key: 'normal' | 'foil' | 'etched'
+    readonly offers: BuylistFinishOffer[];
+}
+
+const FINISH_ORDER = ['normal', 'foil', 'etched'];
+
+/**
+ * Group usable (NM, positive) buylist offers by finish, highest first, marking
+ * the best per finish. Neutral shape shared by the card-page view and the JSON
+ * API so both surface the same offers (Phase 6.5 / #530).
+ */
+export function groupBuylistByFinish(offers: GranularPrice[]): BuylistFinishGroup[] {
+    const usable = offers.filter((o) => o.condition === 'NM' && o.price != null && o.price > 0);
+    return FINISH_ORDER.map((finish): BuylistFinishGroup | null => {
+        const finishOffers = usable
+            .filter((o) => o.finish === finish)
+            .sort((a, b) => (b.price as number) - (a.price as number));
+        if (finishOffers.length === 0) return null;
+        const bestPrice = finishOffers[0].price as number;
+        return {
+            finish,
+            offers: finishOffers.map((o) => ({
+                provider: o.provider,
+                price: o.price as number,
+                isBest: (o.price as number) === bestPrice,
+            })),
+        };
+    }).filter((g): g is BuylistFinishGroup => g !== null);
+}

--- a/src/http/api/api.module.ts
+++ b/src/http/api/api.module.ts
@@ -9,6 +9,7 @@ import { StripeWebhookController } from './billing/stripe-webhook.controller';
 import { BuyListApiController } from './buy-list/buy-list-api.controller';
 import { CardApiController } from './card/card-api.controller';
 import { InventoryApiController } from './inventory/inventory-api.controller';
+import { SellOptimizerApiController } from './optimizer/sell-optimizer-api.controller';
 import { PortfolioApiController } from './portfolio/portfolio-api.controller';
 import { SetApiController } from './set/set-api.controller';
 import { TransactionApiController } from './transaction/transaction-api.controller';
@@ -33,6 +34,7 @@ import { RapidApiProxyGuard } from './shared/rapidapi-proxy.guard';
         BuyListApiController,
         CardApiController,
         InventoryApiController,
+        SellOptimizerApiController,
         PortfolioApiController,
         PriceAlertApiController,
         PriceNotificationApiController,

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -14,6 +14,7 @@ import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { parseDaysParam } from 'src/http/base/query.util';
 import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
 import { CardApiResponseDto, PriceHistoryPointDto } from './dto/card-response.dto';
+import { CardBuylistApiResponseDto } from './dto/card-buylist-response.dto';
 import { CardApiPresenter } from './card-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { OptionalAuthOrApiKeyGuard } from '../shared/optional-auth-or-api-key.guard';
@@ -114,6 +115,19 @@ export class CardApiController {
         return ApiResponseDto.ok(CardApiPresenter.toCardApiResponse(cards[0]));
     }
 
+    @Get(':cardId/buylist')
+    @ApiOperation({
+        operationId: 'getCardBuylist',
+        summary: 'Get current buylist (sell-to-vendor) offers for a card by ID',
+    })
+    @ApiResponse({ status: 200, description: 'Buylist offers grouped by finish (NM, best first)' })
+    async getBuylistById(
+        @Param('cardId') cardId: string
+    ): Promise<ApiResponseDto<CardBuylistApiResponseDto>> {
+        const offers = await this.cardService.findCurrentBuylist(cardId);
+        return ApiResponseDto.ok(CardApiPresenter.toBuylist(cardId, offers));
+    }
+
     @Get(':cardId/price-history')
     @ApiOperation({
         operationId: 'getCardPriceHistory',
@@ -148,6 +162,25 @@ export class CardApiController {
             throw new NotFoundException('Card not found');
         }
         return ApiResponseDto.ok(CardApiPresenter.toCardApiResponse(cardsWithPrices[0]));
+    }
+
+    @Get(':setCode/:setNumber/buylist')
+    @ApiOperation({
+        operationId: 'getCardBuylistBySetAndNumber',
+        summary: 'Get current buylist offers for a card by set code and number',
+    })
+    @ApiResponse({ status: 200, description: 'Buylist offers grouped by finish (NM, best first)' })
+    @ApiResponse({ status: 404, description: 'Card not found' })
+    async getBuylistBySetCodeAndNumber(
+        @Param('setCode') setCode: string,
+        @Param('setNumber') setNumber: string
+    ): Promise<ApiResponseDto<CardBuylistApiResponseDto>> {
+        const card = await this.cardService.findBySetCodeAndNumber(setCode, setNumber);
+        if (!card) {
+            throw new NotFoundException('Card not found');
+        }
+        const offers = await this.cardService.findCurrentBuylist(card.id);
+        return ApiResponseDto.ok(CardApiPresenter.toBuylist(card.id, offers));
     }
 
     @Get(':setCode/:setNumber/price-history')

--- a/src/http/api/card/card-api.presenter.ts
+++ b/src/http/api/card/card-api.presenter.ts
@@ -1,8 +1,26 @@
 import { AffiliateLinkPolicy } from 'src/core/affiliate/affiliate-link.policy';
 import { Card } from 'src/core/card/card.entity';
+import { GranularPrice } from 'src/core/card/granular-price.entity';
+import { groupBuylistByFinish } from 'src/core/pricing/buylist.policy';
+import { vendorDisplayName } from 'src/core/pricing/vendor';
+import { CardBuylistApiResponseDto } from './dto/card-buylist-response.dto';
 import { CardApiResponseDto } from './dto/card-response.dto';
 
 export class CardApiPresenter {
+    /** Structured buylist offers for a card — same grouping the card page uses, raw numbers. */
+    static toBuylist(cardId: string, offers: GranularPrice[]): CardBuylistApiResponseDto {
+        const finishes = groupBuylistByFinish(offers).map((group) => {
+            const mapped = group.offers.map((o) => ({
+                provider: o.provider,
+                vendor: vendorDisplayName(o.provider),
+                price: o.price,
+                isBest: o.isBest,
+            }));
+            return { finish: group.finish, best: mapped[0], offers: mapped };
+        });
+        return { cardId, finishes, hasAny: finishes.length > 0 };
+    }
+
     static toCardApiResponse(card: Card): CardApiResponseDto {
         const latestPrice = card.prices?.[0];
         return {

--- a/src/http/api/card/dto/card-buylist-response.dto.ts
+++ b/src/http/api/card/dto/card-buylist-response.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BuylistOfferApiDto {
+    @ApiProperty({ description: 'Provider key (granular_price.provider)', example: 'cardkingdom' })
+    readonly provider: string;
+
+    @ApiProperty({ description: 'Vendor display name', example: 'Card Kingdom' })
+    readonly vendor: string;
+
+    @ApiProperty({ description: 'Buylist offer in USD (NM)', example: 3.5 })
+    readonly price: number;
+
+    @ApiProperty({ description: 'Highest offer for this finish', example: true })
+    readonly isBest: boolean;
+}
+
+export class BuylistFinishApiDto {
+    @ApiProperty({ description: "Finish key: 'normal' | 'foil' | 'etched'", example: 'normal' })
+    readonly finish: string;
+
+    @ApiProperty({ type: BuylistOfferApiDto, description: 'Highest offer for this finish' })
+    readonly best: BuylistOfferApiDto;
+
+    @ApiProperty({ type: [BuylistOfferApiDto], description: 'All offers for this finish, best first' })
+    readonly offers: BuylistOfferApiDto[];
+}
+
+export class CardBuylistApiResponseDto {
+    @ApiProperty({ description: 'Card id' })
+    readonly cardId: string;
+
+    @ApiProperty({ type: [BuylistFinishApiDto], description: 'Usable NM buylist offers grouped by finish' })
+    readonly finishes: BuylistFinishApiDto[];
+
+    @ApiProperty({ description: 'True when any usable offer exists' })
+    readonly hasAny: boolean;
+}

--- a/src/http/api/inventory/dto/inventory-sell-response.dto.ts
+++ b/src/http/api/inventory/dto/inventory-sell-response.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SellPlanItemApiDto {
+    @ApiProperty()
+    readonly cardId: string;
+
+    @ApiProperty({ required: false })
+    readonly cardName?: string;
+
+    @ApiProperty({ required: false })
+    readonly setCode?: string;
+
+    @ApiProperty({ required: false })
+    readonly number?: string;
+
+    @ApiProperty({ description: "'normal' | 'foil'" })
+    readonly finish: string;
+
+    @ApiProperty({ description: 'Quantity owned' })
+    readonly ownedQuantity: number;
+
+    @ApiProperty({ description: 'Units the vendor would take (qty-capped)' })
+    readonly sellableQuantity: number;
+
+    @ApiProperty({ description: 'True when the vendor buy quantity caps below owned' })
+    readonly quantityCapped: boolean;
+
+    @ApiProperty({ description: 'Best NM buylist offer per unit (USD)' })
+    readonly offer: number;
+
+    @ApiProperty({ description: 'offer * sellableQuantity (USD)' })
+    readonly payout: number;
+}
+
+export class SellPlanGroupApiDto {
+    @ApiProperty({ example: 'cardkingdom' })
+    readonly provider: string;
+
+    @ApiProperty({ example: 'Card Kingdom' })
+    readonly vendor: string;
+
+    @ApiProperty({ description: 'Sum of item payouts in this group (USD)' })
+    readonly payout: number;
+
+    @ApiProperty({ type: [SellPlanItemApiDto] })
+    readonly items: SellPlanItemApiDto[];
+}
+
+export class InventorySellApiResponseDto {
+    @ApiProperty({ description: 'Total market sell value across all groups (USD)' })
+    readonly totalPayout: number;
+
+    @ApiProperty({ description: 'Inventory items with a usable offer' })
+    readonly itemsWithOffers: number;
+
+    @ApiProperty({ description: 'Inventory items with no usable offer' })
+    readonly itemsWithoutOffers: number;
+
+    @ApiProperty({ type: [SellPlanGroupApiDto], description: 'Sorted by payout descending' })
+    readonly groups: SellPlanGroupApiDto[];
+}

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -43,6 +43,7 @@ import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
 import { InventoryItemApiDto } from './dto/inventory-response.dto';
 import { InventoryImportResponseDto } from './dto/inventory-import-response.dto';
 import { InventoryQuantityApiDto } from './dto/inventory-quantity.dto';
+import { InventorySellApiResponseDto } from './dto/inventory-sell-response.dto';
 import { InventoryApiPresenter } from './inventory-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
@@ -87,6 +88,21 @@ export class InventoryApiController {
             items.map((item) => InventoryApiPresenter.toInventoryItem(item)),
             new PaginationMeta(options.page, options.limit, total)
         );
+    }
+
+    @Get('sell')
+    @ApiOperation({
+        summary: "Market sell value of the user's inventory (best buylist offer per item)",
+        description:
+            'Matches every owned card against current buylist offers, picks the best NM offer ' +
+            'per item (qty-capped), groups by vendor, and totals it. Mirrors the /inventory/sell page.',
+    })
+    @ApiResponse({ status: 200, description: 'Market sell value plan' })
+    async sellPlan(
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<InventorySellApiResponseDto>> {
+        const plan = await this.inventoryService.sellPlanForUser(req.user.id);
+        return ApiResponseDto.ok(InventoryApiPresenter.toSellPlan(plan));
     }
 
     @Get('quantities')

--- a/src/http/api/inventory/inventory-api.presenter.ts
+++ b/src/http/api/inventory/inventory-api.presenter.ts
@@ -1,10 +1,42 @@
 import { Inventory } from 'src/core/inventory/inventory.entity';
+import { SellPlan } from 'src/core/pricing/sell-value.policy';
+import { vendorDisplayName } from 'src/core/pricing/vendor';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { BASE_IMAGE_URL, buildCardUrl } from 'src/http/base/http.util';
 import { InventoryItemApiDto } from './dto/inventory-response.dto';
 import { InventoryQuantityApiDto } from './dto/inventory-quantity.dto';
+import { InventorySellApiResponseDto } from './dto/inventory-sell-response.dto';
 
 export class InventoryApiPresenter {
+    /** Market sell value plan (6.4) as structured JSON — same SellPlan the sell page renders. */
+    static toSellPlan(plan: SellPlan): InventorySellApiResponseDto {
+        return {
+            totalPayout: plan.totalPayout,
+            itemsWithOffers: plan.itemsWithOffers,
+            itemsWithoutOffers: plan.itemsWithoutOffers,
+            groups: plan.groups.map((group) => ({
+                provider: group.provider,
+                vendor: vendorDisplayName(group.provider),
+                payout: group.payout,
+                items: group.items.map((item) => {
+                    const card = item.inventory.card;
+                    return {
+                        cardId: item.inventory.cardId,
+                        cardName: card?.name,
+                        setCode: card?.setCode,
+                        number: card?.number,
+                        finish: item.inventory.isFoil ? 'foil' : 'normal',
+                        ownedQuantity: item.inventory.quantity,
+                        sellableQuantity: item.sellableQuantity,
+                        quantityCapped: item.quantityCapped,
+                        offer: item.offer.price as number,
+                        payout: item.payout,
+                    };
+                }),
+            })),
+        };
+    }
+
     static toInventoryItem(item: Inventory): InventoryItemApiDto {
         if (!item.card) {
             return {

--- a/src/http/api/optimizer/dto/optimizer-response.dto.ts
+++ b/src/http/api/optimizer/dto/optimizer-response.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class OptimizerBuyLineApiDto {
+    @ApiProperty()
+    readonly name: string;
+
+    @ApiProperty()
+    readonly setCode: string;
+
+    @ApiProperty()
+    readonly number: string;
+
+    @ApiProperty({ description: "'normal' | 'foil'" })
+    readonly finish: string;
+
+    @ApiProperty()
+    readonly quantity: number;
+
+    @ApiProperty({ nullable: true, description: 'Unit retail (USD); null when no price is known' })
+    readonly unitPrice: number | null;
+
+    @ApiProperty({ nullable: true, description: 'unitPrice * quantity (USD); null when no price' })
+    readonly lineTotal: number | null;
+}
+
+export class OptimizerApiResponseDto {
+    @ApiProperty({ example: 'Card Kingdom' })
+    readonly vendor: string;
+
+    @ApiProperty({ description: 'Store-credit bonus as a fraction (0.30 = +30%)', example: 0.3 })
+    readonly bonusPct: number;
+
+    @ApiProperty({ description: 'Buylist cash payout for the sell list (USD)' })
+    readonly cashValue: number;
+
+    @ApiProperty({ description: 'Store credit offered: cashValue * (1 + bonusPct)' })
+    readonly storeCredit: number;
+
+    @ApiProperty({ description: 'Retail cost of the priced buy-list lines (USD)' })
+    readonly buyListRetail: number;
+
+    @ApiProperty({ description: 'True when store credit beats cash for acquiring the buy list' })
+    readonly recommendCredit: boolean;
+
+    @ApiProperty({ description: 'Out-of-pocket saved by taking credit instead of cash (USD)' })
+    readonly creditAdvantage: number;
+
+    @ApiProperty({ description: 'Out-of-pocket to buy the list with cash: max(0, R - C)' })
+    readonly cashOutOfPocket: number;
+
+    @ApiProperty({ description: 'Out-of-pocket to buy the list with credit: max(0, R - C(1+b))' })
+    readonly creditOutOfPocket: number;
+
+    @ApiProperty({ description: 'Liquid cash kept if C exceeds the buy list: max(0, C - R)' })
+    readonly cashLeftover: number;
+
+    @ApiProperty({ description: 'Credit left after the buy list, spendable only at the vendor' })
+    readonly lockedCredit: number;
+
+    @ApiProperty({ description: 'Cards on the sell list (the CK vendor group)' })
+    readonly sellItemCount: number;
+
+    @ApiProperty({ description: 'Buy-list lines with no current price (excluded from retail)' })
+    readonly itemsWithoutPrice: number;
+
+    @ApiProperty({ type: [OptimizerBuyLineApiDto] })
+    readonly buyLines: OptimizerBuyLineApiDto[];
+}

--- a/src/http/api/optimizer/optimizer-api.presenter.ts
+++ b/src/http/api/optimizer/optimizer-api.presenter.ts
@@ -1,0 +1,33 @@
+import { OptimizerPlan } from 'src/core/optimizer/optimizer.types';
+import { OptimizerApiResponseDto } from './dto/optimizer-response.dto';
+
+export class OptimizerApiPresenter {
+    /** Cash-vs-credit plan (6.5) as structured JSON — same OptimizerPlan the page renders. */
+    static toResponse(plan: OptimizerPlan): OptimizerApiResponseDto {
+        const r = plan.result;
+        return {
+            vendor: plan.vendorName,
+            bonusPct: r.bonusPct,
+            cashValue: r.cashValue,
+            storeCredit: r.storeCredit,
+            buyListRetail: r.buyListRetail,
+            recommendCredit: r.recommendCredit,
+            creditAdvantage: r.creditAdvantage,
+            cashOutOfPocket: r.cashOutOfPocket,
+            creditOutOfPocket: r.creditOutOfPocket,
+            cashLeftover: r.cashLeftover,
+            lockedCredit: r.lockedCredit,
+            sellItemCount: plan.sellItemCount,
+            itemsWithoutPrice: plan.itemsWithoutPrice,
+            buyLines: plan.buyLines.map((l) => ({
+                name: l.name,
+                setCode: l.setCode,
+                number: l.number,
+                finish: l.finish,
+                quantity: l.quantity,
+                unitPrice: l.unitPrice,
+                lineTotal: l.lineTotal,
+            })),
+        };
+    }
+}

--- a/src/http/api/optimizer/sell-optimizer-api.controller.ts
+++ b/src/http/api/optimizer/sell-optimizer-api.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Inject, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { SellOptimizerService } from 'src/core/optimizer/sell-optimizer.service';
+import { ApiResponseDto } from 'src/http/base/api-response.dto';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { JwtOrApiKeyGuard } from '../shared/jwt-or-api-key.guard';
+import { OptimizerApiResponseDto } from './dto/optimizer-response.dto';
+import { OptimizerApiPresenter } from './optimizer-api.presenter';
+
+@ApiTags('Optimizer')
+@ApiBearerAuth()
+@Controller('api/v1/optimizer')
+@UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
+export class SellOptimizerApiController {
+    constructor(
+        @Inject(SellOptimizerService) private readonly optimizerService: SellOptimizerService
+    ) {}
+
+    @Get()
+    @ApiOperation({
+        operationId: 'getOptimizer',
+        summary: 'Cash vs. store-credit recommendation for the sell list vs. the buy list',
+        description:
+            'Compares the buylist cash payout against store credit (worth a bonus %) applied ' +
+            'to the buy list. Mirrors the /optimizer page.',
+    })
+    @ApiQuery({
+        name: 'bonus',
+        required: false,
+        description: 'Store-credit bonus as a fraction (0.30 = +30%). Clamped to [0, 2]; default 0.30.',
+    })
+    @ApiResponse({ status: 200, description: 'Cash-vs-credit plan' })
+    async getOptimizer(
+        @Req() req: AuthenticatedRequest,
+        @Query('bonus') bonus?: string
+    ): Promise<ApiResponseDto<OptimizerApiResponseDto>> {
+        const bonusPct = SellOptimizerService.parseBonus(bonus);
+        const plan = await this.optimizerService.buildPlan(req.user.id, bonusPct);
+        return ApiResponseDto.ok(OptimizerApiPresenter.toResponse(plan));
+    }
+}

--- a/src/http/hbs/card/card.presenter.ts
+++ b/src/http/hbs/card/card.presenter.ts
@@ -5,6 +5,7 @@ import { CardRarity } from 'src/core/card/card.rarity.enum';
 import { Format } from 'src/core/card/format.enum';
 import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { Price } from 'src/core/card/price.entity';
+import { groupBuylistByFinish } from 'src/core/pricing/buylist.policy';
 import { vendorDisplayName } from 'src/core/pricing/vendor';
 import { formatUtcDate } from 'src/http/base/date.util';
 import { BASE_IMAGE_URL, buildCardUrl, toDollar } from 'src/http/base/http.util';
@@ -93,33 +94,20 @@ export class CardPresenter {
      * offers -> hasAny=false so the section is not rendered.
      */
     static toBuylistView(offers: GranularPrice[]): BuylistView {
-        const usable = offers.filter(
-            (o) => o.condition === 'NM' && o.price != null && o.price > 0
-        );
-
-        const finishes: BuylistFinishView[] = Object.keys(this.FINISH_LABELS)
-            .map((finishKey): BuylistFinishView | null => {
-                const finishOffers = usable
-                    .filter((o) => o.finish === finishKey)
-                    .sort((a, b) => (b.price ?? 0) - (a.price ?? 0));
-                if (finishOffers.length === 0) {
-                    return null;
-                }
-                const bestPrice = finishOffers[0].price ?? 0;
-                const views: BuylistOfferView[] = finishOffers.map((o) => ({
-                    vendor: vendorDisplayName(o.provider),
-                    price: toDollar(o.price),
-                    priceRaw: o.price ?? 0,
-                    isBest: (o.price ?? 0) === bestPrice,
-                }));
-                return {
-                    finish: this.FINISH_LABELS[finishKey],
-                    best: views[0],
-                    offers: views,
-                    hasMultiple: views.length > 1,
-                };
-            })
-            .filter((f): f is BuylistFinishView => f !== null);
+        const finishes: BuylistFinishView[] = groupBuylistByFinish(offers).map((group) => {
+            const views: BuylistOfferView[] = group.offers.map((o) => ({
+                vendor: vendorDisplayName(o.provider),
+                price: toDollar(o.price),
+                priceRaw: o.price,
+                isBest: o.isBest,
+            }));
+            return {
+                finish: this.FINISH_LABELS[group.finish],
+                best: views[0],
+                offers: views,
+                hasMultiple: views.length > 1,
+            };
+        });
 
         return { finishes, hasAny: finishes.length > 0 };
     }

--- a/src/http/hbs/optimizer/dto/optimizer.view.dto.ts
+++ b/src/http/hbs/optimizer/dto/optimizer.view.dto.ts
@@ -1,15 +1,8 @@
 import { CashVsCreditResult } from 'src/core/pricing/cash-vs-credit.policy';
+import { OptimizerBuyLine } from 'src/core/optimizer/optimizer.types';
 import { BaseViewDto } from 'src/http/base/base.view.dto';
 
-export interface OptimizerBuyLine {
-    name: string;
-    setCode: string;
-    number: string;
-    finish: 'normal' | 'foil';
-    quantity: number;
-    unitPrice: number | null;
-    lineTotal: number | null;
-}
+export { OptimizerBuyLine };
 
 export class OptimizerViewDto extends BaseViewDto {
     readonly vendorName: string;

--- a/src/http/hbs/optimizer/sell-optimizer.orchestrator.ts
+++ b/src/http/hbs/optimizer/sell-optimizer.orchestrator.ts
@@ -1,94 +1,26 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { BuyListService } from 'src/core/buy-list/buy-list.service';
-import { InventoryService } from 'src/core/inventory/inventory.service';
-import { CashVsCreditResult, computeCashVsCredit } from 'src/core/pricing/cash-vs-credit.policy';
-import { DEFAULT_STORE_CREDIT_BONUS, vendorDisplayName } from 'src/core/pricing/vendor';
+import { OptimizerPlan } from 'src/core/optimizer/optimizer.types';
+import { SellOptimizerService } from 'src/core/optimizer/sell-optimizer.service';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
-import { OptimizerBuyLine, OptimizerViewDto } from './dto/optimizer.view.dto';
-
-/** The single sell-to vendor today (see ROADMAP 6.9 — single-source). */
-const VENDOR_KEY = 'cardkingdom';
-
-interface OptimizerData {
-    vendorName: string;
-    cashValue: number;
-    sellItemCount: number;
-    buyListRetail: number;
-    buyLines: OptimizerBuyLine[];
-    itemsWithoutPrice: number;
-}
+import { OptimizerViewDto } from './dto/optimizer.view.dto';
 
 @Injectable()
 export class SellOptimizerOrchestrator {
     private readonly LOGGER = getLogger(SellOptimizerOrchestrator.name);
 
     constructor(
-        @Inject(InventoryService) private readonly inventoryService: InventoryService,
-        @Inject(BuyListService) private readonly buyListService: BuyListService
+        @Inject(SellOptimizerService) private readonly optimizerService: SellOptimizerService
     ) {
         this.LOGGER.debug('Initialized');
-    }
-
-    /** Clamp a bonus query param (fraction, e.g. 0.3) to a sane range; default on bad input. */
-    private parseBonus(raw?: string): number {
-        if (raw === undefined || raw === '') return DEFAULT_STORE_CREDIT_BONUS;
-        const n = Number(raw);
-        if (!Number.isFinite(n) || n < 0) return DEFAULT_STORE_CREDIT_BONUS;
-        return Math.min(n, 2);
-    }
-
-    private async gather(userId: number): Promise<OptimizerData> {
-        const [sellPlan, buyList] = await Promise.all([
-            this.inventoryService.sellPlanForUser(userId),
-            this.buyListService.list(userId),
-        ]);
-
-        const vendorGroup = sellPlan.groups.find((g) => g.provider === VENDOR_KEY);
-        const cashValue = vendorGroup?.payout ?? 0;
-        const sellItemCount = vendorGroup?.items.length ?? 0;
-
-        let buyListRetail = 0;
-        let itemsWithoutPrice = 0;
-        const buyLines: OptimizerBuyLine[] = buyList.map((item) => {
-            const price = item.card?.prices?.[0];
-            const unit = item.isFoil ? price?.foil : price?.normal;
-            const unitPrice = unit != null ? Number(unit) : null;
-            const lineTotal = unitPrice != null ? unitPrice * item.quantity : null;
-            if (lineTotal != null) buyListRetail += lineTotal;
-            else itemsWithoutPrice++;
-            return {
-                name: item.card?.name ?? item.cardId,
-                setCode: (item.card?.setCode ?? '').toUpperCase(),
-                number: item.card?.number ?? '',
-                finish: item.isFoil ? 'foil' : 'normal',
-                quantity: item.quantity,
-                unitPrice,
-                lineTotal,
-            };
-        });
-
-        return {
-            vendorName: vendorDisplayName(VENDOR_KEY),
-            cashValue,
-            sellItemCount,
-            buyListRetail,
-            buyLines,
-            itemsWithoutPrice,
-        };
     }
 
     async buildView(req: AuthenticatedRequest, bonusParamRaw?: string): Promise<OptimizerViewDto> {
         try {
             HttpErrorHandler.validateAuthenticatedRequest(req);
-            const bonusPct = this.parseBonus(bonusParamRaw);
-            const data = await this.gather(req.user.id);
-            const result = computeCashVsCredit({
-                cashValue: data.cashValue,
-                buyListRetail: data.buyListRetail,
-                bonusPct,
-            });
+            const bonusPct = SellOptimizerService.parseBonus(bonusParamRaw);
+            const plan = await this.optimizerService.buildPlan(req.user.id, bonusPct);
 
             return new OptimizerViewDto({
                 authenticated: true,
@@ -97,12 +29,12 @@ export class SellOptimizerOrchestrator {
                     { label: 'Home', url: '/' },
                     { label: 'Cash vs. Credit', url: '/optimizer' },
                 ],
-                vendorName: data.vendorName,
-                sellItemCount: data.sellItemCount,
-                itemsWithoutPrice: data.itemsWithoutPrice,
-                buyLines: data.buyLines,
+                vendorName: plan.vendorName,
+                sellItemCount: plan.sellItemCount,
+                itemsWithoutPrice: plan.itemsWithoutPrice,
+                buyLines: plan.buyLines,
                 defaultBonusPct: bonusPct,
-                result,
+                result: plan.result,
             });
         } catch (error) {
             this.LOGGER.debug(`Error building optimizer view: ${error?.message}`);
@@ -113,14 +45,9 @@ export class SellOptimizerOrchestrator {
     /** CSV of the plan for the given bonus. */
     async buildCsv(req: AuthenticatedRequest, bonusParamRaw?: string): Promise<string> {
         HttpErrorHandler.validateAuthenticatedRequest(req);
-        const bonusPct = this.parseBonus(bonusParamRaw);
-        const data = await this.gather(req.user.id);
-        const result = computeCashVsCredit({
-            cashValue: data.cashValue,
-            buyListRetail: data.buyListRetail,
-            bonusPct,
-        });
-        return toCsv(data, result);
+        const bonusPct = SellOptimizerService.parseBonus(bonusParamRaw);
+        const plan = await this.optimizerService.buildPlan(req.user.id, bonusPct);
+        return toCsv(plan);
     }
 }
 
@@ -129,10 +56,11 @@ function csvField(v: string | number): string {
     return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
-function toCsv(data: OptimizerData, result: CashVsCreditResult): string {
+function toCsv(plan: OptimizerPlan): string {
+    const result = plan.result;
     const lines: string[] = [];
     lines.push('section,field,value');
-    lines.push(`summary,vendor,${csvField(data.vendorName)}`);
+    lines.push(`summary,vendor,${csvField(plan.vendorName)}`);
     lines.push(`summary,sell_cash_value,${result.cashValue}`);
     lines.push(`summary,store_credit_bonus_pct,${Math.round(result.bonusPct * 100)}`);
     lines.push(`summary,store_credit,${result.storeCredit}`);
@@ -144,7 +72,7 @@ function toCsv(data: OptimizerData, result: CashVsCreditResult): string {
     lines.push(`summary,locked_leftover_credit,${result.lockedCredit}`);
     lines.push('');
     lines.push('buy_list,name,set_code,number,finish,quantity,unit_retail,line_retail');
-    for (const l of data.buyLines) {
+    for (const l of plan.buyLines) {
         lines.push(
             [
                 'buy_list',

--- a/src/http/public/js/optimizer.js
+++ b/src/http/public/js/optimizer.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!root || !input) return;
 
     var defaultBonus = parseFloat(root.getAttribute('data-default-bonus')) || 0;
+    var MAX_BONUS_PCT = 200; // matches input max and the server's [0, 2] clamp
     var debounceTimer = null;
     var latestRequest = 0;
 
@@ -30,6 +31,9 @@ document.addEventListener('DOMContentLoaded', function () {
     function bonusFraction() {
         var pct = parseFloat(input.value);
         if (!isFinite(pct) || pct < 0) pct = 0;
+        // Match the input's max and the server clamp (200% = 2.0) so the fetch
+        // and export never use an out-of-range bonus the server would reject.
+        if (pct > MAX_BONUS_PCT) pct = MAX_BONUS_PCT;
         return pct / 100;
     }
 

--- a/src/http/public/js/optimizer.js
+++ b/src/http/public/js/optimizer.js
@@ -1,17 +1,20 @@
 /**
- * Cash-vs-store-credit optimizer (Phase 6.5). The cash value (C) and buy-list
- * retail (R) are fixed per page load; only the bonus % changes, so recompute
- * the comparison client-side as the user edits it. Mirrors
- * src/core/pricing/cash-vs-credit.policy.ts — keep the two in sync.
+ * Cash-vs-store-credit optimizer (Phase 6.5). The buy-list table is fixed per
+ * page load; only the bonus % changes. As the user edits it, fetch the
+ * recomputed comparison from GET /api/v1/optimizer?bonus= (same backend the
+ * page rendered) instead of mirroring cash-vs-credit.policy.ts client-side.
+ *
+ * The server already renders the result for the default bonus, so we only fetch
+ * on user change. Requests are debounced and the latest one wins.
  */
 document.addEventListener('DOMContentLoaded', function () {
     var root = document.getElementById('optimizer-root');
     var input = document.getElementById('bonus-input');
     if (!root || !input) return;
 
-    var C = parseFloat(root.getAttribute('data-cash-value')) || 0;
-    var R = parseFloat(root.getAttribute('data-buy-list-retail')) || 0;
     var defaultBonus = parseFloat(root.getAttribute('data-default-bonus')) || 0;
+    var debounceTimer = null;
+    var latestRequest = 0;
 
     function money(n) {
         return (
@@ -24,49 +27,32 @@ document.addEventListener('DOMContentLoaded', function () {
         if (el) el.textContent = text;
     }
 
-    function compute(b) {
-        var storeCredit = C * (1 + b);
-        var cashOutOfPocket = Math.max(0, R - C);
-        var cashLeftover = Math.max(0, C - R);
-        var creditOutOfPocket = Math.max(0, R - storeCredit);
-        var lockedCredit = Math.max(0, storeCredit - R);
-        var creditAdvantage = cashOutOfPocket - creditOutOfPocket;
-        return {
-            storeCredit: storeCredit,
-            cashOutOfPocket: cashOutOfPocket,
-            cashLeftover: cashLeftover,
-            creditOutOfPocket: creditOutOfPocket,
-            lockedCredit: lockedCredit,
-            creditAdvantage: creditAdvantage,
-            recommendCredit: creditAdvantage > 0,
-        };
-    }
-
-    function render() {
+    function bonusFraction() {
         var pct = parseFloat(input.value);
         if (!isFinite(pct) || pct < 0) pct = 0;
-        var b = pct / 100;
-        var r = compute(b);
+        return pct / 100;
+    }
 
-        setText('store-credit', money(r.storeCredit));
-        setText('store-credit-sub', '+' + money(r.storeCredit - C) + ' vs cash');
-        setText('cash-oop', money(r.cashOutOfPocket));
-        setText('credit-oop', money(r.creditOutOfPocket));
-        setText('credit-advantage', money(r.creditAdvantage));
-        setText('locked-credit', money(r.lockedCredit));
+    function apply(data) {
+        setText('store-credit', money(data.storeCredit));
+        setText('store-credit-sub', '+' + money(data.storeCredit - data.cashValue) + ' vs cash');
+        setText('cash-oop', money(data.cashOutOfPocket));
+        setText('credit-oop', money(data.creditOutOfPocket));
+        setText('credit-advantage', money(data.creditAdvantage));
+        setText('locked-credit', money(data.lockedCredit));
 
         var rec = document.getElementById('recommendation');
         if (rec) {
             var html;
-            if (r.recommendCredit) {
+            if (data.recommendCredit) {
                 html =
                     '<strong>Take store credit.</strong> It saves ' +
-                    money(r.creditAdvantage) +
+                    money(data.creditAdvantage) +
                     ' toward your buy list versus taking cash.';
-            } else if (R > 0) {
+            } else if (data.buyListRetail > 0) {
                 html =
                     '<strong>Take cash.</strong> You&rsquo;re selling more than you&rsquo;re buying — keep ' +
-                    money(r.cashLeftover) +
+                    money(data.cashLeftover) +
                     ' liquid rather than locking it in credit.';
             } else {
                 html =
@@ -74,12 +60,36 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             rec.innerHTML = html;
         }
+    }
 
+    function refresh() {
+        var b = bonusFraction();
+
+        // Export link stays current immediately, independent of the fetch.
         var exportLink = document.getElementById('export-link');
         if (exportLink) exportLink.setAttribute('href', '/optimizer/export.csv?bonus=' + b);
+
+        var requestId = ++latestRequest;
+        fetch('/api/v1/optimizer?bonus=' + b, {
+            headers: { Accept: 'application/json' },
+            credentials: 'same-origin',
+        })
+            .then(function (res) {
+                return res.ok ? res.json() : null;
+            })
+            .then(function (body) {
+                // Ignore stale responses and failures; keep the last good values.
+                if (requestId !== latestRequest || !body || !body.data) return;
+                apply(body.data);
+            })
+            .catch(function () {
+                /* network error — leave the current values in place */
+            });
     }
 
     input.value = String(Math.round(defaultBonus * 100));
-    render();
-    input.addEventListener('input', render);
+    input.addEventListener('input', function () {
+        if (debounceTimer) clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(refresh, 250);
+    });
 });

--- a/src/http/views/optimizer.hbs
+++ b/src/http/views/optimizer.hbs
@@ -1,6 +1,5 @@
 <section id="optimizer-root"
     class="border border-gray-200 dark:border-midnight-700 rounded-xl sm:m-0 md:m-4"
-    data-cash-value="{{result.cashValue}}" data-buy-list-retail="{{result.buyListRetail}}"
     data-default-bonus="{{defaultBonusPct}}">
     <section class="text-center bg-teal-50 dark:bg-midnight-900 mb-4 rounded-t-lg py-4 px-4">
         <h1 class="page-title">Cash vs. Store Credit</h1>

--- a/test/core/card/card.service.spec.ts
+++ b/test/core/card/card.service.spec.ts
@@ -151,12 +151,14 @@ describe('CardService', () => {
     });
 
     describe('findBySetCodeAndNumber', () => {
-        it('should return card when found', async () => {
+        it('should return card when found, normalizing the set code to lowercase', async () => {
             repository.findBySetCodeAndNumber.mockResolvedValue(testCard);
 
             const result = await service.findBySetCodeAndNumber('TST', '123');
 
-            expect(repository.findBySetCodeAndNumber).toHaveBeenCalledWith('TST', '123', [
+            // Codes are stored lowercase + the query is case-sensitive, so the
+            // service lowercases before the lookup (handles uppercase API input).
+            expect(repository.findBySetCodeAndNumber).toHaveBeenCalledWith('tst', '123', [
                 'set',
                 'legalities',
                 'prices',
@@ -169,7 +171,7 @@ describe('CardService', () => {
 
             const result = await service.findBySetCodeAndNumber('TST', '999');
 
-            expect(repository.findBySetCodeAndNumber).toHaveBeenCalledWith('TST', '999', [
+            expect(repository.findBySetCodeAndNumber).toHaveBeenCalledWith('tst', '999', [
                 'set',
                 'legalities',
                 'prices',
@@ -181,7 +183,7 @@ describe('CardService', () => {
             repository.findBySetCodeAndNumber.mockRejectedValue(new Error('Database error'));
 
             await expect(service.findBySetCodeAndNumber('TST', '123')).rejects.toThrow(
-                'Error finding card with set code TST and number 123'
+                'Error finding card with set code tst and number 123'
             );
         });
     });

--- a/test/core/optimizer/sell-optimizer.service.spec.ts
+++ b/test/core/optimizer/sell-optimizer.service.spec.ts
@@ -1,0 +1,117 @@
+import { SellOptimizerService } from 'src/core/optimizer/sell-optimizer.service';
+
+describe('SellOptimizerService', () => {
+    let inventoryService: { sellPlanForUser: jest.Mock };
+    let buyListService: { list: jest.Mock };
+    let service: SellOptimizerService;
+
+    beforeEach(() => {
+        inventoryService = { sellPlanForUser: jest.fn() };
+        buyListService = { list: jest.fn() };
+        service = new SellOptimizerService(inventoryService as any, buyListService as any);
+    });
+
+    describe('parseBonus', () => {
+        it('defaults when raw is undefined or empty', () => {
+            expect(SellOptimizerService.parseBonus(undefined)).toBe(0.3);
+            expect(SellOptimizerService.parseBonus('')).toBe(0.3);
+        });
+
+        it('defaults on non-numeric or negative input', () => {
+            expect(SellOptimizerService.parseBonus('abc')).toBe(0.3);
+            expect(SellOptimizerService.parseBonus('-1')).toBe(0.3);
+        });
+
+        it('clamps to the UI cap of 2.0 (200%)', () => {
+            expect(SellOptimizerService.parseBonus('5')).toBe(2);
+            expect(SellOptimizerService.parseBonus('0.5')).toBe(0.5);
+            expect(SellOptimizerService.parseBonus('2')).toBe(2);
+        });
+    });
+
+    describe('buildPlan', () => {
+        it('uses the Card Kingdom cash group, retail from buy-list prices, and the cash-vs-credit result', async () => {
+            inventoryService.sellPlanForUser.mockResolvedValue({
+                groups: [{ provider: 'cardkingdom', items: [{}, {}], payout: 14 }],
+                totalPayout: 14,
+                itemsWithOffers: 2,
+                itemsWithoutOffers: 0,
+            });
+            buyListService.list.mockResolvedValue([
+                {
+                    cardId: 'c4',
+                    isFoil: false,
+                    quantity: 2,
+                    card: {
+                        name: 'Test Dragon',
+                        setCode: 'tst',
+                        number: '4',
+                        prices: [{ normal: 20, foil: null }],
+                    },
+                },
+            ]);
+
+            const plan = await service.buildPlan(7, 0.3);
+
+            expect(plan.vendorKey).toBe('cardkingdom');
+            expect(plan.vendorName).toBe('Card Kingdom');
+            expect(plan.cashValue).toBe(14);
+            expect(plan.sellItemCount).toBe(2);
+            expect(plan.buyListRetail).toBe(40);
+            expect(plan.itemsWithoutPrice).toBe(0);
+            expect(plan.buyLines).toEqual([
+                {
+                    name: 'Test Dragon',
+                    setCode: 'TST',
+                    number: '4',
+                    finish: 'normal',
+                    quantity: 2,
+                    unitPrice: 20,
+                    lineTotal: 40,
+                },
+            ]);
+            // C=14, R=40, b=0.3 -> store credit 18.2, recommend credit, advantage C*b=4.2
+            expect(plan.result.storeCredit).toBe(18.2);
+            expect(plan.result.recommendCredit).toBe(true);
+            expect(plan.result.creditAdvantage).toBe(4.2);
+        });
+
+        it('counts buy-list lines with no usable price and keeps them out of retail', async () => {
+            inventoryService.sellPlanForUser.mockResolvedValue({
+                groups: [],
+                totalPayout: 0,
+                itemsWithOffers: 0,
+                itemsWithoutOffers: 0,
+            });
+            buyListService.list.mockResolvedValue([
+                { cardId: 'c9', isFoil: false, quantity: 3, card: { name: 'No Price', setCode: 'tst', number: '9', prices: [] } },
+            ]);
+
+            const plan = await service.buildPlan(7, 0.3);
+
+            expect(plan.cashValue).toBe(0);
+            expect(plan.buyListRetail).toBe(0);
+            expect(plan.itemsWithoutPrice).toBe(1);
+            expect(plan.buyLines[0].unitPrice).toBeNull();
+            expect(plan.buyLines[0].lineTotal).toBeNull();
+        });
+
+        it('uses the foil price for foil buy-list lines', async () => {
+            inventoryService.sellPlanForUser.mockResolvedValue({
+                groups: [],
+                totalPayout: 0,
+                itemsWithOffers: 0,
+                itemsWithoutOffers: 0,
+            });
+            buyListService.list.mockResolvedValue([
+                { cardId: 'c1', isFoil: true, quantity: 1, card: { name: 'Foil Card', setCode: 'tst', number: '1', prices: [{ normal: 5, foil: 12 }] } },
+            ]);
+
+            const plan = await service.buildPlan(7, 0.3);
+
+            expect(plan.buyLines[0].finish).toBe('foil');
+            expect(plan.buyLines[0].unitPrice).toBe(12);
+            expect(plan.buyListRetail).toBe(12);
+        });
+    });
+});

--- a/test/core/pricing/buylist.policy.spec.ts
+++ b/test/core/pricing/buylist.policy.spec.ts
@@ -1,5 +1,5 @@
 import { GranularPrice } from 'src/core/card/granular-price.entity';
-import { bestBuylistOffer } from 'src/core/pricing/buylist.policy';
+import { bestBuylistOffer, groupBuylistByFinish } from 'src/core/pricing/buylist.policy';
 
 function offer(overrides: Partial<GranularPrice> = {}): GranularPrice {
     return new GranularPrice({
@@ -29,5 +29,33 @@ describe('bestBuylistOffer', () => {
         ]);
         expect(result?.price).toBe(7);
         expect(result?.finish).toBe('foil');
+    });
+});
+
+describe('groupBuylistByFinish', () => {
+    it('drops non-NM, zero, and null-priced offers', () => {
+        expect(
+            groupBuylistByFinish([
+                offer({ condition: 'LP', price: 9 }),
+                offer({ price: 0 }),
+                offer({ price: null }),
+            ])
+        ).toEqual([]);
+    });
+
+    it('orders finishes normal, foil, etched and offers highest-first with isBest marked', () => {
+        const groups = groupBuylistByFinish([
+            offer({ finish: 'foil', provider: 'cardkingdom', price: 7 }),
+            offer({ finish: 'normal', provider: 'cardsphere', price: 3.25 }),
+            offer({ finish: 'normal', provider: 'cardkingdom', price: 3.5 }),
+        ]);
+
+        expect(groups.map((g) => g.finish)).toEqual(['normal', 'foil']);
+        const normal = groups[0];
+        expect(normal.offers).toEqual([
+            { provider: 'cardkingdom', price: 3.5, isBest: true },
+            { provider: 'cardsphere', price: 3.25, isBest: false },
+        ]);
+        expect(groups[1].offers).toEqual([{ provider: 'cardkingdom', price: 7, isBest: true }]);
     });
 });

--- a/test/frontend/optimizer.spec.js
+++ b/test/frontend/optimizer.spec.js
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ */
+
+function setupDom(defaultBonus) {
+    document.body.innerHTML =
+        '<section id="optimizer-root" data-default-bonus="' + defaultBonus + '">' +
+        '<input id="bonus-input" type="number" />' +
+        '<div id="store-credit"></div>' +
+        '<div id="store-credit-sub"></div>' +
+        '<div id="cash-oop"></div>' +
+        '<div id="credit-oop"></div>' +
+        '<div id="credit-advantage"></div>' +
+        '<div id="locked-credit"></div>' +
+        '<div id="recommendation"></div>' +
+        '<a id="export-link" href="/optimizer/export.csv?bonus=0.3"></a>' +
+        '</section>';
+}
+
+// The jsdom document persists across tests, so each require would stack another
+// DOMContentLoaded listener. Capture them instead of registering on document and
+// run only the freshly-required one.
+var domReadyHandlers = [];
+
+function loadScript() {
+    jest.resetModules();
+    domReadyHandlers = [];
+    require('../../src/http/public/js/optimizer.js');
+    domReadyHandlers.forEach(function (cb) { cb(); });
+}
+
+function jsonResponse(data) {
+    return Promise.resolve({ ok: true, json: function () { return Promise.resolve({ success: true, data: data }); } });
+}
+
+// Flush several microtask ticks (the fetch chain resolves over a few hops).
+function flushPromises() {
+    var p = Promise.resolve();
+    for (var i = 0; i < 5; i++) p = p.then(function () {});
+    return p;
+}
+
+describe('optimizer.js', function () {
+    var realAddEventListener;
+
+    beforeEach(function () {
+        jest.useFakeTimers();
+        global.fetch = jest.fn();
+        realAddEventListener = document.addEventListener.bind(document);
+        jest.spyOn(document, 'addEventListener').mockImplementation(function (type, cb, opts) {
+            if (type === 'DOMContentLoaded') domReadyHandlers.push(cb);
+            else realAddEventListener(type, cb, opts);
+        });
+    });
+
+    afterEach(function () {
+        document.addEventListener.mockRestore();
+        jest.clearAllTimers();
+        jest.useRealTimers();
+        delete global.fetch;
+    });
+
+    it('seeds the input from the default bonus and does not fetch on load', function () {
+        setupDom(0.3);
+        loadScript();
+        expect(document.getElementById('bonus-input').value).toBe('30');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('debounces and fetches the API with the bonus as a fraction on change', function () {
+        setupDom(0.3);
+        global.fetch.mockReturnValue(jsonResponse({}));
+        loadScript();
+
+        var input = document.getElementById('bonus-input');
+        input.value = '50';
+        input.dispatchEvent(new Event('input'));
+        input.value = '60';
+        input.dispatchEvent(new Event('input'));
+
+        // Debounced: nothing fired yet, and only one call after the window.
+        expect(global.fetch).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(250);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch.mock.calls[0][0]).toBe('/api/v1/optimizer?bonus=0.6');
+        expect(global.fetch.mock.calls[0][1].credentials).toBe('same-origin');
+    });
+
+    it('renders the recommendation and tiles from the API response', async function () {
+        setupDom(0.3);
+        global.fetch.mockReturnValue(
+            jsonResponse({
+                cashValue: 14,
+                storeCredit: 18.2,
+                buyListRetail: 40,
+                cashOutOfPocket: 26,
+                creditOutOfPocket: 21.8,
+                creditAdvantage: 4.2,
+                cashLeftover: 0,
+                lockedCredit: 0,
+                recommendCredit: true,
+            })
+        );
+        loadScript();
+
+        var input = document.getElementById('bonus-input');
+        input.value = '30';
+        input.dispatchEvent(new Event('input'));
+        jest.advanceTimersByTime(250);
+        await flushPromises();
+
+        expect(document.getElementById('store-credit').textContent).toBe('$18.20');
+        expect(document.getElementById('store-credit-sub').textContent).toBe('+$4.20 vs cash');
+        expect(document.getElementById('credit-advantage').textContent).toBe('$4.20');
+        expect(document.getElementById('recommendation').innerHTML).toContain('Take store credit');
+    });
+
+    it('updates the export link immediately, independent of the fetch', function () {
+        setupDom(0.3);
+        global.fetch.mockReturnValue(jsonResponse({}));
+        loadScript();
+
+        var input = document.getElementById('bonus-input');
+        input.value = '50';
+        input.dispatchEvent(new Event('input'));
+        jest.advanceTimersByTime(250);
+
+        expect(document.getElementById('export-link').getAttribute('href')).toBe(
+            '/optimizer/export.csv?bonus=0.5'
+        );
+    });
+
+    it('ignores a stale response when a newer request has been made', async function () {
+        setupDom(0.3);
+        var resolveFirst;
+        // Request #1 stays pending until we release it; request #2 resolves now.
+        var firstGate = new Promise(function (r) { resolveFirst = r; });
+        global.fetch
+            .mockReturnValueOnce(
+                firstGate.then(function () {
+                    return { ok: true, json: function () { return Promise.resolve({ data: { storeCredit: 1, cashValue: 0 } }); } };
+                })
+            )
+            .mockReturnValueOnce(jsonResponse({ storeCredit: 99, cashValue: 0 }));
+
+        loadScript();
+        var input = document.getElementById('bonus-input');
+
+        input.value = '10';
+        input.dispatchEvent(new Event('input'));
+        jest.advanceTimersByTime(250); // fires request #1 (pending on the gate)
+        input.value = '20';
+        input.dispatchEvent(new Event('input'));
+        jest.advanceTimersByTime(250); // fires request #2 (resolves immediately)
+        await flushPromises();
+
+        expect(document.getElementById('store-credit').textContent).toBe('$99.00');
+
+        resolveFirst(); // let the now-stale request #1 resolve
+        await flushPromises();
+
+        // The stale response must not overwrite the newer one.
+        expect(document.getElementById('store-credit').textContent).toBe('$99.00');
+    });
+});

--- a/test/frontend/optimizer.spec.js
+++ b/test/frontend/optimizer.spec.js
@@ -115,6 +115,22 @@ describe('optimizer.js', function () {
         expect(document.getElementById('recommendation').innerHTML).toContain('Take store credit');
     });
 
+    it('clamps an over-cap bonus to 200% (2.0) for fetch and export', function () {
+        setupDom(0.3);
+        global.fetch.mockReturnValue(jsonResponse({}));
+        loadScript();
+
+        var input = document.getElementById('bonus-input');
+        input.value = '300';
+        input.dispatchEvent(new Event('input'));
+        jest.advanceTimersByTime(250);
+
+        expect(global.fetch.mock.calls[0][0]).toBe('/api/v1/optimizer?bonus=2');
+        expect(document.getElementById('export-link').getAttribute('href')).toBe(
+            '/optimizer/export.csv?bonus=2'
+        );
+    });
+
     it('updates the export link immediately, independent of the fetch', function () {
         setupDom(0.3);
         global.fetch.mockReturnValue(jsonResponse({}));

--- a/test/http/api/card/card-api.presenter.spec.ts
+++ b/test/http/api/card/card-api.presenter.spec.ts
@@ -1,9 +1,22 @@
 import { TCGPLAYER_PRODUCT_URL_TEMPLATE } from 'src/core/affiliate/affiliate-link.policy';
 import { Card } from 'src/core/card/card.entity';
 import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { GranularPrice } from 'src/core/card/granular-price.entity';
 import { Price } from 'src/core/card/price.entity';
 import { Set } from 'src/core/set/set.entity';
 import { CardApiPresenter } from 'src/http/api/card/card-api.presenter';
+
+function buylistOffer(overrides: Partial<GranularPrice> = {}): GranularPrice {
+    return new GranularPrice({
+        cardId: 'card-1',
+        provider: 'cardkingdom',
+        priceType: 'buylist',
+        finish: 'normal',
+        condition: 'NM',
+        price: 3.5,
+        ...overrides,
+    });
+}
 
 function createCard(overrides: Partial<Card> = {}): Card {
     return new Card({
@@ -179,6 +192,38 @@ describe('CardApiPresenter', () => {
 
             expect(result.prices).toHaveProperty('normalChangeWeekly');
             expect(result.prices).toHaveProperty('foilChangeWeekly');
+        });
+    });
+
+    describe('toBuylist', () => {
+        it('groups offers by finish with the best marked and the vendor display name', () => {
+            const result = CardApiPresenter.toBuylist('card-1', [
+                buylistOffer({ provider: 'cardsphere', price: 3.25 }),
+                buylistOffer({ provider: 'cardkingdom', price: 3.5 }),
+                buylistOffer({ provider: 'cardkingdom', finish: 'foil', price: 7 }),
+            ]);
+
+            expect(result.cardId).toBe('card-1');
+            expect(result.hasAny).toBe(true);
+            expect(result.finishes.map((f) => f.finish)).toEqual(['normal', 'foil']);
+            expect(result.finishes[0].best).toEqual({
+                provider: 'cardkingdom',
+                vendor: 'Card Kingdom',
+                price: 3.5,
+                isBest: true,
+            });
+            expect(result.finishes[0].offers).toHaveLength(2);
+            expect(result.finishes[1].best.price).toBe(7);
+        });
+
+        it('returns hasAny=false when there are no usable offers', () => {
+            const result = CardApiPresenter.toBuylist('card-1', [
+                buylistOffer({ condition: 'LP' }),
+                buylistOffer({ price: 0 }),
+            ]);
+
+            expect(result.hasAny).toBe(false);
+            expect(result.finishes).toEqual([]);
         });
     });
 });

--- a/test/http/api/inventory/inventory-api.presenter.spec.ts
+++ b/test/http/api/inventory/inventory-api.presenter.spec.ts
@@ -201,4 +201,53 @@ describe('InventoryApiPresenter', () => {
             expect(result[0].normalQuantity).toBe(0);
         });
     });
+
+    describe('toSellPlan', () => {
+        it('maps a sell plan to vendor groups and totals with raw numbers', () => {
+            const card = createCard();
+            const inventory = createInventory({ card, quantity: 4 });
+            const offer = { provider: 'cardkingdom', price: 3.5 } as any;
+            const plan = {
+                totalPayout: 14,
+                itemsWithOffers: 1,
+                itemsWithoutOffers: 2,
+                groups: [
+                    {
+                        provider: 'cardkingdom',
+                        payout: 14,
+                        items: [
+                            {
+                                inventory,
+                                offer,
+                                sellableQuantity: 4,
+                                quantityCapped: false,
+                                payout: 14,
+                            },
+                        ],
+                    },
+                ],
+            } as any;
+
+            const result = InventoryApiPresenter.toSellPlan(plan);
+
+            expect(result.totalPayout).toBe(14);
+            expect(result.itemsWithOffers).toBe(1);
+            expect(result.itemsWithoutOffers).toBe(2);
+            expect(result.groups).toHaveLength(1);
+            expect(result.groups[0].provider).toBe('cardkingdom');
+            expect(result.groups[0].vendor).toBe('Card Kingdom');
+            expect(result.groups[0].items[0]).toEqual({
+                cardId: 'card-1',
+                cardName: 'Lightning Bolt',
+                setCode: 'lea',
+                number: '161',
+                finish: 'normal',
+                ownedQuantity: 4,
+                sellableQuantity: 4,
+                quantityCapped: false,
+                offer: 3.5,
+                payout: 14,
+            });
+        });
+    });
 });

--- a/test/http/api/optimizer/optimizer-api.presenter.spec.ts
+++ b/test/http/api/optimizer/optimizer-api.presenter.spec.ts
@@ -1,0 +1,77 @@
+import { computeCashVsCredit } from 'src/core/pricing/cash-vs-credit.policy';
+import { OptimizerPlan } from 'src/core/optimizer/optimizer.types';
+import { OptimizerApiPresenter } from 'src/http/api/optimizer/optimizer-api.presenter';
+
+function plan(overrides: Partial<OptimizerPlan> = {}): OptimizerPlan {
+    const bonusPct = overrides.bonusPct ?? 0.3;
+    return {
+        vendorKey: 'cardkingdom',
+        vendorName: 'Card Kingdom',
+        cashValue: 14,
+        sellItemCount: 2,
+        buyListRetail: 40,
+        itemsWithoutPrice: 0,
+        bonusPct,
+        buyLines: [
+            {
+                name: 'Test Dragon',
+                setCode: 'TST',
+                number: '4',
+                finish: 'normal',
+                quantity: 2,
+                unitPrice: 20,
+                lineTotal: 40,
+            },
+        ],
+        result: computeCashVsCredit({ cashValue: 14, buyListRetail: 40, bonusPct }),
+        ...overrides,
+    };
+}
+
+describe('OptimizerApiPresenter', () => {
+    it('flattens the cash-vs-credit result and buy lines into the response DTO', () => {
+        const result = OptimizerApiPresenter.toResponse(plan());
+
+        expect(result.vendor).toBe('Card Kingdom');
+        expect(result.bonusPct).toBe(0.3);
+        expect(result.cashValue).toBe(14);
+        expect(result.buyListRetail).toBe(40);
+        expect(result.storeCredit).toBe(18.2);
+        expect(result.recommendCredit).toBe(true);
+        expect(result.creditAdvantage).toBe(4.2);
+        expect(result.sellItemCount).toBe(2);
+        expect(result.itemsWithoutPrice).toBe(0);
+        expect(result.buyLines).toEqual([
+            {
+                name: 'Test Dragon',
+                setCode: 'TST',
+                number: '4',
+                finish: 'normal',
+                quantity: 2,
+                unitPrice: 20,
+                lineTotal: 40,
+            },
+        ]);
+    });
+
+    it('preserves null unit/line prices for unpriced buy-list lines', () => {
+        const result = OptimizerApiPresenter.toResponse(
+            plan({
+                buyLines: [
+                    {
+                        name: 'No Price',
+                        setCode: 'TST',
+                        number: '9',
+                        finish: 'normal',
+                        quantity: 3,
+                        unitPrice: null,
+                        lineTotal: null,
+                    },
+                ],
+            })
+        );
+
+        expect(result.buyLines[0].unitPrice).toBeNull();
+        expect(result.buyLines[0].lineTotal).toBeNull();
+    });
+});

--- a/test/integration/api-sell-tools.e2e-spec.ts
+++ b/test/integration/api-sell-tools.e2e-spec.ts
@@ -1,0 +1,173 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import {
+    closeTestApp,
+    createTestApp,
+    getTestUserId,
+    loginTestUserApi,
+    TEST_CARD_ID,
+    TEST_CARD_ID_4,
+} from './setup';
+
+/**
+ * JSON API for the Phase 6 sell tools (#530): buylist pricing, market sell
+ * value, and the cash-vs-credit optimizer. Same backends as the HBS pages.
+ *
+ * Seeded buylist (global): card 1 CK $3.50 / cardsphere $3.25 normal, CK $7.00
+ * foil. Per-user setup: own card 1 normal x4 + foil x1 (CK cash C = $21.00);
+ * buy-list card 4 x2 at retail $20.00 (R = $40.00).
+ */
+describe('Sell-tools API (e2e)', () => {
+    let app: INestApplication;
+    let ds: DataSource;
+    let bearerToken: string;
+    let userId: number;
+
+    beforeAll(async () => {
+        app = await createTestApp();
+        ds = app.get(DataSource);
+        bearerToken = await loginTestUserApi(app);
+        userId = await getTestUserId(app);
+
+        await ds.query(`DELETE FROM inventory WHERE user_id = $1`, [userId]);
+        await ds.query(`DELETE FROM buy_list WHERE user_id = $1`, [userId]);
+        await ds.query(
+            `INSERT INTO inventory (user_id, card_id, foil, quantity)
+             VALUES ($1, $2, false, 4), ($1, $2, true, 1)`,
+            [userId, TEST_CARD_ID]
+        );
+        await ds.query(
+            `INSERT INTO buy_list (user_id, card_id, foil, quantity) VALUES ($1, $2, false, 2)`,
+            [userId, TEST_CARD_ID_4]
+        );
+    }, 30000);
+
+    afterAll(async () => {
+        await ds.query(`DELETE FROM inventory WHERE user_id = $1`, [userId]);
+        await ds.query(`DELETE FROM buy_list WHERE user_id = $1`, [userId]);
+        await closeTestApp(app);
+    });
+
+    describe('GET /api/v1/cards/:setCode/:number/buylist', () => {
+        it('returns offers grouped by finish, best first, with raw numbers', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/cards/tst/1/buylist')
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            const data = res.body.data;
+            expect(data.hasAny).toBe(true);
+            expect(data.finishes.map((f: any) => f.finish)).toEqual(['normal', 'foil']);
+
+            const normal = data.finishes[0];
+            expect(normal.best).toEqual({
+                provider: 'cardkingdom',
+                vendor: 'Card Kingdom',
+                price: 3.5,
+                isBest: true,
+            });
+            // The seeded retail row for card 1 must not leak into buylist offers.
+            expect(normal.offers).toHaveLength(2);
+            expect(normal.offers[1]).toEqual({
+                provider: 'cardsphere',
+                vendor: 'Cardsphere',
+                price: 3.25,
+                isBest: false,
+            });
+            expect(data.finishes[1].best.price).toBe(7);
+        });
+
+        it('returns the same data by card id', async () => {
+            const res = await request(app.getHttpServer())
+                .get(`/api/v1/cards/${TEST_CARD_ID}/buylist`)
+                .expect(200);
+            expect(res.body.data.finishes[0].best.price).toBe(3.5);
+        });
+
+        it('returns hasAny=false for a card with no buylist offers', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/cards/tst/4/buylist')
+                .expect(200);
+            expect(res.body.data.hasAny).toBe(false);
+            expect(res.body.data.finishes).toEqual([]);
+        });
+
+        it('404s for an unknown card', async () => {
+            await request(app.getHttpServer()).get('/api/v1/cards/tst/9999/buylist').expect(404);
+        });
+    });
+
+    describe('GET /api/v1/inventory/sell', () => {
+        it('requires authentication', async () => {
+            await request(app.getHttpServer()).get('/api/v1/inventory/sell').expect(401);
+        });
+
+        it('returns the market sell value plan grouped by vendor', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/inventory/sell')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            const data = res.body.data;
+            expect(data.totalPayout).toBe(21); // 4*3.50 + 1*7.00
+            expect(data.itemsWithOffers).toBe(2);
+            expect(data.itemsWithoutOffers).toBe(0);
+            expect(data.groups).toHaveLength(1);
+            expect(data.groups[0].provider).toBe('cardkingdom');
+            expect(data.groups[0].vendor).toBe('Card Kingdom');
+            expect(data.groups[0].payout).toBe(21);
+
+            const normalItem = data.groups[0].items.find((i: any) => i.finish === 'normal');
+            expect(normalItem.offer).toBe(3.5);
+            expect(normalItem.ownedQuantity).toBe(4);
+            expect(normalItem.sellableQuantity).toBe(4);
+            expect(normalItem.payout).toBe(14);
+        });
+    });
+
+    describe('GET /api/v1/optimizer', () => {
+        it('requires authentication', async () => {
+            await request(app.getHttpServer()).get('/api/v1/optimizer').expect(401);
+        });
+
+        it('returns the cash-vs-credit recommendation at the default bonus', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/optimizer')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            const data = res.body.data;
+            expect(data.vendor).toBe('Card Kingdom');
+            expect(data.bonusPct).toBe(0.3);
+            expect(data.cashValue).toBe(21);
+            expect(data.buyListRetail).toBe(40);
+            expect(data.storeCredit).toBe(27.3); // 21 * 1.3
+            expect(data.recommendCredit).toBe(true);
+            expect(data.buyLines).toHaveLength(1);
+            expect(data.buyLines[0]).toEqual({
+                name: 'Test Dragon',
+                setCode: 'TST',
+                number: '4',
+                finish: 'normal',
+                quantity: 2,
+                unitPrice: 20,
+                lineTotal: 40,
+            });
+        });
+
+        it('honors a bonus override and clamps to the UI cap of 2.0', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/optimizer?bonus=0.5')
+                .set('Authorization', bearerToken)
+                .expect(200);
+            expect(res.body.data.storeCredit).toBe(31.5); // 21 * 1.5
+
+            const clamped = await request(app.getHttpServer())
+                .get('/api/v1/optimizer?bonus=99')
+                .set('Authorization', bearerToken)
+                .expect(200);
+            expect(clamped.body.data.bonusPct).toBe(2);
+        });
+    });
+});


### PR DESCRIPTION
Closes #530. Exposes the Phase 6 sell tools — buylist pricing, market sell value, and the cash-vs-credit optimizer — on `/api/v1`, and points the optimizer page at the new endpoint. Built **DRY**: the JSON API and the HBS pages share one backend (services/policies/presenters), no duplicated logic.

## Endpoints (auth mirrors the pages)
- `GET /api/v1/cards/:setCode/:number/buylist` + `GET /api/v1/cards/:cardId/buylist` — **public** (card page is public); per-finish best + offers, raw numbers.
- `GET /api/v1/inventory/sell` — **auth**; market sell value plan grouped by vendor with totals.
- `GET /api/v1/optimizer?bonus=` — **auth**; cash-vs-credit recommendation + buy lines. Bonus clamped to `[0, 2]`.

## DRY extractions (so page + API share one backend)
- **`SellOptimizerService`** lifted into `CoreModule` (the HBS optimizer orchestrator's private `gather()`/`parseBonus()` moved here); the page now delegates to it.
- **`groupBuylistByFinish`** added to `buylist.policy`; the card-page presenter and the API presenter both consume it.
- The sell endpoint reuses the existing `inventoryService.sellPlanForUser`.

## Optimizer page now calls the API
`optimizer.js` no longer mirrors `cash-vs-credit.policy.ts` in JS — on bonus change it fetches `GET /api/v1/optimizer?bonus=` and renders the response.
- Debounced (250ms), same-origin credentialed fetch; latest request wins (stale responses ignored); graceful fallback keeps last values on error.
- Server still renders the default-bonus state, so there is no fetch on load.
- Export link still updates immediately (CSV stays web-side).

## Docs
Marks Phase 6 complete (epic #498 closed, 6.5 shipped) in `ROADMAP.md` + the handoff doc.

## Tests
- Unit: `SellOptimizerService`, `groupBuylistByFinish`, and the three API presenters.
- Integration: `api-sell-tools.e2e-spec.ts` covers all three endpoints (auth + shapes + values).
- Frontend: `optimizer.spec.js` (debounce, render-from-response, export link, stale-response-ignored).
- Existing optimizer/sell/card e2e + full unit/frontend suites stay green; tsc clean.

## Note
Each bonus change now re-runs the sell-plan + buy-list queries server-side (vs. the old pure-client math). Debouncing makes this fine interactively; a pure `POST` variant taking `cashValue`/`buyListRetail`/`bonus` is a cheap future optimization if latency ever warrants it.

Unblocks the pricing/optimizer tools in iwantmymtg-mcp#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)