### PR TITLE
feat: portfolio "By Color" breakdown (10.2)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -299,13 +299,18 @@ The marketing push — community, launch events, analytics — split out from pl
 - [ ] If migrating: execute migration module by module
 - [ ] If keeping: document decision and rationale
 
-### 10.2 Portfolio Breakdown: by=color Dimension
+### 10.2 Portfolio Breakdown: by=color Dimension ✅
 
-Deferred from 3.4. Blocked on Scry repo: needs `card.colors` populated from MTGJSON `colorIdentity` first. Once that lands, add a `color` case to `PortfolioBreakdownRepository.dimensionConfig()` and a tab on `portfolioBreakdown.hbs`.
+Deferred from 3.4. **Built — pending scry release + web deploy to light up.**
 
-- [ ] Scry: ingest `card.colors` from MTGJSON `colorIdentity` into the `card` table
-- [ ] Add `color` case to `BreakdownDimension` and `dimensionConfig()`
-- [ ] Add "By Color" tab to `portfolioBreakdown.hbs`
+**Color model (chosen during scoping):** color is a *membership* dimension, not a partition - a card belongs to **every** color in its identity, so a W/U card lands in both the White and Blue rows and the rows intentionally overlap (they sum past the portfolio total; the tab carries a caption saying so). Cards with no color identity (or not yet ingested, NULL) group under **Colorless**. The same color chips drive a **superset filter**: selecting W+U keeps only cards whose identity contains both (a W/U/R card still qualifies); 'C' filters to colorless and is ignored when real colors are selected.
+
+- [x] Scry: ingest `card.colors` from MTGJSON `colorIdentity` into the `card` table (`text[]`; domain field + mapper + upsert change-detection)
+- [x] `card.colors text[]` column (migration `040`, nullable, mirrored in init SQL)
+- [x] `color` case in `BreakdownDimension` + a dedicated `aggregateColor()` (per-color `unnest` rows + `colors @> ARRAY[...]` superset filter), threaded through service/orchestrator/controller; exposed on the JSON API (`?colors=`) + MCP (`colors[]`)
+- [x] "By Color" tab + color filter chips (W/U/B/R/G/Colorless) + overlap caption in `portfolioBreakdown.hbs`
+
+**Deploy coupling (web + scry, same pattern as 6.7/6.8):** the web side is inert until `card.colors` is populated. Sequence: (1) release scry (additive, safe - the old binary keeps running and never references the column); (2) deploy web - migration `040` adds the column *before* `setup-cron.sh` extracts the new scry binary, so the column exists before the binary writes it. Until the next full ingest runs, existing rows read NULL and show as Colorless.
 
 ### 10.4 Feature: Deck Building
 

--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -108,7 +108,8 @@ CREATE TABLE public.card (
     type character varying NOT NULL,
     tcgplayer_product_id character varying,
     tcgplayer_etched_product_id character varying,
-    scryfall_id character varying
+    scryfall_id character varying,
+    colors text[]
 );
 
 

--- a/migrations/040_card_colors.sql
+++ b/migrations/040_card_colors.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+-- 10.2: add card.colors for the portfolio "By Color" breakdown.
+--
+-- Stores a card's color identity (MTGJSON `colorIdentity`) as a text array of
+-- single-letter codes, e.g. {W,U}; an empty array {} is colorless. Scry writes
+-- this going forward; existing rows read NULL until the next full ingest, which
+-- the breakdown query treats the same as colorless.
+--
+-- Nullable, no default: NULL means "not yet ingested", distinct from the empty
+-- array a re-ingested colorless card gets. text[] lets the breakdown use array
+-- containment (colors @> ARRAY['W','U']) for the superset color filter and
+-- unnest(colors) for per-color slices.
+--
+-- Guarded with IF NOT EXISTS so the untracked migration set stays replayable
+-- across deploys.
+ALTER TABLE public.card ADD COLUMN IF NOT EXISTS colors text[];
+
+COMMIT;

--- a/src/core/portfolio/portfolio-breakdown.entity.ts
+++ b/src/core/portfolio/portfolio-breakdown.entity.ts
@@ -1,11 +1,26 @@
-export type BreakdownDimension = 'set' | 'rarity' | 'type' | 'cost-basis';
+export type BreakdownDimension = 'set' | 'rarity' | 'type' | 'cost-basis' | 'color';
 
 export const BREAKDOWN_DIMENSIONS: BreakdownDimension[] = [
     'set',
     'rarity',
     'type',
     'cost-basis',
+    'color',
 ];
+
+// Color-identity codes (MTGJSON letters) plus 'C' for colorless (empty identity).
+// A card belongs to every color in its identity, so these are membership groups,
+// not a partition - multicolor cards count in each of their colors.
+export const COLOR_CODES = ['W', 'U', 'B', 'R', 'G', 'C'] as const;
+export type ColorCode = (typeof COLOR_CODES)[number];
+export const COLOR_LABELS: Record<string, string> = {
+    W: 'White',
+    U: 'Blue',
+    B: 'Black',
+    R: 'Red',
+    G: 'Green',
+    C: 'Colorless',
+};
 
 export class PortfolioBreakdownSlice {
     readonly key: string;

--- a/src/core/portfolio/portfolio-breakdown.service.ts
+++ b/src/core/portfolio/portfolio-breakdown.service.ts
@@ -3,6 +3,8 @@ import { getLogger } from 'src/logger/global-app-logger';
 import {
     BREAKDOWN_DIMENSIONS,
     BreakdownDimension,
+    COLOR_CODES,
+    ColorCode,
     PortfolioBreakdown,
 } from './portfolio-breakdown.entity';
 import { PortfolioBreakdownRepositoryPort } from './ports/portfolio-breakdown.repository.port';
@@ -20,12 +22,33 @@ export class PortfolioBreakdownService {
         return !!value && (BREAKDOWN_DIMENSIONS as string[]).includes(value);
     }
 
+    /**
+     * Parse a `colors` filter param (e.g. "W,U") into validated, de-duped color
+     * codes, preserving input order. Unknown codes are dropped.
+     */
+    static parseColors(raw: string | undefined | null): ColorCode[] {
+        if (!raw) {
+            return [];
+        }
+        const seen = new Set<string>();
+        const out: ColorCode[] = [];
+        for (const part of raw.split(',')) {
+            const code = part.trim().toUpperCase();
+            if ((COLOR_CODES as readonly string[]).includes(code) && !seen.has(code)) {
+                seen.add(code);
+                out.push(code as ColorCode);
+            }
+        }
+        return out;
+    }
+
     async getBreakdown(
         userId: number,
-        dimension: BreakdownDimension
+        dimension: BreakdownDimension,
+        selectedColors: string[] = []
     ): Promise<PortfolioBreakdown> {
         this.LOGGER.debug(`Get ${dimension} breakdown for user ${userId}.`);
-        const slices = await this.repository.aggregate(userId, dimension);
+        const slices = await this.repository.aggregate(userId, dimension, selectedColors);
         return new PortfolioBreakdown(dimension, slices);
     }
 }

--- a/src/core/portfolio/ports/portfolio-breakdown.repository.port.ts
+++ b/src/core/portfolio/ports/portfolio-breakdown.repository.port.ts
@@ -3,5 +3,9 @@ import { BreakdownDimension, PortfolioBreakdownSlice } from '../portfolio-breakd
 export const PortfolioBreakdownRepositoryPort = 'PortfolioBreakdownRepositoryPort';
 
 export interface PortfolioBreakdownRepositoryPort {
-    aggregate(userId: number, dimension: BreakdownDimension): Promise<PortfolioBreakdownSlice[]>;
+    aggregate(
+        userId: number,
+        dimension: BreakdownDimension,
+        selectedColors?: string[]
+    ): Promise<PortfolioBreakdownSlice[]>;
 }

--- a/src/database/portfolio/portfolio-breakdown.repository.ts
+++ b/src/database/portfolio/portfolio-breakdown.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import {
     BreakdownDimension,
+    COLOR_LABELS,
     PortfolioBreakdownSlice,
 } from 'src/core/portfolio/portfolio-breakdown.entity';
 import { PortfolioBreakdownRepositoryPort } from 'src/core/portfolio/ports/portfolio-breakdown.repository.port';
@@ -28,10 +29,14 @@ export class PortfolioBreakdownRepository implements PortfolioBreakdownRepositor
 
     async aggregate(
         userId: number,
-        dimension: BreakdownDimension
+        dimension: BreakdownDimension,
+        selectedColors: string[] = []
     ): Promise<PortfolioBreakdownSlice[]> {
         if (dimension === 'cost-basis') {
             return this.aggregateCostBasis(userId);
+        }
+        if (dimension === 'color') {
+            return this.aggregateColor(userId, selectedColors);
         }
         const config = this.dimensionConfig(dimension);
         this.LOGGER.debug(`Aggregating portfolio by ${dimension} for user ${userId}.`);
@@ -145,6 +150,75 @@ export class PortfolioBreakdownRepository implements PortfolioBreakdownRepositor
                 new PortfolioBreakdownSlice({
                     key: String(r.key ?? ''),
                     label: String(r.label ?? r.key ?? ''),
+                    cardCount: Number(r.cardCount) || 0,
+                    itemCount: Number(r.itemCount) || 0,
+                    value: Number(r.value) || 0,
+                })
+        );
+    }
+
+    /**
+     * Value grouped by color identity. A card belongs to every color it
+     * contains (a W/U card lands in both the W and U rows), so rows overlap
+     * and intentionally sum past the portfolio total. Cards with no color
+     * identity (or not yet ingested, NULL) group under 'C' (Colorless).
+     *
+     * selectedColors applies a superset filter: passing ['W','U'] keeps only
+     * cards whose identity contains both (a W/U/R card still qualifies). 'C'
+     * filters to colorless cards and is ignored when real colors are selected.
+     */
+    private async aggregateColor(
+        userId: number,
+        selectedColors: string[]
+    ): Promise<PortfolioBreakdownSlice[]> {
+        this.LOGGER.debug(
+            `Aggregating portfolio by color for user ${userId} (filter: ${selectedColors.join(',') || 'none'}).`
+        );
+        const colored = selectedColors.filter((c) => c !== 'C');
+        const params: unknown[] = [userId];
+        let filterSql = '';
+        if (colored.length > 0) {
+            params.push(colored);
+            filterSql = `AND c.colors @> $${params.length}::text[]`;
+        } else if (selectedColors.includes('C')) {
+            filterSql = 'AND (c.colors IS NULL OR cardinality(c.colors) = 0)';
+        }
+
+        const rows = (await this.inventoryRepo.query(
+            `
+            SELECT
+                col AS "key",
+                COUNT(DISTINCT i.card_id)::int AS "cardCount",
+                SUM(i.quantity)::int AS "itemCount",
+                COALESCE(SUM(i.quantity * (CASE WHEN i.foil THEN p.foil ELSE p.normal END)), 0)::numeric AS "value"
+            FROM inventory i
+            JOIN card c ON i.card_id = c.id
+            CROSS JOIN LATERAL unnest(
+                CASE
+                    WHEN c.colors IS NULL OR cardinality(c.colors) = 0 THEN ARRAY['C']
+                    ELSE c.colors
+                END
+            ) AS col
+            LEFT JOIN LATERAL (
+                SELECT p2.normal, p2.foil
+                FROM price p2
+                WHERE p2.card_id = c.id
+                ORDER BY p2.date DESC
+                LIMIT 1
+            ) p ON TRUE
+            WHERE i.user_id = $1
+            ${filterSql}
+            GROUP BY col
+            ORDER BY "value" DESC NULLS LAST
+            `,
+            params
+        )) as AggregationRow[];
+
+        return rows.map(
+            (r) =>
+                new PortfolioBreakdownSlice({
+                    key: String(r.key ?? ''),
+                    label: COLOR_LABELS[String(r.key)] ?? String(r.key ?? ''),
                     cardCount: Number(r.cardCount) || 0,
                     itemCount: Number(r.itemCount) || 0,
                     value: Number(r.value) || 0,

--- a/src/http/api/portfolio/portfolio-api.controller.ts
+++ b/src/http/api/portfolio/portfolio-api.controller.ts
@@ -184,18 +184,30 @@ export class PortfolioApiController {
     @ApiQuery({
         name: 'by',
         required: false,
-        description: 'Dimension to group by (set, rarity, type, cost-basis)',
+        description: 'Dimension to group by (set, rarity, type, color, cost-basis)',
+    })
+    @ApiQuery({
+        name: 'colors',
+        required: false,
+        description:
+            "For by=color: comma-separated codes (W,U,B,R,G,C) to keep only cards whose color identity contains all of them; 'C' is colorless. Ignored for other dimensions.",
     })
     @ApiResponse({ status: 200, description: 'Breakdown slices and totals' })
     @ApiResponse({ status: 403, description: 'Premium subscription required' })
     async getBreakdown(
         @Req() req: AuthenticatedRequest,
-        @Query('by') by?: string
+        @Query('by') by?: string,
+        @Query('colors') colors?: string
     ): Promise<ApiResponseDto<PortfolioBreakdown>> {
         const dimension: BreakdownDimension = PortfolioBreakdownService.isDimension(by)
             ? by
             : 'set';
-        const breakdown = await this.breakdownService.getBreakdown(req.user.id, dimension);
+        const selectedColors = PortfolioBreakdownService.parseColors(colors);
+        const breakdown = await this.breakdownService.getBreakdown(
+            req.user.id,
+            dimension,
+            selectedColors
+        );
         return ApiResponseDto.ok(breakdown);
     }
 }

--- a/src/http/hbs/portfolio/dto/portfolio-breakdown.view.dto.ts
+++ b/src/http/hbs/portfolio/dto/portfolio-breakdown.view.dto.ts
@@ -12,6 +12,13 @@ export interface BreakdownSliceView {
     percentFormatted: string;
 }
 
+export interface ColorChipView {
+    code: string;
+    label: string;
+    active: boolean;
+    href: string;
+}
+
 export class PortfolioBreakdownViewDto extends BaseViewDto {
     readonly dimension: BreakdownDimension;
     readonly locked: boolean;
@@ -19,6 +26,9 @@ export class PortfolioBreakdownViewDto extends BaseViewDto {
     readonly totalValue: number;
     readonly totalValueFormatted: string;
     readonly totalItems: number;
+    readonly colorChips: ColorChipView[];
+    readonly selectedColors: string[];
+    readonly filterLabel: string;
 
     constructor(init: Partial<PortfolioBreakdownViewDto>) {
         super(init);
@@ -28,5 +38,8 @@ export class PortfolioBreakdownViewDto extends BaseViewDto {
         this.totalValue = init.totalValue ?? 0;
         this.totalValueFormatted = init.totalValueFormatted ?? '$0.00';
         this.totalItems = init.totalItems ?? 0;
+        this.colorChips = init.colorChips ?? [];
+        this.selectedColors = init.selectedColors ?? [];
+        this.filterLabel = init.filterLabel ?? '';
     }
 }

--- a/src/http/hbs/portfolio/portfolio.controller.ts
+++ b/src/http/hbs/portfolio/portfolio.controller.ts
@@ -53,13 +53,15 @@ export class PortfolioController {
     @Render('portfolioBreakdown')
     async getBreakdown(
         @Req() req: AuthenticatedRequest,
-        @Query('by') by?: string
+        @Query('by') by?: string,
+        @Query('colors') colors?: string
     ): Promise<PortfolioBreakdownViewDto> {
         const dimension: BreakdownDimension = PortfolioBreakdownService.isDimension(by)
             ? by
             : 'set';
+        const selectedColors = PortfolioBreakdownService.parseColors(colors);
         this.LOGGER.log(`Get portfolio breakdown by ${dimension} for user ${req.user?.id}.`);
-        return this.orchestrator.getBreakdownView(req, dimension);
+        return this.orchestrator.getBreakdownView(req, dimension, selectedColors);
     }
 
     @UseGuards(JwtAuthGuard, SubscriptionGuard)

--- a/src/http/hbs/portfolio/portfolio.orchestrator.ts
+++ b/src/http/hbs/portfolio/portfolio.orchestrator.ts
@@ -270,9 +270,18 @@ export class PortfolioOrchestrator {
         const selected = new Set(selectedColors);
         return COLOR_CODES.map((code) => {
             const active = selected.has(code);
-            const next = COLOR_CODES.filter((c) =>
-                c === code ? !active : selected.has(c)
-            );
+            // 'C' (colorless) is mutually exclusive with real colors: the
+            // backend ignores 'C' whenever any WUBRG is selected, so the chips
+            // never combine them. Toggling 'C' clears the real colors, and
+            // toggling a real color drops 'C'.
+            const next: string[] =
+                code === 'C'
+                    ? active
+                        ? []
+                        : ['C']
+                    : COLOR_CODES.filter((c) =>
+                          c === 'C' ? false : c === code ? !active : selected.has(c)
+                      );
             const params = new URLSearchParams({ by: 'color' });
             if (next.length > 0) {
                 params.set('colors', next.join(','));

--- a/src/http/hbs/portfolio/portfolio.orchestrator.ts
+++ b/src/http/hbs/portfolio/portfolio.orchestrator.ts
@@ -5,6 +5,8 @@ import { CardService } from 'src/core/card/card.service';
 import { PortfolioBreakdownService } from 'src/core/portfolio/portfolio-breakdown.service';
 import {
     BreakdownDimension,
+    COLOR_CODES,
+    COLOR_LABELS,
     PortfolioBreakdown,
 } from 'src/core/portfolio/portfolio-breakdown.entity';
 import { PortfolioSummaryService } from 'src/core/portfolio/portfolio-summary.service';
@@ -17,7 +19,11 @@ import {
     PortfolioValueHistoryPointDto,
     PortfolioValueHistoryResponseDto,
 } from './dto/portfolio-value-history-response.dto';
-import { PortfolioBreakdownViewDto, BreakdownSliceView } from './dto/portfolio-breakdown.view.dto';
+import {
+    PortfolioBreakdownViewDto,
+    BreakdownSliceView,
+    ColorChipView,
+} from './dto/portfolio-breakdown.view.dto';
 import { PortfolioViewDto } from './dto/portfolio.view.dto';
 import { formatGain, gainSign } from 'src/http/base/http.util';
 import {
@@ -181,12 +187,20 @@ export class PortfolioOrchestrator {
 
     async getBreakdownView(
         req: AuthenticatedRequest,
-        dimension: BreakdownDimension
+        dimension: BreakdownDimension,
+        selectedColors: string[] = []
     ): Promise<PortfolioBreakdownViewDto> {
         this.LOGGER.debug(`Get ${dimension} breakdown view for user ${req.user?.id}.`);
         try {
             HttpErrorHandler.validateAuthenticatedRequest(req);
             const subscribed = await this.subscriptionService.isUserSubscribed(req.user.id);
+
+            const colorChips =
+                dimension === 'color' ? this.buildColorChips(selectedColors) : [];
+            const filterLabel =
+                dimension === 'color' && selectedColors.length > 0
+                    ? selectedColors.map((c) => COLOR_LABELS[c] ?? c).join(', ')
+                    : '';
 
             const baseInit = {
                 authenticated: true,
@@ -198,6 +212,9 @@ export class PortfolioOrchestrator {
                 ],
                 title: 'Portfolio Analytics - I Want My MTG',
                 dimension,
+                colorChips,
+                selectedColors,
+                filterLabel,
             };
 
             if (!subscribed) {
@@ -211,7 +228,7 @@ export class PortfolioOrchestrator {
             }
 
             const [breakdown, summary] = await Promise.all([
-                this.breakdownService.getBreakdown(req.user.id, dimension),
+                this.breakdownService.getBreakdown(req.user.id, dimension, selectedColors),
                 this.summaryService.getSummary(req.user.id),
             ]);
 
@@ -242,6 +259,31 @@ export class PortfolioOrchestrator {
             this.LOGGER.debug(`Error getting breakdown view: ${error?.message}`);
             return HttpErrorHandler.toHttpException(error, 'getBreakdownView');
         }
+    }
+
+    /**
+     * Build the color filter chips for the By Color tab. Each chip links to the
+     * breakdown with its color toggled in/out of the selection, so the filter
+     * works without JS. Codes stay in canonical WUBRG(C) order.
+     */
+    private buildColorChips(selectedColors: string[]): ColorChipView[] {
+        const selected = new Set(selectedColors);
+        return COLOR_CODES.map((code) => {
+            const active = selected.has(code);
+            const next = COLOR_CODES.filter((c) =>
+                c === code ? !active : selected.has(c)
+            );
+            const params = new URLSearchParams({ by: 'color' });
+            if (next.length > 0) {
+                params.set('colors', next.join(','));
+            }
+            return {
+                code,
+                label: COLOR_LABELS[code],
+                active,
+                href: `/portfolio/breakdown?${params.toString()}`,
+            };
+        });
     }
 
     private static readonly CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -1238,6 +1238,10 @@ img,
   width: 1.75rem;
 }
 
+.w-8 {
+  width: 2rem;
+}
+
 .w-9 {
   width: 2.25rem;
 }
@@ -1539,6 +1543,10 @@ img,
   border-radius: 0.5rem;
 }
 
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
 .rounded-sm {
   border-radius: 0.125rem;
 }
@@ -1642,6 +1650,11 @@ img,
 .border-red-500 {
   --tw-border-opacity: 1;
   border-color: rgb(239 68 68 / var(--tw-border-opacity, 1));
+}
+
+.border-teal-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(168 244 239 / var(--tw-border-opacity, 1));
 }
 
 .border-teal-300 {
@@ -1917,6 +1930,10 @@ img,
   padding-bottom: 0.5rem;
 }
 
+.pb-4 {
+  padding-bottom: 1rem;
+}
+
 .pb-5 {
   padding-bottom: 1.25rem;
 }
@@ -2141,6 +2158,11 @@ img,
 .text-blue-800 {
   --tw-text-opacity: 1;
   color: rgb(30 64 175 / var(--tw-text-opacity, 1));
+}
+
+.text-emerald-600 {
+  --tw-text-opacity: 1;
+  color: rgb(5 150 105 / var(--tw-text-opacity, 1));
 }
 
 .text-emerald-700 {
@@ -7742,6 +7764,119 @@ img,
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
 }
 
+/* Color filter chips (By Color breakdown) */
+
+:where(.flex,.breakdown-color-chip, .grid) > * {
+  min-width: 0;
+}
+
+.breakdown-color-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  border-radius: 9999px;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.breakdown-color-chip:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(46 39 88 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(26 21 51 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-color-chip {
+  text-decoration: none;
+}
+
+.breakdown-color-chip:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(114 236 229 / var(--tw-border-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(17 24 39 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-color-chip:hover:is(.dark *) {
+  border-color: rgb(44 200 202 / 0.4);
+  --tw-text-opacity: 1;
+  color: rgb(243 244 246 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-color-chip.active {
+  --tw-border-opacity: 1;
+  border-color: rgb(44 200 202 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(240 253 251 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(26 122 120 / var(--tw-text-opacity, 1));
+  --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.breakdown-color-chip.active:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(69 221 214 / var(--tw-border-opacity, 1));
+  background-color: rgb(44 200 202 / 0.1);
+  --tw-text-opacity: 1;
+  color: rgb(168 244 239 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-color-dot {
+  display: inline-block;
+  height: 0.75rem;
+  width: 0.75rem;
+  border-radius: 9999px;
+  border-width: 1px;
+  border-color: rgb(0 0 0 / 0.1);
+}
+
+.breakdown-color-dot:is(.dark *) {
+  border-color: rgb(255 255 255 / 0.2);
+}
+
+.color-W .breakdown-color-dot {
+  background: #fffbe6;
+}
+
+.color-U .breakdown-color-dot {
+  background: #2a6fb0;
+}
+
+.color-B .breakdown-color-dot {
+  background: #4b4b4b;
+}
+
+.color-R .breakdown-color-dot {
+  background: #d3392c;
+}
+
+.color-G .breakdown-color-dot {
+  background: #3f9b54;
+}
+
+.color-C .breakdown-color-dot {
+  background: #b9b4ab;
+}
+
 /* ===== Tile quick-add (+) overlay ===== */
 
 :where(.tile-quick-add, .inline-flex, .grid) > * {
@@ -7919,6 +8054,11 @@ img,
     color: rgb(220 38 38 / var(--tw-text-opacity, 1));
   }
 
+  .hover\:text-red-700:hover {
+    --tw-text-opacity: 1;
+    color: rgb(185 28 28 / var(--tw-text-opacity, 1));
+  }
+
   .hover\:text-teal-100:hover {
     --tw-text-opacity: 1;
     color: rgb(212 250 247 / var(--tw-text-opacity, 1));
@@ -7936,6 +8076,10 @@ img,
 
   .hover\:underline:hover {
     text-decoration-line: underline;
+  }
+
+  .hover\:no-underline:hover {
+    text-decoration-line: none;
   }
 
   .hover\:opacity-100:hover {
@@ -8015,6 +8159,11 @@ img,
   border-color: rgb(36 30 69 / var(--tw-border-opacity, 1));
 }
 
+.dark\:border-midnight-800:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(26 21 51 / var(--tw-border-opacity, 1));
+}
+
 .dark\:border-purple-600:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(139 66 198 / var(--tw-border-opacity, 1));
@@ -8043,6 +8192,10 @@ img,
 .dark\:border-teal-700:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(26 122 120 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-teal-700\/50:is(.dark *) {
+  border-color: rgb(26 122 120 / 0.5);
 }
 
 .dark\:bg-amber-900\/20:is(.dark *) {

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -1854,6 +1854,32 @@
     @apply text-xs text-gray-500 dark:text-gray-500 mt-2;
 }
 
+/* Color filter chips (By Color breakdown) */
+.breakdown-color-chip {
+    @apply inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium
+           border border-gray-200 dark:border-midnight-600
+           text-gray-600 dark:text-gray-300
+           bg-gray-50 dark:bg-midnight-800
+           transition-colors duration-150;
+    text-decoration: none;
+}
+.breakdown-color-chip:hover {
+    @apply border-teal-300 dark:border-teal-500/40 text-gray-900 dark:text-gray-100;
+}
+.breakdown-color-chip.active {
+    @apply border-teal-500 dark:border-teal-400 text-teal-700 dark:text-teal-200
+           bg-teal-50 dark:bg-teal-500/10 shadow-sm;
+}
+.breakdown-color-dot {
+    @apply inline-block w-3 h-3 rounded-full border border-black/10 dark:border-white/20;
+}
+.color-W .breakdown-color-dot { background: #fffbe6; }
+.color-U .breakdown-color-dot { background: #2a6fb0; }
+.color-B .breakdown-color-dot { background: #4b4b4b; }
+.color-R .breakdown-color-dot { background: #d3392c; }
+.color-G .breakdown-color-dot { background: #3f9b54; }
+.color-C .breakdown-color-dot { background: #b9b4ab; }
+
 /* ===== Tile quick-add (+) overlay ===== */
 .tile-quick-add {
     @apply absolute top-1.5 right-1.5 z-10

--- a/src/http/views/portfolioBreakdown.hbs
+++ b/src/http/views/portfolioBreakdown.hbs
@@ -66,7 +66,7 @@
                     <div class='flex flex-wrap items-center gap-2' role='group' aria-label='Filter by color'>
                         <span class='text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mr-1'>Filter</span>
                         {{#each colorChips}}
-                            <a href='{{href}}' class='breakdown-color-chip color-{{code}} {{#if active}}active{{/if}}' aria-pressed='{{#if active}}true{{else}}false{{/if}}'>
+                            <a href='{{href}}' class='breakdown-color-chip color-{{code}} {{#if active}}active{{/if}}' aria-label='{{#if active}}Remove {{label}} filter{{else}}Add {{label}} filter{{/if}}'>
                                 <span class='breakdown-color-dot' aria-hidden='true'></span>{{label}}
                             </a>
                         {{/each}}

--- a/src/http/views/portfolioBreakdown.hbs
+++ b/src/http/views/portfolioBreakdown.hbs
@@ -2,7 +2,7 @@
     <div class='flex items-center justify-between mb-2 flex-wrap gap-3'>
         <div>
             <h1 class='page-title'>Portfolio Analytics</h1>
-            <p class='page-subtitle'>Where your collection's value lives - by set, rarity, type, or cost basis.</p>
+            <p class='page-subtitle'>Where your collection's value lives - by set, rarity, type, color, or cost basis.</p>
         </div>
         <a href='/portfolio' class='btn btn-ghost text-sm'>&larr; Back to Portfolio</a>
     </div>
@@ -51,6 +51,7 @@
                     <a href='/portfolio/breakdown?by=set' class='breakdown-tab {{#if (eq dimension "set")}}active{{/if}}' data-dimension='set'>By Set</a>
                     <a href='/portfolio/breakdown?by=rarity' class='breakdown-tab {{#if (eq dimension "rarity")}}active{{/if}}' data-dimension='rarity'>By Rarity</a>
                     <a href='/portfolio/breakdown?by=type' class='breakdown-tab {{#if (eq dimension "type")}}active{{/if}}' data-dimension='type'>By Type</a>
+                    <a href='/portfolio/breakdown?by=color' class='breakdown-tab {{#if (eq dimension "color")}}active{{/if}}' data-dimension='color'>By Color</a>
                     <a href='/portfolio/breakdown?by=cost-basis' class='breakdown-tab {{#if (eq dimension "cost-basis")}}active{{/if}}' data-dimension='cost-basis'>By Cost Basis</a>
                 </div>
                 <div class='text-sm text-gray-600 dark:text-gray-400'>
@@ -59,6 +60,28 @@
                     {{totalItems}} item{{#unless (eq totalItems 1)}}s{{/unless}}
                 </div>
             </div>
+
+            {{#if (eq dimension "color")}}
+                <div class='mb-4'>
+                    <div class='flex flex-wrap items-center gap-2' role='group' aria-label='Filter by color'>
+                        <span class='text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mr-1'>Filter</span>
+                        {{#each colorChips}}
+                            <a href='{{href}}' class='breakdown-color-chip color-{{code}} {{#if active}}active{{/if}}' aria-pressed='{{#if active}}true{{else}}false{{/if}}'>
+                                <span class='breakdown-color-dot' aria-hidden='true'></span>{{label}}
+                            </a>
+                        {{/each}}
+                    </div>
+                    {{#if filterLabel}}
+                        <p class='text-xs text-gray-600 dark:text-gray-400 mt-2'>
+                            Showing cards containing <span class='font-semibold text-gray-800 dark:text-gray-200'>{{filterLabel}}</span>.
+                            <a href='/portfolio/breakdown?by=color' class='underline hover:no-underline'>Clear</a>
+                        </p>
+                    {{/if}}
+                    <p class='text-xs text-gray-500 dark:text-gray-400 mt-2'>
+                        A card counts toward every color in its identity, so these rows overlap and don&rsquo;t add up to 100%.
+                    </p>
+                </div>
+            {{/if}}
 
             {{#if slices.length}}
                 <div class='breakdown-list'>
@@ -123,7 +146,7 @@
 <script>
     (function () {
         var STORAGE_KEY = 'iwmtg.portfolioBreakdownDimension';
-        var validDims = ['set', 'rarity', 'type', 'cost-basis'];
+        var validDims = ['set', 'rarity', 'type', 'color', 'cost-basis'];
         var params = new URLSearchParams(window.location.search);
         var current = params.get('by');
         if (!current) {

--- a/src/mcp/tools/portfolio.tools.ts
+++ b/src/mcp/tools/portfolio.tools.ts
@@ -106,7 +106,7 @@ export class PortfolioMcpTools {
                     "Get the user's collection value broken down by a dimension. Premium-gated. Requires IWMM_API_KEY.",
                 inputSchema: z.object({
                     by: z
-                        .enum(['set', 'rarity', 'type', 'color', 'format', 'cost-basis'])
+                        .enum(['set', 'rarity', 'type', 'color', 'cost-basis'])
                         .describe(
                             "Dimension to break down by. 'cost-basis' buckets are gain/loss/at-cost. 'color' groups by color identity (a card counts in every color it contains, so rows overlap)."
                         ),

--- a/src/mcp/tools/portfolio.tools.ts
+++ b/src/mcp/tools/portfolio.tools.ts
@@ -106,9 +106,15 @@ export class PortfolioMcpTools {
                     "Get the user's collection value broken down by a dimension. Premium-gated. Requires IWMM_API_KEY.",
                 inputSchema: z.object({
                     by: z
-                        .enum(['set', 'rarity', 'type', 'format', 'cost-basis'])
+                        .enum(['set', 'rarity', 'type', 'color', 'format', 'cost-basis'])
                         .describe(
-                            "Dimension to break down by. 'cost-basis' buckets are gain/loss/at-cost."
+                            "Dimension to break down by. 'cost-basis' buckets are gain/loss/at-cost. 'color' groups by color identity (a card counts in every color it contains, so rows overlap)."
+                        ),
+                    colors: z
+                        .array(z.enum(['W', 'U', 'B', 'R', 'G', 'C']))
+                        .optional()
+                        .describe(
+                            "For by=color: keep only cards whose color identity contains all of these (superset match); 'C' is colorless. Ignored for other dimensions."
                         ),
                 }),
                 requiresAuth: true,
@@ -192,9 +198,17 @@ export class PortfolioMcpTools {
         return ApiResponseDto.ok({ totalRealizedGain });
     }
 
-    private async breakdown(args: { by: string }, ctx: McpToolContext): Promise<unknown> {
+    private async breakdown(
+        args: { by: string; colors?: string[] },
+        ctx: McpToolContext
+    ): Promise<unknown> {
         const dimension = PortfolioBreakdownService.isDimension(args.by) ? args.by : 'set';
-        const breakdown = await this.breakdownService.getBreakdown(ctx.user.id, dimension);
+        const selectedColors = PortfolioBreakdownService.parseColors((args.colors ?? []).join(','));
+        const breakdown = await this.breakdownService.getBreakdown(
+            ctx.user.id,
+            dimension,
+            selectedColors
+        );
         return ApiResponseDto.ok(breakdown);
     }
 

--- a/test/core/portfolio/portfolio-breakdown.service.spec.ts
+++ b/test/core/portfolio/portfolio-breakdown.service.spec.ts
@@ -1,0 +1,47 @@
+import { PortfolioBreakdownService } from 'src/core/portfolio/portfolio-breakdown.service';
+
+describe('PortfolioBreakdownService', () => {
+    describe('isDimension', () => {
+        it.each(['set', 'rarity', 'type', 'cost-basis', 'color'])(
+            'accepts known dimension %s',
+            (dimension) => {
+                expect(PortfolioBreakdownService.isDimension(dimension)).toBe(true);
+            }
+        );
+
+        it('rejects unknown / empty values', () => {
+            expect(PortfolioBreakdownService.isDimension('format')).toBe(false);
+            expect(PortfolioBreakdownService.isDimension('')).toBe(false);
+            expect(PortfolioBreakdownService.isDimension(undefined)).toBe(false);
+            expect(PortfolioBreakdownService.isDimension(null)).toBe(false);
+        });
+    });
+
+    describe('parseColors', () => {
+        it('returns [] for empty / undefined / null', () => {
+            expect(PortfolioBreakdownService.parseColors(undefined)).toEqual([]);
+            expect(PortfolioBreakdownService.parseColors(null)).toEqual([]);
+            expect(PortfolioBreakdownService.parseColors('')).toEqual([]);
+        });
+
+        it('parses comma-separated codes and uppercases them', () => {
+            expect(PortfolioBreakdownService.parseColors('w,u')).toEqual(['W', 'U']);
+        });
+
+        it('drops unknown codes', () => {
+            expect(PortfolioBreakdownService.parseColors('W,X,Z,G')).toEqual(['W', 'G']);
+        });
+
+        it('de-dupes while preserving first-seen order', () => {
+            expect(PortfolioBreakdownService.parseColors('U,W,W,U')).toEqual(['U', 'W']);
+        });
+
+        it('accepts colorless (C)', () => {
+            expect(PortfolioBreakdownService.parseColors('C')).toEqual(['C']);
+        });
+
+        it('trims surrounding whitespace', () => {
+            expect(PortfolioBreakdownService.parseColors(' W , u ')).toEqual(['W', 'U']);
+        });
+    });
+});

--- a/test/http/portfolio/portfolio.orchestrator.spec.ts
+++ b/test/http/portfolio/portfolio.orchestrator.spec.ts
@@ -413,6 +413,24 @@ describe('PortfolioOrchestrator', () => {
             expect(colorsOf(result.colorChips.find((c) => c.code === 'W')!.href)).toBeNull();
         });
 
+        it('makes Colorless mutually exclusive with real colors in chip hrefs', async () => {
+            // From a real-color selection, the Colorless chip switches to just C.
+            const fromColors = await orchestrator.getBreakdownView(
+                mockAuthenticatedRequest,
+                'color',
+                ['W', 'U']
+            );
+            expect(colorsOf(fromColors.colorChips.find((c) => c.code === 'C')!.href)).toBe('C');
+
+            // From Colorless, clicking a real color drops C and selects just that color.
+            const fromColorless = await orchestrator.getBreakdownView(
+                mockAuthenticatedRequest,
+                'color',
+                ['C']
+            );
+            expect(colorsOf(fromColorless.colorChips.find((c) => c.code === 'W')!.href)).toBe('W');
+        });
+
         it('omits color chips and filter label for non-color dimensions', async () => {
             const result = await orchestrator.getBreakdownView(mockAuthenticatedRequest, 'set');
 

--- a/test/http/portfolio/portfolio.orchestrator.spec.ts
+++ b/test/http/portfolio/portfolio.orchestrator.spec.ts
@@ -2,6 +2,7 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CardService } from 'src/core/card/card.service';
 import { PortfolioSummary } from 'src/core/portfolio/portfolio-summary.entity';
+import { PortfolioBreakdown } from 'src/core/portfolio/portfolio-breakdown.entity';
 import { PortfolioBreakdownService } from 'src/core/portfolio/portfolio-breakdown.service';
 import { PortfolioSummaryService } from 'src/core/portfolio/portfolio-summary.service';
 import { SubscriptionService } from 'src/core/billing/subscription.service';
@@ -16,6 +17,8 @@ describe('PortfolioOrchestrator', () => {
     let portfolioService: jest.Mocked<PortfolioService>;
     let summaryService: jest.Mocked<PortfolioSummaryService>;
     let transactionService: jest.Mocked<TransactionService>;
+    let breakdownService: jest.Mocked<PortfolioBreakdownService>;
+    let subscriptionService: jest.Mocked<SubscriptionService>;
 
     const mockAuthenticatedRequest = {
         user: { id: 1, name: 'Test User', email: 'test@example.com' },
@@ -110,6 +113,12 @@ describe('PortfolioOrchestrator', () => {
             PortfolioSummaryService
         ) as jest.Mocked<PortfolioSummaryService>;
         transactionService = module.get(TransactionService) as jest.Mocked<TransactionService>;
+        breakdownService = module.get(
+            PortfolioBreakdownService
+        ) as jest.Mocked<PortfolioBreakdownService>;
+        subscriptionService = module.get(
+            SubscriptionService
+        ) as jest.Mocked<SubscriptionService>;
     });
 
     beforeEach(() => {
@@ -350,6 +359,65 @@ describe('PortfolioOrchestrator', () => {
             await expect(
                 orchestrator.getRealizedGains(mockUnauthenticatedRequest)
             ).rejects.toThrow();
+        });
+    });
+
+    describe('getBreakdownView (color)', () => {
+        const colorsOf = (href: string): string | null =>
+            new URL(href, 'https://x').searchParams.get('colors');
+
+        beforeEach(() => {
+            subscriptionService.isUserSubscribed.mockResolvedValue(true);
+            summaryService.getSummary.mockResolvedValue(testSummary);
+            breakdownService.getBreakdown.mockResolvedValue(new PortfolioBreakdown('color', []));
+        });
+
+        it('passes the selected colors through to the breakdown service', async () => {
+            await orchestrator.getBreakdownView(mockAuthenticatedRequest, 'color', ['W', 'U']);
+
+            expect(breakdownService.getBreakdown).toHaveBeenCalledWith(1, 'color', ['W', 'U']);
+        });
+
+        it('builds a chip per color and marks the selected ones active', async () => {
+            const result = await orchestrator.getBreakdownView(
+                mockAuthenticatedRequest,
+                'color',
+                ['W', 'U']
+            );
+
+            expect(result.colorChips.map((c) => c.code)).toEqual(['W', 'U', 'B', 'R', 'G', 'C']);
+            const active = result.colorChips.filter((c) => c.active).map((c) => c.code);
+            expect(active).toEqual(['W', 'U']);
+            expect(result.filterLabel).toBe('White, Blue');
+        });
+
+        it('chip href toggles its own color off and adds inactive ones in WUBRG order', async () => {
+            const result = await orchestrator.getBreakdownView(
+                mockAuthenticatedRequest,
+                'color',
+                ['W', 'U']
+            );
+            const chip = (code: string) => result.colorChips.find((c) => c.code === code)!;
+
+            // active W -> removing it leaves U
+            expect(colorsOf(chip('W').href)).toBe('U');
+            // inactive B -> adds B, canonical order W,U,B
+            expect(colorsOf(chip('B').href)).toBe('W,U,B');
+        });
+
+        it('clearing the last selected color drops the colors param entirely', async () => {
+            const result = await orchestrator.getBreakdownView(mockAuthenticatedRequest, 'color', [
+                'W',
+            ]);
+
+            expect(colorsOf(result.colorChips.find((c) => c.code === 'W')!.href)).toBeNull();
+        });
+
+        it('omits color chips and filter label for non-color dimensions', async () => {
+            const result = await orchestrator.getBreakdownView(mockAuthenticatedRequest, 'set');
+
+            expect(result.colorChips).toEqual([]);
+            expect(result.filterLabel).toBe('');
         });
     });
 });


### PR DESCRIPTION
Per-color value rows (a card counts toward every color in its identity) plus a superset color filter. Adds card.colors (migration 040), the aggregateColor query, and exposes color via the JSON API and MCP.