### PR TITLE
feat: deck building MVP (10.4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -307,20 +307,22 @@ Deferred from 3.4. Blocked on Scry repo: needs `card.colors` populated from MTGJ
 - [ ] Add `color` case to `BreakdownDimension` and `dimensionConfig()`
 - [ ] Add "By Color" tab to `portfolioBreakdown.hbs`
 
-### 10.4 Feature: Deck Building
+### 10.4 Feature: Deck Building (MVP shipped)
 
-Deferred from former §3.5. Not on the near-term roadmap; revisit after monetization, platform expansion, and ecosystem phases land.
+Deferred from former §3.5. **MVP built 2026-06-17** - free to create (deeper analytics gated for later), modeled on Archidekt/ManaBox, mirroring the `buy_list` layering. The heavier pieces are deferred to a follow-up.
 
-- [ ] Design deck data model (deck table with user FK, deck_card join table with quantity, sideboard flag)
-- [ ] Create database migration for deck tables
-- [ ] Implement domain entities, repository ports, ORM entities, mappers, and repositories
-- [ ] Implement DeckService with CRUD operations (create, update, delete, add/remove cards)
-- [ ] Create REST API endpoints for decks (CRUD, add/remove cards, list user decks)
-- [ ] Build deck list view page (user's saved decks with name, format, card count, estimated value)
-- [ ] Build deck detail view page (card list grouped by type, mana curve visualization, price breakdown)
-- [ ] Add "Add to Deck" action from card detail and search results
-- [ ] Deck import/export (paste decklist text format, CSV)
-- [ ] Format legality validation (check deck against format rules - Standard, Modern, Commander, etc.)
+- [x] Deck data model (`deck` + `deck_card`, migration `041`): `deck` (user FK, name, nullable `format`, timestamps); `deck_card` keyed `(deck_id, card_id, is_sideboard)` so a card can sit in main + side
+- [x] Domain entities, repository port, ORM entities, mappers, repository (`DeckRepository`)
+- [x] `DeckService` CRUD + add/remove/set-quantity, with per-deck ownership checks (`NotFoundException` on miss / not-owned)
+- [x] REST API `/api/v1/decks` (list/create/get/rename/delete + add/remove/set-quantity card; free tier via `JwtOrApiKeyGuard`)
+- [x] Deck list page (`/decks`): name, format, card count, estimated value; create + delete inline
+- [x] Deck detail page (`/decks/:id`): cards grouped by primary type, per-card legality flag, estimated value; qty steppers + remove via AJAX, totals recomputed client-side
+- [x] Per-card legality check reusing the existing `legality` table (`DeckLegalityPolicy`); estimated value via `PriceCalculationPolicy` (`DeckSummaryPolicy`)
+- [x] "Add to Deck" on the **card detail** page (pick a deck or create one inline)
+- [ ] **Deferred:** "Add to Deck" from **search results** (needs a per-row picker; card-detail covers the primary add path)
+- [ ] **Deferred:** Deck import/export (paste decklist text + CSV)
+- [ ] **Deferred:** Mana-curve visualization + fuller price breakdown on the detail page
+- [ ] **Deferred:** Full construction-rule validation (singleton, 4-of limits, deck-size minimums) - today's check is per-card legal/banned only
 
 ---
 

--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -1008,6 +1008,45 @@ CREATE INDEX idx_api_usage_day ON public.api_usage (day);
 
 
 --
+-- Name: deck; Type: TABLE; Schema: public
+--
+
+CREATE TABLE public.deck (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    user_id integer NOT NULL,
+    name character varying NOT NULL,
+    format public.format_enum,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    CONSTRAINT deck_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_deck_user FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_deck_user_id ON public.deck (user_id);
+
+
+--
+-- Name: deck_card; Type: TABLE; Schema: public
+--
+
+CREATE TABLE public.deck_card (
+    deck_id integer NOT NULL,
+    card_id character varying NOT NULL,
+    quantity integer NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    is_sideboard boolean NOT NULL DEFAULT false,
+    CONSTRAINT deck_card_pkey PRIMARY KEY (deck_id, card_id, is_sideboard),
+    CONSTRAINT fk_deck_card_deck FOREIGN KEY (deck_id)
+        REFERENCES public.deck(id) ON DELETE CASCADE,
+    CONSTRAINT fk_deck_card_card FOREIGN KEY (card_id)
+        REFERENCES public.card(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_deck_card_deck_id ON public.deck_card (deck_id);
+CREATE INDEX idx_deck_card_card_id ON public.deck_card (card_id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 

--- a/migrations/041_deck.sql
+++ b/migrations/041_deck.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+-- 10.4: deck building (MVP). A user's decks plus the cards in each.
+--
+-- `deck` has a generated id (decks need a stable id for URLs + the join) and a
+-- nullable `format` (a deck need not target a constructed format). `deck_card`
+-- is the join, keyed by (deck_id, card_id, is_sideboard) so the same card can
+-- sit in both the maindeck and sideboard as separate rows. Quantity per row.
+--
+-- IF NOT EXISTS guards keep this replayable (the migration set re-runs every
+-- deploy).
+
+CREATE TABLE IF NOT EXISTS public.deck (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    user_id integer NOT NULL,
+    name character varying NOT NULL,
+    format public.format_enum,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    CONSTRAINT deck_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_deck_user FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_deck_user_id ON public.deck (user_id);
+
+CREATE TABLE IF NOT EXISTS public.deck_card (
+    deck_id integer NOT NULL,
+    card_id character varying NOT NULL,
+    quantity integer NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    is_sideboard boolean NOT NULL DEFAULT false,
+    CONSTRAINT deck_card_pkey PRIMARY KEY (deck_id, card_id, is_sideboard),
+    CONSTRAINT fk_deck_card_deck FOREIGN KEY (deck_id)
+        REFERENCES public.deck(id) ON DELETE CASCADE,
+    CONSTRAINT fk_deck_card_card FOREIGN KEY (card_id)
+        REFERENCES public.card(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_deck_card_deck_id ON public.deck_card (deck_id);
+CREATE INDEX IF NOT EXISTS idx_deck_card_card_id ON public.deck_card (card_id);
+
+COMMIT;

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -6,6 +6,7 @@ import { BillingModule } from './billing/billing.module';
 import { BlogModule } from './blog/blog.module';
 import { BuyListModule } from './buy-list/buy-list.module';
 import { CardModule } from './card/card.module';
+import { DeckModule } from './deck/deck.module';
 import { EmailModule } from './email/email.module';
 import { ImportModule } from './import/import.module';
 import { InventoryModule } from './inventory/inventory.module';
@@ -27,6 +28,7 @@ import { UserModule } from './user/user.module';
         BlogModule,
         BuyListModule,
         CardModule,
+        DeckModule,
         EmailModule,
         ImportModule,
         InventoryModule,
@@ -47,6 +49,7 @@ import { UserModule } from './user/user.module';
         BlogModule,
         BuyListModule,
         CardModule,
+        DeckModule,
         EmailModule,
         ImportModule,
         InventoryModule,

--- a/src/core/deck/deck-card.entity.ts
+++ b/src/core/deck/deck-card.entity.ts
@@ -1,0 +1,24 @@
+import { Card } from 'src/core/card/card.entity';
+import { validateInit } from 'src/core/validation.util';
+
+/**
+ * A card entry within a deck (10.4). One row per card + board, so the same
+ * card can appear once in the maindeck and once in the sideboard.
+ */
+export class DeckCard {
+    readonly deckId?: number;
+    readonly cardId: string;
+    readonly quantity: number;
+    readonly isSideboard: boolean;
+    // For read operations only
+    readonly card?: Card;
+
+    constructor(init: Partial<DeckCard>) {
+        validateInit(init, ['cardId', 'quantity', 'isSideboard']);
+        this.deckId = init.deckId;
+        this.cardId = init.cardId;
+        this.quantity = init.quantity;
+        this.isSideboard = init.isSideboard;
+        this.card = init.card;
+    }
+}

--- a/src/core/deck/deck-legality.policy.ts
+++ b/src/core/deck/deck-legality.policy.ts
@@ -1,0 +1,35 @@
+import { Format } from 'src/core/card/format.enum';
+import { Legality } from 'src/core/card/legality.entity';
+import { LegalityStatus } from 'src/core/card/legality.status.enum';
+
+/**
+ * Per-card legality for a deck's format (10.4 MVP). MTGJSON only emits a
+ * legality row for formats where a card is legal/banned/restricted, so a
+ * missing row means "not in this format".
+ *
+ * Full construction rules (singleton, 4-of, deck-size minimums) are a later
+ * pass; this covers only "may this card legally appear in a deck of format X".
+ */
+export class DeckLegalityPolicy {
+    /**
+     * - No format target: everything is allowed.
+     * - legal / restricted: allowed (the 1-copy restricted limit is a
+     *   construction rule deferred to a later pass).
+     * - banned, or no legality entry for the format: not legal.
+     */
+    static isCardLegal(
+        format: Format | null | undefined,
+        legalities: Legality[] | undefined
+    ): boolean {
+        if (!format) {
+            return true;
+        }
+        const entry = (legalities ?? []).find((l) => l.format === format);
+        if (!entry) {
+            return false;
+        }
+        return (
+            entry.status === LegalityStatus.Legal || entry.status === LegalityStatus.Restricted
+        );
+    }
+}

--- a/src/core/deck/deck-summary.policy.ts
+++ b/src/core/deck/deck-summary.policy.ts
@@ -1,0 +1,33 @@
+import { Card } from 'src/core/card/card.entity';
+import { PriceCalculationPolicy } from 'src/core/pricing/price-calculation.policy';
+import { DeckCard } from './deck-card.entity';
+
+/**
+ * Pure deck rollups (10.4): estimated value and counts, derived from the loaded
+ * deck cards. Value uses the same "normal price, fall back to foil" rule as the
+ * rest of the app via PriceCalculationPolicy.
+ */
+export class DeckSummaryPolicy {
+    /** A card's current value (normal, falling back to foil). 0 if no price. */
+    static cardValue(card?: Card): number {
+        const price = card?.prices?.[0];
+        if (!price) {
+            return 0;
+        }
+        return PriceCalculationPolicy.calculateCardValue(price.normal, price.foil, false);
+    }
+
+    /** Estimated total value of a deck's cards (main + side), quantity-weighted. */
+    static estimatedValue(cards: DeckCard[] = []): number {
+        return cards.reduce((sum, dc) => sum + dc.quantity * DeckSummaryPolicy.cardValue(dc.card), 0);
+    }
+
+    /** Total card count (sum of quantities), optionally limited to one board. */
+    static cardCount(cards: DeckCard[] = [], board?: 'main' | 'side'): number {
+        return cards
+            .filter((dc) =>
+                board === 'main' ? !dc.isSideboard : board === 'side' ? dc.isSideboard : true
+            )
+            .reduce((sum, dc) => sum + dc.quantity, 0);
+    }
+}

--- a/src/core/deck/deck.entity.ts
+++ b/src/core/deck/deck.entity.ts
@@ -1,0 +1,29 @@
+import { Format } from 'src/core/card/format.enum';
+import { validateInit } from 'src/core/validation.util';
+import { DeckCard } from './deck-card.entity';
+
+/**
+ * A user's deck (10.4). `format` is optional - a deck need not target a
+ * constructed format; when set, it drives the per-card legality check.
+ */
+export class Deck {
+    readonly id?: number;
+    readonly userId: number;
+    readonly name: string;
+    readonly format?: Format | null;
+    readonly createdAt?: Date;
+    readonly updatedAt?: Date;
+    // For read operations only
+    readonly cards?: DeckCard[];
+
+    constructor(init: Partial<Deck>) {
+        validateInit(init, ['userId', 'name']);
+        this.id = init.id;
+        this.userId = init.userId;
+        this.name = init.name;
+        this.format = init.format ?? null;
+        this.createdAt = init.createdAt;
+        this.updatedAt = init.updatedAt;
+        this.cards = init.cards;
+    }
+}

--- a/src/core/deck/deck.module.ts
+++ b/src/core/deck/deck.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/database/database.module';
+import { getLogger } from 'src/logger/global-app-logger';
+import { DeckService } from './deck.service';
+
+@Module({
+    imports: [DatabaseModule],
+    providers: [DeckService],
+    exports: [DeckService],
+})
+export class DeckModule {
+    private readonly LOGGER = getLogger(DeckModule.name);
+
+    constructor() {
+        this.LOGGER.log('Initialized');
+    }
+}

--- a/src/core/deck/deck.service.ts
+++ b/src/core/deck/deck.service.ts
@@ -1,0 +1,110 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Format } from 'src/core/card/format.enum';
+import { getLogger } from 'src/logger/global-app-logger';
+import { Deck } from './deck.entity';
+import { DeckRepositoryPort } from './ports/deck.repository.port';
+
+@Injectable()
+export class DeckService {
+    private readonly LOGGER = getLogger(DeckService.name);
+
+    constructor(@Inject(DeckRepositoryPort) private readonly repository: DeckRepositoryPort) {}
+
+    /** A user's decks (with cards), most-recently-updated first. */
+    async listDecks(userId: number): Promise<Deck[]> {
+        this.LOGGER.debug(`list decks for user ${userId}.`);
+        return userId ? this.repository.findByUser(userId) : [];
+    }
+
+    async countDecks(userId: number): Promise<number> {
+        return userId ? this.repository.countByUser(userId) : 0;
+    }
+
+    /** A deck owned by the user (with cards), or null if missing / not theirs. */
+    async getDeck(deckId: number, userId: number): Promise<Deck | null> {
+        const deck = await this.repository.findById(deckId);
+        return deck && deck.userId === userId ? deck : null;
+    }
+
+    async createDeck(userId: number, name: string, format?: Format | null): Promise<Deck> {
+        const cleanName = (name ?? '').trim();
+        if (!cleanName) {
+            throw new Error('Deck name is required.');
+        }
+        this.LOGGER.debug(`create deck "${cleanName}" for user ${userId}.`);
+        return this.repository.create(new Deck({ userId, name: cleanName, format: format ?? null }));
+    }
+
+    async updateDeck(
+        deckId: number,
+        userId: number,
+        name: string,
+        format?: Format | null
+    ): Promise<Deck> {
+        await this.assertOwner(deckId, userId);
+        const cleanName = (name ?? '').trim();
+        if (!cleanName) {
+            throw new Error('Deck name is required.');
+        }
+        this.LOGGER.debug(`update deck ${deckId} for user ${userId}.`);
+        return this.repository.update(
+            new Deck({ id: deckId, userId, name: cleanName, format: format ?? null })
+        );
+    }
+
+    async deleteDeck(deckId: number, userId: number): Promise<void> {
+        await this.assertOwner(deckId, userId);
+        this.LOGGER.debug(`delete deck ${deckId} for user ${userId}.`);
+        await this.repository.delete(deckId);
+    }
+
+    /** Add to a card entry: increment quantity, creating the entry if absent. */
+    async addCard(
+        deckId: number,
+        userId: number,
+        cardId: string,
+        isSideboard: boolean,
+        quantity = 1
+    ): Promise<void> {
+        if (quantity <= 0) {
+            return;
+        }
+        await this.assertOwner(deckId, userId);
+        this.LOGGER.debug(`add ${quantity} of ${cardId} (side=${isSideboard}) to deck ${deckId}.`);
+        await this.repository.addCard(deckId, cardId, isSideboard, quantity);
+    }
+
+    /** Set the absolute quantity for a card entry; quantity <= 0 removes it. */
+    async setCardQuantity(
+        deckId: number,
+        userId: number,
+        cardId: string,
+        isSideboard: boolean,
+        quantity: number
+    ): Promise<void> {
+        await this.assertOwner(deckId, userId);
+        if (quantity <= 0) {
+            await this.repository.removeCard(deckId, cardId, isSideboard);
+            return;
+        }
+        await this.repository.setCardQuantity(deckId, cardId, isSideboard, quantity);
+    }
+
+    async removeCard(
+        deckId: number,
+        userId: number,
+        cardId: string,
+        isSideboard: boolean
+    ): Promise<void> {
+        await this.assertOwner(deckId, userId);
+        await this.repository.removeCard(deckId, cardId, isSideboard);
+    }
+
+    /** Throws NotFoundException if the deck is missing or not owned by the user. */
+    private async assertOwner(deckId: number, userId: number): Promise<void> {
+        const ownerId = await this.repository.getOwnerId(deckId);
+        if (ownerId !== userId) {
+            throw new NotFoundException(`Deck ${deckId} not found.`);
+        }
+    }
+}

--- a/src/core/deck/ports/deck.repository.port.ts
+++ b/src/core/deck/ports/deck.repository.port.ts
@@ -1,0 +1,47 @@
+import { Deck } from '../deck.entity';
+
+export const DeckRepositoryPort = 'DeckRepositoryPort';
+
+/**
+ * Persistence for decks (10.4). Decks are addressed by a generated id; card
+ * entries are keyed by (deckId, cardId, isSideboard).
+ */
+export interface DeckRepositoryPort {
+    /** A user's decks, most-recently-updated first, each with its cards (card + latest price). */
+    findByUser(userId: number): Promise<Deck[]>;
+
+    /** A single deck with its cards (card + set + latest price + legalities), or null. */
+    findById(deckId: number): Promise<Deck | null>;
+
+    /** The owning user's id for a deck, or null if the deck does not exist. */
+    getOwnerId(deckId: number): Promise<number | null>;
+
+    /** Create a deck; returns it with the generated id. */
+    create(deck: Deck): Promise<Deck>;
+
+    /** Update a deck's name/format; returns the updated deck (without cards). */
+    update(deck: Deck): Promise<Deck>;
+
+    /** Delete a deck (cascades to its card entries). */
+    delete(deckId: number): Promise<void>;
+
+    /**
+     * Add `delta` to a card entry, creating it at `delta` if absent
+     * (INSERT ... ON CONFLICT DO UPDATE). Returns the resulting quantity.
+     */
+    addCard(deckId: number, cardId: string, isSideboard: boolean, delta: number): Promise<number>;
+
+    /** Set the absolute quantity for a card entry. */
+    setCardQuantity(
+        deckId: number,
+        cardId: string,
+        isSideboard: boolean,
+        quantity: number
+    ): Promise<void>;
+
+    /** Remove a card entry. */
+    removeCard(deckId: number, cardId: string, isSideboard: boolean): Promise<void>;
+
+    /** Count a user's decks. */
+    countByUser(userId: number): Promise<number>;
+}

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -5,6 +5,7 @@ import { GranularPriceRepositoryPort } from 'src/core/card/ports/granular-price.
 import { PriceHistoryRepositoryPort } from 'src/core/card/ports/price-history.repository.port';
 import { InventoryRepositoryPort } from 'src/core/inventory/ports/inventory.repository.port';
 import { BuyListRepositoryPort } from 'src/core/buy-list/ports/buy-list.repository.port';
+import { DeckRepositoryPort } from 'src/core/deck/ports/deck.repository.port';
 import { PasswordResetRepositoryPort } from 'src/core/password-reset/ports/password-reset.repository.port';
 import { SetPriceHistoryRepositoryPort } from 'src/core/set/ports/set-price-history.repository.port';
 import { SetRepositoryPort } from 'src/core/set/ports/set.repository.port';
@@ -26,6 +27,9 @@ import { InventoryOrmEntity } from './inventory/inventory.orm-entity';
 import { InventoryRepository } from './inventory/inventory.repository';
 import { BuyListOrmEntity } from './buy-list/buy-list.orm-entity';
 import { BuyListRepository } from './buy-list/buy-list.repository';
+import { DeckOrmEntity } from './deck/deck.orm-entity';
+import { DeckCardOrmEntity } from './deck/deck-card.orm-entity';
+import { DeckRepository } from './deck/deck.repository';
 import { PasswordResetOrmEntity } from './password-reset/password-reset.orm-entity';
 import { PasswordResetRepository } from './password-reset/password-reset.repository';
 import { GranularPriceOrmEntity } from './granular-price/granular-price.orm-entity';
@@ -79,6 +83,8 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
             CardOrmEntity,
             InventoryOrmEntity,
             BuyListOrmEntity,
+            DeckOrmEntity,
+            DeckCardOrmEntity,
             LegalityOrmEntity,
             PasswordResetOrmEntity,
             GranularPriceOrmEntity,
@@ -111,6 +117,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         { provide: PriceHistoryRepositoryPort, useClass: PriceHistoryRepository },
         { provide: InventoryRepositoryPort, useClass: InventoryRepository },
         { provide: BuyListRepositoryPort, useClass: BuyListRepository },
+        { provide: DeckRepositoryPort, useClass: DeckRepository },
         { provide: PasswordResetRepositoryPort, useClass: PasswordResetRepository },
         { provide: SetPriceHistoryRepositoryPort, useClass: SetPriceHistoryRepository },
         { provide: SetRepositoryPort, useClass: SetRepository },
@@ -138,6 +145,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         PriceHistoryRepositoryPort,
         InventoryRepositoryPort,
         BuyListRepositoryPort,
+        DeckRepositoryPort,
         PasswordResetRepositoryPort,
         SetPriceHistoryRepositoryPort,
         SetRepositoryPort,

--- a/src/database/deck/deck-card.orm-entity.ts
+++ b/src/database/deck/deck-card.orm-entity.ts
@@ -1,0 +1,34 @@
+import { CardOrmEntity } from 'src/database/card/card.orm-entity';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { DeckOrmEntity } from './deck.orm-entity';
+
+@Entity('deck_card')
+export class DeckCardOrmEntity {
+    @PrimaryColumn({ name: 'deck_id' })
+    deckId: number;
+
+    @PrimaryColumn({ name: 'card_id' })
+    cardId: string;
+
+    @PrimaryColumn({ name: 'is_sideboard', type: 'boolean' })
+    isSideboard: boolean;
+
+    @Column({ type: 'int', default: 1 })
+    quantity: number;
+
+    @ManyToOne(() => DeckOrmEntity, (deck) => deck.cards, { onDelete: 'CASCADE' })
+    @JoinColumn({
+        name: 'deck_id',
+        referencedColumnName: 'id',
+        foreignKeyConstraintName: 'fk_deck_card_deck',
+    })
+    deck: DeckOrmEntity;
+
+    @ManyToOne(() => CardOrmEntity, { onDelete: 'CASCADE' })
+    @JoinColumn({
+        name: 'card_id',
+        referencedColumnName: 'id',
+        foreignKeyConstraintName: 'fk_deck_card_card',
+    })
+    card: CardOrmEntity;
+}

--- a/src/database/deck/deck.mapper.ts
+++ b/src/database/deck/deck.mapper.ts
@@ -1,0 +1,40 @@
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { Deck } from 'src/core/deck/deck.entity';
+import { CardMapper } from 'src/database/card/card.mapper';
+import { DeckCardOrmEntity } from './deck-card.orm-entity';
+import { DeckOrmEntity } from './deck.orm-entity';
+
+export class DeckMapper {
+    static toCore(orm: DeckOrmEntity): Deck {
+        return new Deck({
+            id: orm.id,
+            userId: orm.userId,
+            name: orm.name,
+            format: orm.format ?? null,
+            createdAt: orm.createdAt,
+            updatedAt: orm.updatedAt,
+            cards: orm.cards ? orm.cards.map((c) => DeckMapper.cardToCore(c)) : undefined,
+        });
+    }
+
+    static cardToCore(orm: DeckCardOrmEntity): DeckCard {
+        return new DeckCard({
+            deckId: orm.deckId,
+            cardId: orm.cardId,
+            quantity: orm.quantity,
+            isSideboard: orm.isSideboard,
+            card: orm.card ? CardMapper.toCore(orm.card) : undefined,
+        });
+    }
+
+    static toOrmEntity(deck: Deck): DeckOrmEntity {
+        const orm = new DeckOrmEntity();
+        if (deck.id !== undefined) {
+            orm.id = deck.id;
+        }
+        orm.userId = deck.userId;
+        orm.name = deck.name;
+        orm.format = deck.format ?? null;
+        return orm;
+    }
+}

--- a/src/database/deck/deck.orm-entity.ts
+++ b/src/database/deck/deck.orm-entity.ts
@@ -1,0 +1,45 @@
+import { Format } from 'src/core/card/format.enum';
+import { UserOrmEntity } from 'src/database/user/user.orm-entity';
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    OneToMany,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { DeckCardOrmEntity } from './deck-card.orm-entity';
+
+@Entity('deck')
+export class DeckOrmEntity {
+    @PrimaryGeneratedColumn('identity')
+    id: number;
+
+    @Column({ name: 'user_id' })
+    userId: number;
+
+    @Column()
+    name: string;
+
+    @Column({ type: 'enum', enum: Format, enumName: 'format_enum', nullable: true })
+    format: Format | null;
+
+    @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+    createdAt: Date;
+
+    @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+    updatedAt: Date;
+
+    @OneToMany(() => DeckCardOrmEntity, (dc) => dc.deck, { cascade: true })
+    cards: DeckCardOrmEntity[];
+
+    @ManyToOne(() => UserOrmEntity, { onDelete: 'CASCADE' })
+    @JoinColumn({
+        name: 'user_id',
+        referencedColumnName: 'id',
+        foreignKeyConstraintName: 'fk_deck_user',
+    })
+    user: UserOrmEntity;
+}

--- a/src/database/deck/deck.repository.ts
+++ b/src/database/deck/deck.repository.ts
@@ -1,0 +1,127 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Deck } from 'src/core/deck/deck.entity';
+import { DeckRepositoryPort } from 'src/core/deck/ports/deck.repository.port';
+import { getLogger } from 'src/logger/global-app-logger';
+import { Repository } from 'typeorm';
+import { DeckMapper } from './deck.mapper';
+import { DeckOrmEntity } from './deck.orm-entity';
+
+const LATEST_PRICE = 'prices.date = (SELECT MAX(p2.date) FROM price p2 WHERE p2.card_id = card.id)';
+
+@Injectable()
+export class DeckRepository implements DeckRepositoryPort {
+    private readonly LOGGER = getLogger(DeckRepository.name);
+
+    constructor(
+        @InjectRepository(DeckOrmEntity)
+        private readonly repository: Repository<DeckOrmEntity>
+    ) {}
+
+    async findByUser(userId: number): Promise<Deck[]> {
+        this.LOGGER.debug(`findByUser ${userId}.`);
+        // Each deck with its cards + latest price (enough for card counts + value).
+        const decks = await this.repository
+            .createQueryBuilder('deck')
+            .leftJoinAndSelect('deck.cards', 'dc')
+            .leftJoinAndSelect('dc.card', 'card')
+            .leftJoinAndSelect('card.prices', 'prices', LATEST_PRICE)
+            .where('deck.userId = :userId', { userId })
+            .orderBy('deck.updatedAt', 'DESC')
+            .addOrderBy('card.name', 'ASC')
+            .getMany();
+        return decks.map((d) => DeckMapper.toCore(d));
+    }
+
+    async findById(deckId: number): Promise<Deck | null> {
+        // Detail view also needs the set (keyrune) and legalities (format check).
+        const deck = await this.repository
+            .createQueryBuilder('deck')
+            .leftJoinAndSelect('deck.cards', 'dc')
+            .leftJoinAndSelect('dc.card', 'card')
+            .leftJoinAndSelect('card.set', 'set')
+            .leftJoinAndSelect('card.legalities', 'legalities')
+            .leftJoinAndSelect('card.prices', 'prices', LATEST_PRICE)
+            .where('deck.id = :deckId', { deckId })
+            .addOrderBy('card.name', 'ASC')
+            .getOne();
+        return deck ? DeckMapper.toCore(deck) : null;
+    }
+
+    async getOwnerId(deckId: number): Promise<number | null> {
+        const row = await this.repository.findOne({
+            where: { id: deckId },
+            select: { id: true, userId: true },
+        });
+        return row ? row.userId : null;
+    }
+
+    async create(deck: Deck): Promise<Deck> {
+        const saved = await this.repository.save(DeckMapper.toOrmEntity(deck));
+        return DeckMapper.toCore(saved);
+    }
+
+    async update(deck: Deck): Promise<Deck> {
+        await this.repository.update(
+            { id: deck.id },
+            { name: deck.name, format: deck.format ?? null }
+        );
+        const reloaded = await this.repository.findOneOrFail({ where: { id: deck.id } });
+        return DeckMapper.toCore(reloaded);
+    }
+
+    async delete(deckId: number): Promise<void> {
+        await this.repository.delete({ id: deckId });
+    }
+
+    async addCard(
+        deckId: number,
+        cardId: string,
+        isSideboard: boolean,
+        delta: number
+    ): Promise<number> {
+        const rows = await this.repository.query(
+            `INSERT INTO deck_card (deck_id, card_id, is_sideboard, quantity)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (deck_id, card_id, is_sideboard)
+             DO UPDATE SET quantity = deck_card.quantity + EXCLUDED.quantity
+             RETURNING quantity`,
+            [deckId, cardId, isSideboard, delta]
+        );
+        await this.touch(deckId);
+        return Number(rows[0]?.quantity ?? delta);
+    }
+
+    async setCardQuantity(
+        deckId: number,
+        cardId: string,
+        isSideboard: boolean,
+        quantity: number
+    ): Promise<void> {
+        await this.repository.query(
+            `INSERT INTO deck_card (deck_id, card_id, is_sideboard, quantity)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (deck_id, card_id, is_sideboard)
+             DO UPDATE SET quantity = EXCLUDED.quantity`,
+            [deckId, cardId, isSideboard, quantity]
+        );
+        await this.touch(deckId);
+    }
+
+    async removeCard(deckId: number, cardId: string, isSideboard: boolean): Promise<void> {
+        await this.repository.query(
+            `DELETE FROM deck_card WHERE deck_id = $1 AND card_id = $2 AND is_sideboard = $3`,
+            [deckId, cardId, isSideboard]
+        );
+        await this.touch(deckId);
+    }
+
+    async countByUser(userId: number): Promise<number> {
+        return this.repository.count({ where: { userId } });
+    }
+
+    /** Bump updated_at so card edits float the deck to the top of the list. */
+    private async touch(deckId: number): Promise<void> {
+        await this.repository.query(`UPDATE deck SET updated_at = NOW() WHERE id = $1`, [deckId]);
+    }
+}

--- a/src/http/api/api.module.ts
+++ b/src/http/api/api.module.ts
@@ -8,6 +8,7 @@ import { BillingApiController } from './billing/billing-api.controller';
 import { StripeWebhookController } from './billing/stripe-webhook.controller';
 import { BuyListApiController } from './buy-list/buy-list-api.controller';
 import { CardApiController } from './card/card-api.controller';
+import { DeckApiController } from './deck/deck-api.controller';
 import { InventoryApiController } from './inventory/inventory-api.controller';
 import { SellOptimizerApiController } from './optimizer/sell-optimizer-api.controller';
 import { PortfolioApiController } from './portfolio/portfolio-api.controller';
@@ -33,6 +34,7 @@ import { RapidApiProxyGuard } from './shared/rapidapi-proxy.guard';
         StripeWebhookController,
         BuyListApiController,
         CardApiController,
+        DeckApiController,
         InventoryApiController,
         SellOptimizerApiController,
         PortfolioApiController,

--- a/src/http/api/deck/deck-api.controller.ts
+++ b/src/http/api/deck/deck-api.controller.ts
@@ -1,0 +1,149 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Inject,
+    NotFoundException,
+    Param,
+    ParseIntPipe,
+    Patch,
+    Post,
+    Req,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { DeckService } from 'src/core/deck/deck.service';
+import { ApiResponseDto } from 'src/http/base/api-response.dto';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { JwtOrApiKeyGuard } from '../shared/jwt-or-api-key.guard';
+import { DeckApiPresenter } from './deck-api.presenter';
+import {
+    DeckCardAddApiDto,
+    DeckCardRemoveApiDto,
+    DeckCardSetQuantityApiDto,
+    DeckCreateApiDto,
+    DeckUpdateApiDto,
+} from './dto/deck-request-api.dto';
+import { DeckDetailApiDto, DeckSummaryApiDto } from './dto/deck-response.dto';
+
+@ApiTags('Decks')
+@ApiBearerAuth()
+@Controller('api/v1/decks')
+@UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
+export class DeckApiController {
+    constructor(@Inject(DeckService) private readonly deckService: DeckService) {}
+
+    @Get()
+    @ApiOperation({ summary: "List the authenticated user's decks" })
+    @ApiResponse({ status: 200, description: 'Deck summaries' })
+    async list(@Req() req: AuthenticatedRequest): Promise<ApiResponseDto<DeckSummaryApiDto[]>> {
+        const decks = await this.deckService.listDecks(req.user.id);
+        return ApiResponseDto.ok(decks.map((d) => DeckApiPresenter.toSummary(d)));
+    }
+
+    @Post()
+    @ApiOperation({ summary: 'Create a deck' })
+    @ApiResponse({ status: 201, description: 'Created deck' })
+    async create(
+        @Body() dto: DeckCreateApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<DeckDetailApiDto>> {
+        const deck = await this.deckService.createDeck(req.user.id, dto.name, dto.format ?? null);
+        return ApiResponseDto.ok(DeckApiPresenter.toDetail(deck));
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: 'Get a deck with its cards' })
+    @ApiResponse({ status: 200, description: 'Deck detail' })
+    @ApiResponse({ status: 404, description: 'Deck not found' })
+    async get(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<DeckDetailApiDto>> {
+        const deck = await this.deckService.getDeck(id, req.user.id);
+        if (!deck) {
+            throw new NotFoundException(`Deck ${id} not found.`);
+        }
+        return ApiResponseDto.ok(DeckApiPresenter.toDetail(deck));
+    }
+
+    @Patch(':id')
+    @ApiOperation({ summary: 'Rename / re-format a deck' })
+    @ApiResponse({ status: 200, description: 'Updated deck' })
+    @ApiResponse({ status: 404, description: 'Deck not found' })
+    async update(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: DeckUpdateApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<DeckSummaryApiDto>> {
+        const deck = await this.deckService.updateDeck(id, req.user.id, dto.name, dto.format ?? null);
+        return ApiResponseDto.ok(DeckApiPresenter.toSummary(deck));
+    }
+
+    @Delete(':id')
+    @ApiOperation({ summary: 'Delete a deck' })
+    @ApiResponse({ status: 200, description: 'Deleted' })
+    @ApiResponse({ status: 404, description: 'Deck not found' })
+    async remove(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ deleted: boolean }>> {
+        await this.deckService.deleteDeck(id, req.user.id);
+        return ApiResponseDto.ok({ deleted: true });
+    }
+
+    @Post(':id/cards')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Add a card to a deck (increments quantity)' })
+    @ApiResponse({ status: 200, description: 'Added' })
+    async addCard(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: DeckCardAddApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ added: boolean }>> {
+        await this.deckService.addCard(
+            id,
+            req.user.id,
+            dto.cardId,
+            dto.isSideboard ?? false,
+            dto.quantity ?? 1
+        );
+        return ApiResponseDto.ok({ added: true });
+    }
+
+    @Patch(':id/cards')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Set the absolute quantity for a card (0 removes it)' })
+    @ApiResponse({ status: 200, description: 'Updated' })
+    async setCardQuantity(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: DeckCardSetQuantityApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ updated: boolean }>> {
+        await this.deckService.setCardQuantity(
+            id,
+            req.user.id,
+            dto.cardId,
+            dto.isSideboard,
+            dto.quantity
+        );
+        return ApiResponseDto.ok({ updated: true });
+    }
+
+    @Delete(':id/cards')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Remove a card from a deck' })
+    @ApiResponse({ status: 200, description: 'Removed' })
+    async removeCard(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() dto: DeckCardRemoveApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ deleted: boolean }>> {
+        await this.deckService.removeCard(id, req.user.id, dto.cardId, dto.isSideboard);
+        return ApiResponseDto.ok({ deleted: true });
+    }
+}

--- a/src/http/api/deck/deck-api.presenter.ts
+++ b/src/http/api/deck/deck-api.presenter.ts
@@ -1,0 +1,65 @@
+import { Format } from 'src/core/card/format.enum';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckLegalityPolicy } from 'src/core/deck/deck-legality.policy';
+import { DeckSummaryPolicy } from 'src/core/deck/deck-summary.policy';
+import { Deck } from 'src/core/deck/deck.entity';
+import { BASE_IMAGE_URL, buildCardUrl } from 'src/http/base/http.util';
+import { DeckCardApiDto, DeckDetailApiDto, DeckSummaryApiDto } from './dto/deck-response.dto';
+
+export class DeckApiPresenter {
+    static toSummary(deck: Deck): DeckSummaryApiDto {
+        const cards = deck.cards ?? [];
+        return {
+            id: deck.id!,
+            name: deck.name,
+            format: deck.format ?? null,
+            cardCount: DeckSummaryPolicy.cardCount(cards),
+            estimatedValue: round2(DeckSummaryPolicy.estimatedValue(cards)),
+            createdAt: deck.createdAt?.toISOString() ?? '',
+            updatedAt: deck.updatedAt?.toISOString() ?? '',
+        };
+    }
+
+    static toDetail(deck: Deck): DeckDetailApiDto {
+        const cards = deck.cards ?? [];
+        const cardDtos = cards.map((c) => DeckApiPresenter.toCard(c, deck.format ?? null));
+        return {
+            ...DeckApiPresenter.toSummary(deck),
+            illegalCount: cardDtos.filter((c) => c.legalInFormat === false).length,
+            cards: cardDtos,
+        };
+    }
+
+    static toCard(deckCard: DeckCard, format: Format | null): DeckCardApiDto {
+        const card = deckCard.card;
+        if (!card) {
+            return {
+                cardId: deckCard.cardId,
+                quantity: deckCard.quantity,
+                isSideboard: deckCard.isSideboard,
+            };
+        }
+        const price = card.prices?.[0];
+        return {
+            cardId: deckCard.cardId,
+            quantity: deckCard.quantity,
+            isSideboard: deckCard.isSideboard,
+            cardName: card.name,
+            setCode: card.setCode,
+            cardNumber: card.number,
+            imgSrc: `${BASE_IMAGE_URL}/normal/front/${card.imgSrc}`,
+            rarity: card.rarity?.toLowerCase(),
+            type: card.type,
+            manaCost: card.manaCost,
+            keyruneCode: card.set?.keyruneCode ?? card.setCode,
+            priceNormal: price?.normal != null ? Number(price.normal) : null,
+            priceFoil: price?.foil != null ? Number(price.foil) : null,
+            legalInFormat: format ? DeckLegalityPolicy.isCardLegal(format, card.legalities) : null,
+            url: buildCardUrl(card.setCode, card.number),
+        };
+    }
+}
+
+function round2(n: number): number {
+    return Math.round(n * 100) / 100;
+}

--- a/src/http/api/deck/dto/deck-request-api.dto.ts
+++ b/src/http/api/deck/dto/deck-request-api.dto.ts
@@ -1,0 +1,72 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Format } from 'src/core/card/format.enum';
+import { IsBoolean, IsEnum, IsInt, IsOptional, IsString, IsUUID, Min } from 'class-validator';
+
+/** Create a deck. */
+export class DeckCreateApiDto {
+    @ApiProperty()
+    @IsString()
+    readonly name: string;
+
+    @ApiPropertyOptional({ enum: Format, description: 'Target format (omit for no format).' })
+    @IsOptional()
+    @IsEnum(Format)
+    readonly format?: Format;
+}
+
+/** Rename / re-format a deck. */
+export class DeckUpdateApiDto {
+    @ApiProperty()
+    @IsString()
+    readonly name: string;
+
+    @ApiPropertyOptional({ enum: Format, description: 'Target format (omit to clear).' })
+    @IsOptional()
+    @IsEnum(Format)
+    readonly format?: Format;
+}
+
+/** Add a card to a deck (increments quantity for card + board). */
+export class DeckCardAddApiDto {
+    @ApiProperty()
+    @IsUUID()
+    readonly cardId: string;
+
+    @ApiPropertyOptional({ default: false })
+    @IsOptional()
+    @IsBoolean()
+    readonly isSideboard?: boolean;
+
+    @ApiPropertyOptional({ default: 1, minimum: 1 })
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    readonly quantity?: number;
+}
+
+/** Set the absolute quantity for a card + board; 0 removes it. */
+export class DeckCardSetQuantityApiDto {
+    @ApiProperty()
+    @IsUUID()
+    readonly cardId: string;
+
+    @ApiProperty({ default: false })
+    @IsBoolean()
+    readonly isSideboard: boolean;
+
+    @ApiProperty({ minimum: 0 })
+    @IsInt()
+    @Min(0)
+    readonly quantity: number;
+}
+
+/** Remove a card + board from a deck. */
+export class DeckCardRemoveApiDto {
+    @ApiProperty()
+    @IsUUID()
+    readonly cardId: string;
+
+    @ApiProperty({ default: false })
+    @IsBoolean()
+    readonly isSideboard: boolean;
+}

--- a/src/http/api/deck/dto/deck-response.dto.ts
+++ b/src/http/api/deck/dto/deck-response.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class DeckCardApiDto {
+    @ApiProperty()
+    readonly cardId: string;
+
+    @ApiProperty()
+    readonly quantity: number;
+
+    @ApiProperty()
+    readonly isSideboard: boolean;
+
+    @ApiPropertyOptional()
+    readonly cardName?: string;
+
+    @ApiPropertyOptional()
+    readonly setCode?: string;
+
+    @ApiPropertyOptional()
+    readonly cardNumber?: string;
+
+    @ApiPropertyOptional()
+    readonly imgSrc?: string;
+
+    @ApiPropertyOptional()
+    readonly rarity?: string;
+
+    @ApiPropertyOptional()
+    readonly type?: string;
+
+    @ApiPropertyOptional()
+    readonly manaCost?: string;
+
+    @ApiPropertyOptional()
+    readonly keyruneCode?: string;
+
+    @ApiPropertyOptional()
+    readonly priceNormal?: number | null;
+
+    @ApiPropertyOptional()
+    readonly priceFoil?: number | null;
+
+    @ApiPropertyOptional({
+        description: 'Whether the card is legal in the deck format. Null when the deck has no format.',
+    })
+    readonly legalInFormat?: boolean | null;
+
+    @ApiPropertyOptional()
+    readonly url?: string;
+}
+
+/** Lightweight deck row for the list endpoint. */
+export class DeckSummaryApiDto {
+    @ApiProperty()
+    readonly id: number;
+
+    @ApiProperty()
+    readonly name: string;
+
+    @ApiPropertyOptional({ nullable: true })
+    readonly format?: string | null;
+
+    @ApiProperty({ description: 'Total card count (sum of quantities, main + side).' })
+    readonly cardCount: number;
+
+    @ApiProperty()
+    readonly estimatedValue: number;
+
+    @ApiProperty()
+    readonly createdAt: string;
+
+    @ApiProperty()
+    readonly updatedAt: string;
+}
+
+/** Full deck with its cards. */
+export class DeckDetailApiDto extends DeckSummaryApiDto {
+    @ApiProperty({ description: 'Count of cards not legal in the deck format (0 when no format).' })
+    readonly illegalCount: number;
+
+    @ApiProperty({ type: [DeckCardApiDto] })
+    readonly cards: DeckCardApiDto[];
+}

--- a/src/http/hbs/deck/deck-page.controller.ts
+++ b/src/http/hbs/deck/deck-page.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Inject, Param, ParseIntPipe, Render, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { DeckPageOrchestrator } from './deck-page.orchestrator';
+import { DeckDetailViewDto, DeckListViewDto } from './dto/deck.view.dto';
+
+@Controller('decks')
+export class DeckPageController {
+    constructor(
+        @Inject(DeckPageOrchestrator) private readonly orchestrator: DeckPageOrchestrator
+    ) {}
+
+    @UseGuards(JwtAuthGuard)
+    @Get()
+    @Render('decks')
+    async list(@Req() req: AuthenticatedRequest): Promise<DeckListViewDto> {
+        return this.orchestrator.buildListView(req);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @Get(':id')
+    @Render('deckDetail')
+    async detail(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req: AuthenticatedRequest
+    ): Promise<DeckDetailViewDto> {
+        return this.orchestrator.buildDetailView(req, id);
+    }
+}

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -1,0 +1,196 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Format } from 'src/core/card/format.enum';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckLegalityPolicy } from 'src/core/deck/deck-legality.policy';
+import { DeckSummaryPolicy } from 'src/core/deck/deck-summary.policy';
+import { Deck } from 'src/core/deck/deck.entity';
+import { DeckService } from 'src/core/deck/deck.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { buildCardUrl } from 'src/http/base/http.util';
+import { HttpErrorHandler } from 'src/http/http.error.handler';
+import { getLogger } from 'src/logger/global-app-logger';
+import {
+    DeckCardGroupView,
+    DeckCardView,
+    DeckDetailViewDto,
+    DeckListViewDto,
+    FormatOptionView,
+} from './dto/deck.view.dto';
+
+// Maindeck grouping: pick a card's primary type, in deckbuilder display order.
+const TYPE_ORDER = [
+    'Creature',
+    'Planeswalker',
+    'Instant',
+    'Sorcery',
+    'Artifact',
+    'Enchantment',
+    'Battle',
+    'Land',
+];
+const TYPE_PLURAL: Record<string, string> = {
+    Creature: 'Creatures',
+    Planeswalker: 'Planeswalkers',
+    Instant: 'Instants',
+    Sorcery: 'Sorceries',
+    Artifact: 'Artifacts',
+    Enchantment: 'Enchantments',
+    Battle: 'Battles',
+    Land: 'Lands',
+    Other: 'Other',
+};
+
+@Injectable()
+export class DeckPageOrchestrator {
+    private readonly LOGGER = getLogger(DeckPageOrchestrator.name);
+
+    private static readonly CURRENCY = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+    });
+
+    constructor(@Inject(DeckService) private readonly deckService: DeckService) {}
+
+    async buildListView(req: AuthenticatedRequest): Promise<DeckListViewDto> {
+        try {
+            HttpErrorHandler.validateAuthenticatedRequest(req);
+            const decks = await this.deckService.listDecks(req.user.id);
+            return new DeckListViewDto({
+                authenticated: true,
+                title: 'Decks - I Want My MTG',
+                breadcrumbs: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Decks', url: '/decks' },
+                ],
+                hasDecks: decks.length > 0,
+                decks: decks.map((d) => this.toListItem(d)),
+                formatOptions: this.buildFormatOptions(null),
+            });
+        } catch (error) {
+            this.LOGGER.debug(`Error building deck list view: ${error?.message}`);
+            return HttpErrorHandler.toHttpException(error, 'buildListView');
+        }
+    }
+
+    async buildDetailView(req: AuthenticatedRequest, deckId: number): Promise<DeckDetailViewDto> {
+        try {
+            HttpErrorHandler.validateAuthenticatedRequest(req);
+            const deck = await this.deckService.getDeck(deckId, req.user.id);
+            if (!deck) {
+                throw new Error(`Deck ${deckId} not found.`);
+            }
+            const cards = deck.cards ?? [];
+            const main = cards.filter((c) => !c.isSideboard);
+            const side = cards.filter((c) => c.isSideboard);
+            const illegalCount = deck.format
+                ? cards.filter((c) => this.isIllegal(deck.format, c)).length
+                : 0;
+
+            return new DeckDetailViewDto({
+                authenticated: true,
+                title: `${deck.name} - Decks - I Want My MTG`,
+                breadcrumbs: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Decks', url: '/decks' },
+                    { label: deck.name, url: `/decks/${deck.id}` },
+                ],
+                deckId: deck.id!,
+                name: deck.name,
+                format: deck.format ?? null,
+                formatLabel: deck.format ? this.capitalize(deck.format) : 'No format',
+                formatOptions: this.buildFormatOptions(deck.format ?? null),
+                mainGroups: this.groupByType(main, deck.format ?? null),
+                sideboard: side.map((c) => this.toCardView(c, deck.format ?? null)),
+                mainCount: DeckSummaryPolicy.cardCount(main),
+                sideCount: DeckSummaryPolicy.cardCount(side),
+                estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
+                illegalCount,
+                hasCards: cards.length > 0,
+            });
+        } catch (error) {
+            this.LOGGER.debug(`Error building deck detail view: ${error?.message}`);
+            return HttpErrorHandler.toHttpException(error, 'buildDetailView');
+        }
+    }
+
+    private toListItem(deck: Deck) {
+        const cards = deck.cards ?? [];
+        return {
+            id: deck.id!,
+            name: deck.name,
+            formatLabel: deck.format ? this.capitalize(deck.format) : 'No format',
+            cardCount: DeckSummaryPolicy.cardCount(cards),
+            estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
+            updatedAt: deck.updatedAt ? deck.updatedAt.toLocaleDateString('en-US') : '',
+            url: `/decks/${deck.id}`,
+        };
+    }
+
+    private groupByType(cards: DeckCard[], format: Format | null): DeckCardGroupView[] {
+        const buckets = new Map<string, DeckCardView[]>();
+        for (const dc of cards) {
+            const key = this.primaryType(dc.card?.type ?? '');
+            const list = buckets.get(key) ?? [];
+            list.push(this.toCardView(dc, format));
+            buckets.set(key, list);
+        }
+        const order = [...TYPE_ORDER, 'Other'];
+        return order
+            .filter((t) => buckets.has(t))
+            .map((t) => {
+                const cardViews = buckets.get(t)!;
+                return {
+                    type: TYPE_PLURAL[t] ?? t,
+                    count: cardViews.reduce((sum, c) => sum + c.quantity, 0),
+                    cards: cardViews,
+                };
+            });
+    }
+
+    private toCardView(dc: DeckCard, format: Format | null): DeckCardView {
+        const card = dc.card;
+        const unitValue = DeckSummaryPolicy.cardValue(card);
+        return {
+            cardId: dc.cardId,
+            name: card?.name ?? dc.cardId,
+            setCode: card?.setCode ?? '',
+            number: card?.number ?? '',
+            url: card ? buildCardUrl(card.setCode, card.number) : '#',
+            manaCost: card?.manaCost,
+            quantity: dc.quantity,
+            unitValue: Math.round(unitValue * 100) / 100,
+            lineValue: this.formatCurrency(dc.quantity * unitValue),
+            isSideboard: dc.isSideboard,
+            illegal: this.isIllegal(format, dc),
+        };
+    }
+
+    private isIllegal(format: Format | null, dc: DeckCard): boolean {
+        return !!format && !DeckLegalityPolicy.isCardLegal(format, dc.card?.legalities);
+    }
+
+    private primaryType(typeLine: string): string {
+        // MTGJSON type lines use an em dash (U+2014) before subtypes, e.g.
+        // "Legendary Creature [em dash] God"; take the part before it.
+        const head = (typeLine ?? '').split(String.fromCharCode(0x2014))[0];
+        return TYPE_ORDER.find((t) => head.includes(t)) ?? 'Other';
+    }
+
+    private buildFormatOptions(selected: string | null): FormatOptionView[] {
+        const options: FormatOptionView[] = [
+            { value: '', label: 'No format', selected: !selected },
+        ];
+        for (const f of Object.values(Format)) {
+            options.push({ value: f, label: this.capitalize(f), selected: f === selected });
+        }
+        return options;
+    }
+
+    private capitalize(value: string): string {
+        return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+    }
+
+    private formatCurrency(value: number): string {
+        return DeckPageOrchestrator.CURRENCY.format(value || 0);
+    }
+}

--- a/src/http/hbs/deck/dto/deck.view.dto.ts
+++ b/src/http/hbs/deck/dto/deck.view.dto.ts
@@ -1,0 +1,81 @@
+import { BaseViewDto } from 'src/http/base/base.view.dto';
+
+export interface FormatOptionView {
+    value: string;
+    label: string;
+    selected: boolean;
+}
+
+export interface DeckListItemView {
+    id: number;
+    name: string;
+    formatLabel: string;
+    cardCount: number;
+    estimatedValue: string;
+    updatedAt: string;
+    url: string;
+}
+
+export class DeckListViewDto extends BaseViewDto {
+    readonly decks: DeckListItemView[];
+    readonly hasDecks: boolean;
+    readonly formatOptions: FormatOptionView[];
+
+    constructor(init: Partial<DeckListViewDto>) {
+        super(init);
+        this.decks = init.decks ?? [];
+        this.hasDecks = init.hasDecks ?? false;
+        this.formatOptions = init.formatOptions ?? [];
+    }
+}
+
+export interface DeckCardView {
+    cardId: string;
+    name: string;
+    setCode: string;
+    number: string;
+    url: string;
+    manaCost?: string;
+    quantity: number;
+    unitValue: number;
+    lineValue: string;
+    isSideboard: boolean;
+    illegal: boolean;
+}
+
+export interface DeckCardGroupView {
+    type: string;
+    count: number;
+    cards: DeckCardView[];
+}
+
+export class DeckDetailViewDto extends BaseViewDto {
+    readonly deckId: number;
+    readonly name: string;
+    readonly format: string | null;
+    readonly formatLabel: string;
+    readonly formatOptions: FormatOptionView[];
+    readonly mainGroups: DeckCardGroupView[];
+    readonly sideboard: DeckCardView[];
+    readonly mainCount: number;
+    readonly sideCount: number;
+    readonly estimatedValue: string;
+    readonly illegalCount: number;
+    readonly hasCards: boolean;
+
+    constructor(init: Partial<DeckDetailViewDto>) {
+        super(init);
+        this.deckId = init.deckId ?? 0;
+        this.name = init.name ?? '';
+        this.format = init.format ?? null;
+        this.formatLabel = init.formatLabel ?? '';
+        this.formatOptions = init.formatOptions ?? [];
+        this.mainGroups = init.mainGroups ?? [];
+        this.sideboard = init.sideboard ?? [];
+        this.mainCount = init.mainCount ?? 0;
+        this.sideCount = init.sideCount ?? 0;
+        this.estimatedValue = init.estimatedValue ?? '$0.00';
+        this.illegalCount = init.illegalCount ?? 0;
+        this.hasCards = init.hasCards ?? false;
+    }
+}

--- a/src/http/hbs/hbs.module.ts
+++ b/src/http/hbs/hbs.module.ts
@@ -11,6 +11,8 @@ import { BillingOrchestrator } from './billing/billing.orchestrator';
 import { BlogController } from './blog/blog.controller';
 import { BuyListPageController } from './buy-list/buy-list-page.controller';
 import { BuyListPageOrchestrator } from './buy-list/buy-list-page.orchestrator';
+import { DeckPageController } from './deck/deck-page.controller';
+import { DeckPageOrchestrator } from './deck/deck-page.orchestrator';
 import { SellOptimizerController } from './optimizer/sell-optimizer.controller';
 import { SellOptimizerOrchestrator } from './optimizer/sell-optimizer.orchestrator';
 import { PricingController } from './billing/pricing.controller';
@@ -51,6 +53,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         PricingController,
         BlogController,
         BuyListPageController,
+        DeckPageController,
         SellOptimizerController,
         CardController,
         HomeController,
@@ -73,6 +76,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         PricingOrchestrator,
         { provide: APP_INTERCEPTOR, useClass: SubscriptionViewInterceptor },
         BuyListPageOrchestrator,
+        DeckPageOrchestrator,
         SellOptimizerOrchestrator,
         CardOrchestrator,
         InventoryOrchestrator,
@@ -90,6 +94,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         BillingOrchestrator,
         PricingOrchestrator,
         BuyListPageOrchestrator,
+        DeckPageOrchestrator,
         SellOptimizerOrchestrator,
         CardOrchestrator,
         InventoryOrchestrator,

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -1238,6 +1238,10 @@ img,
   width: 1.75rem;
 }
 
+.w-8 {
+  width: 2rem;
+}
+
 .w-9 {
   width: 2.25rem;
 }
@@ -1248,6 +1252,10 @@ img,
 
 .min-w-0 {
   min-width: 0px;
+}
+
+.min-w-\[12rem\] {
+  min-width: 12rem;
 }
 
 .min-w-full {
@@ -1539,6 +1547,10 @@ img,
   border-radius: 0.5rem;
 }
 
+.rounded-md {
+  border-radius: 0.375rem;
+}
+
 .rounded-sm {
   border-radius: 0.125rem;
 }
@@ -1644,6 +1656,11 @@ img,
   border-color: rgb(239 68 68 / var(--tw-border-opacity, 1));
 }
 
+.border-teal-200 {
+  --tw-border-opacity: 1;
+  border-color: rgb(168 244 239 / var(--tw-border-opacity, 1));
+}
+
 .border-teal-300 {
   --tw-border-opacity: 1;
   border-color: rgb(114 236 229 / var(--tw-border-opacity, 1));
@@ -1727,6 +1744,11 @@ img,
 .bg-purple-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(250 246 254 / var(--tw-bg-opacity, 1));
+}
+
+.bg-red-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 226 226 / var(--tw-bg-opacity, 1));
 }
 
 .bg-red-50 {
@@ -1915,6 +1937,10 @@ img,
 
 .pb-2 {
   padding-bottom: 0.5rem;
+}
+
+.pb-4 {
+  padding-bottom: 1rem;
 }
 
 .pb-5 {
@@ -2143,6 +2169,11 @@ img,
   color: rgb(30 64 175 / var(--tw-text-opacity, 1));
 }
 
+.text-emerald-600 {
+  --tw-text-opacity: 1;
+  color: rgb(5 150 105 / var(--tw-text-opacity, 1));
+}
+
 .text-emerald-700 {
   --tw-text-opacity: 1;
   color: rgb(4 120 87 / var(--tw-text-opacity, 1));
@@ -2251,6 +2282,11 @@ img,
 .text-red-600 {
   --tw-text-opacity: 1;
   color: rgb(220 38 38 / var(--tw-text-opacity, 1));
+}
+
+.text-red-700 {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
 }
 
 .text-red-800 {
@@ -7919,6 +7955,11 @@ img,
     color: rgb(220 38 38 / var(--tw-text-opacity, 1));
   }
 
+  .hover\:text-red-700:hover {
+    --tw-text-opacity: 1;
+    color: rgb(185 28 28 / var(--tw-text-opacity, 1));
+  }
+
   .hover\:text-teal-100:hover {
     --tw-text-opacity: 1;
     color: rgb(212 250 247 / var(--tw-text-opacity, 1));
@@ -8015,6 +8056,11 @@ img,
   border-color: rgb(36 30 69 / var(--tw-border-opacity, 1));
 }
 
+.dark\:border-midnight-800:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(26 21 51 / var(--tw-border-opacity, 1));
+}
+
 .dark\:border-purple-600:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(139 66 198 / var(--tw-border-opacity, 1));
@@ -8043,6 +8089,10 @@ img,
 .dark\:border-teal-700:is(.dark *) {
   --tw-border-opacity: 1;
   border-color: rgb(26 122 120 / var(--tw-border-opacity, 1));
+}
+
+.dark\:border-teal-700\/50:is(.dark *) {
+  border-color: rgb(26 122 120 / 0.5);
 }
 
 .dark\:bg-amber-900\/20:is(.dark *) {
@@ -8118,6 +8168,10 @@ img,
 
 .dark\:bg-red-900\/30:is(.dark *) {
   background-color: rgb(127 29 29 / 0.3);
+}
+
+.dark\:bg-red-900\/40:is(.dark *) {
+  background-color: rgb(127 29 29 / 0.4);
 }
 
 .dark\:bg-teal-600:is(.dark *) {
@@ -8250,6 +8304,11 @@ img,
 .dark\:text-red-200:is(.dark *) {
   --tw-text-opacity: 1;
   color: rgb(254 202 202 / var(--tw-text-opacity, 1));
+}
+
+.dark\:text-red-300:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(252 165 165 / var(--tw-text-opacity, 1));
 }
 
 .dark\:text-red-400:is(.dark *) {

--- a/src/http/public/js/deckAdd.js
+++ b/src/http/public/js/deckAdd.js
@@ -1,0 +1,105 @@
+/**
+ * "Add to deck" control (10.4) on the card page. Loads the user's decks into a
+ * select (GET /api/v1/decks), then POSTs the card to the chosen deck. Choosing
+ * "New deck" prompts for a name, creates it, then adds the card.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    var container = document.getElementById('deck-add');
+    if (!container || typeof AjaxUtils === 'undefined') return;
+    var select = document.getElementById('deck-add-select');
+    var btn = document.getElementById('deck-add-btn');
+    var result = document.getElementById('deck-add-result');
+    var cardId = container.getAttribute('data-card-id');
+    var NEW = '__new__';
+
+    function setOptions(decks) {
+        select.innerHTML = '';
+        decks.forEach(function (d) {
+            var opt = document.createElement('option');
+            opt.value = String(d.id);
+            opt.textContent = d.name;
+            select.appendChild(opt);
+        });
+        var newOpt = document.createElement('option');
+        newOpt.value = NEW;
+        newOpt.textContent = decks.length ? '+ New deck…' : 'Create a deck…';
+        select.appendChild(newOpt);
+        btn.disabled = false;
+    }
+
+    AjaxUtils.fetchWithGate('/api/v1/decks', { method: 'GET' })
+        .then(function (res) {
+            if (res.gated) return;
+            var decks = res.ok && res.body && res.body.data ? res.body.data : [];
+            setOptions(decks);
+        })
+        .catch(function () {
+            setOptions([]);
+        });
+
+    function addToDeck(deckId) {
+        return AjaxUtils.fetchWithGate('/api/v1/decks/' + deckId + '/cards', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ cardId: cardId, quantity: 1 }),
+        });
+    }
+
+    btn.addEventListener('click', function () {
+        if (!cardId) return;
+        var value = select.value;
+        if (result) result.textContent = '';
+        btn.disabled = true;
+
+        var resolveDeckId;
+        if (value === NEW) {
+            var name = (window.prompt('New deck name:') || '').trim();
+            if (!name) {
+                btn.disabled = false;
+                return;
+            }
+            resolveDeckId = AjaxUtils.fetchWithGate('/api/v1/decks', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name: name }),
+            }).then(function (res) {
+                if (res.gated) return null;
+                if (!res.ok) throw new Error('create failed');
+                var deck = res.body && res.body.data;
+                var opt = document.createElement('option');
+                opt.value = String(deck.id);
+                opt.textContent = deck.name;
+                select.insertBefore(opt, select.lastChild);
+                select.value = String(deck.id);
+                return deck.id;
+            });
+        } else if (value) {
+            resolveDeckId = Promise.resolve(parseInt(value, 10));
+        } else {
+            btn.disabled = false;
+            return;
+        }
+
+        resolveDeckId
+            .then(function (deckId) {
+                if (!deckId) {
+                    btn.disabled = false;
+                    return;
+                }
+                return addToDeck(deckId).then(function (res) {
+                    btn.disabled = false;
+                    if (res.gated) return;
+                    if (!res.ok) {
+                        if (result) result.textContent = 'Could not add.';
+                        return;
+                    }
+                    var opt = select.options[select.selectedIndex];
+                    if (result) result.textContent = 'Added to ' + (opt ? opt.textContent : 'deck') + '.';
+                });
+            })
+            .catch(function () {
+                btn.disabled = false;
+                if (result) result.textContent = 'Could not add.';
+            });
+    });
+});

--- a/src/http/public/js/deckDetail.js
+++ b/src/http/public/js/deckDetail.js
@@ -1,0 +1,176 @@
+/**
+ * Deck detail page (10.4): quantity steppers, remove, rename/format, delete.
+ * Card mutations hit /api/v1/decks/:id/cards and update the DOM in place;
+ * totals (deck value, board counts, group counts, illegal count) recompute
+ * client-side from data-unit-value on each row. Deck-level edits reload so the
+ * server re-renders legality + grouping.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    if (typeof AjaxUtils === 'undefined') return;
+
+    var root = document.querySelector('.content-wrapper[data-deck-id]');
+    if (!root) return;
+    var base = '/api/v1/decks/' + root.getAttribute('data-deck-id');
+
+    function fmt(n) {
+        return '$' + (Math.round(n * 100) / 100).toFixed(2);
+    }
+
+    function rowQty(row) {
+        return parseInt(row.querySelector('.deck-qty-val').textContent, 10) || 0;
+    }
+
+    function recompute() {
+        var rows = document.querySelectorAll('#deck-cards [data-card-id]');
+        var total = 0;
+        var mainCount = 0;
+        var sideCount = 0;
+        rows.forEach(function (row) {
+            var qty = rowQty(row);
+            var unit = parseFloat(row.getAttribute('data-unit-value')) || 0;
+            total += qty * unit;
+            if (row.getAttribute('data-sideboard') === 'true') sideCount += qty;
+            else mainCount += qty;
+        });
+        setText('deck-est-value', fmt(total));
+        setText('deck-main-count', mainCount);
+        setText('deck-side-count', sideCount);
+
+        document.querySelectorAll('.deck-group').forEach(function (group) {
+            var count = 0;
+            group.querySelectorAll('[data-card-id]').forEach(function (row) {
+                count += rowQty(row);
+            });
+            var span = group.querySelector('.deck-group-count');
+            if (span) span.textContent = count;
+        });
+
+        var notice = document.getElementById('deck-illegal-notice');
+        if (notice) {
+            var badges = document.querySelectorAll('#deck-cards .deck-illegal-badge').length;
+            setText('deck-illegal-count', badges);
+            notice.classList.toggle('hidden', badges === 0);
+        }
+    }
+
+    function setText(id, value) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = value;
+    }
+
+    function updateLineValue(row, qty) {
+        var unit = parseFloat(row.getAttribute('data-unit-value')) || 0;
+        var lv = row.querySelector('.deck-line-value');
+        if (lv) lv.textContent = fmt(qty * unit);
+    }
+
+    function removeRow(row) {
+        var group = row.closest('.deck-group');
+        row.remove();
+        if (group && group.querySelectorAll('[data-card-id]').length === 0) group.remove();
+        if (!document.querySelector('#deck-cards [data-card-id]')) {
+            window.location.reload();
+            return;
+        }
+        recompute();
+    }
+
+    function cardPayload(row, extra) {
+        var payload = {
+            cardId: row.getAttribute('data-card-id'),
+            isSideboard: row.getAttribute('data-sideboard') === 'true',
+        };
+        if (extra) Object.keys(extra).forEach(function (k) { payload[k] = extra[k]; });
+        return payload;
+    }
+
+    document.querySelectorAll('#deck-cards .deck-step').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var row = btn.closest('[data-card-id]');
+            if (!row) return;
+            var next = rowQty(row) + (parseInt(btn.getAttribute('data-delta'), 10) || 0);
+            if (next < 0) next = 0;
+            btn.disabled = true;
+            AjaxUtils.fetchWithGate(base + '/cards', {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(cardPayload(row, { quantity: next })),
+            })
+                .then(function (res) {
+                    btn.disabled = false;
+                    if (res.gated || !res.ok) return;
+                    if (next <= 0) {
+                        removeRow(row);
+                    } else {
+                        row.querySelector('.deck-qty-val').textContent = next;
+                        updateLineValue(row, next);
+                        recompute();
+                    }
+                })
+                .catch(function () {
+                    btn.disabled = false;
+                });
+        });
+    });
+
+    document.querySelectorAll('#deck-cards .deck-remove').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var row = btn.closest('[data-card-id]');
+            if (!row) return;
+            btn.disabled = true;
+            AjaxUtils.fetchWithGate(base + '/cards', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(cardPayload(row)),
+            })
+                .then(function (res) {
+                    btn.disabled = false;
+                    if (res.gated || !res.ok) return;
+                    removeRow(row);
+                })
+                .catch(function () {
+                    btn.disabled = false;
+                });
+        });
+    });
+
+    var editForm = document.getElementById('deck-edit-form');
+    var editResult = document.getElementById('deck-edit-result');
+    if (editForm) {
+        editForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            var name = document.getElementById('deck-name-input').value.trim();
+            var format = document.getElementById('deck-format-input').value;
+            if (!name) {
+                if (editResult) editResult.textContent = 'Enter a name.';
+                return;
+            }
+            var body = { name: name };
+            if (format) body.format = format;
+            AjaxUtils.fetchWithGate(base, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            })
+                .then(function (res) {
+                    if (res.gated) return;
+                    if (res.ok) window.location.reload();
+                    else if (editResult) editResult.textContent = 'Could not save.';
+                })
+                .catch(function () {
+                    if (editResult) editResult.textContent = 'Could not save.';
+                });
+        });
+    }
+
+    var deleteBtn = document.getElementById('deck-delete-btn');
+    if (deleteBtn) {
+        deleteBtn.addEventListener('click', function () {
+            if (!window.confirm('Delete this deck? This cannot be undone.')) return;
+            AjaxUtils.fetchWithGate(base, { method: 'DELETE' }).then(function (res) {
+                if (res.gated) return;
+                if (res.ok) window.location.href = '/decks';
+            });
+        });
+    }
+});

--- a/src/http/public/js/decks.js
+++ b/src/http/public/js/decks.js
@@ -1,0 +1,64 @@
+/**
+ * Decks list page (10.4): create a deck (POST /api/v1/decks then open it) and
+ * delete a deck inline. Uses AjaxUtils.fetchWithGate for the shared envelope.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    if (typeof AjaxUtils === 'undefined') return;
+
+    var form = document.getElementById('deck-create-form');
+    var result = document.getElementById('deck-create-result');
+
+    if (form) {
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            var name = document.getElementById('deck-name').value.trim();
+            var format = document.getElementById('deck-format').value;
+            if (!name) {
+                if (result) result.textContent = 'Enter a deck name.';
+                return;
+            }
+            var body = { name: name };
+            if (format) body.format = format;
+            AjaxUtils.fetchWithGate('/api/v1/decks', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            })
+                .then(function (res) {
+                    if (res.gated) return;
+                    if (!res.ok) {
+                        if (result) result.textContent = 'Could not create deck.';
+                        return;
+                    }
+                    var id = res.body && res.body.data && res.body.data.id;
+                    if (id) window.location.href = '/decks/' + id;
+                    else window.location.reload();
+                })
+                .catch(function () {
+                    if (result) result.textContent = 'Could not create deck.';
+                });
+        });
+    }
+
+    document.querySelectorAll('.deck-delete-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var id = btn.getAttribute('data-deck-id');
+            var name = btn.getAttribute('data-deck-name') || 'this deck';
+            if (!id) return;
+            if (!window.confirm('Delete "' + name + '"? This cannot be undone.')) return;
+            btn.disabled = true;
+            AjaxUtils.fetchWithGate('/api/v1/decks/' + id, { method: 'DELETE' })
+                .then(function (res) {
+                    btn.disabled = false;
+                    if (res.gated) return;
+                    if (res.ok) {
+                        var card = document.querySelector('.section-container[data-deck-id="' + id + '"]');
+                        if (card) card.remove();
+                    }
+                })
+                .catch(function () {
+                    btn.disabled = false;
+                });
+        });
+    });
+});

--- a/src/http/views/card.hbs
+++ b/src/http/views/card.hbs
@@ -193,6 +193,16 @@
                     </button>
                     <span id="buy-list-add-result" class="text-sm text-teal-600 dark:text-teal-400" role="status" aria-live="polite"></span>
                 </div>
+
+                <div class="mt-2 flex items-center gap-2 flex-wrap" id="deck-add" data-card-id="{{card.cardId}}">
+                    <select id="deck-add-select" class="rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 text-sm py-1.5" aria-label="Choose a deck">
+                        <option value="">Loading decks&hellip;</option>
+                    </select>
+                    <button type="button" id="deck-add-btn" class="btn btn-secondary btn--sm" disabled>
+                        <i class="fas fa-layer-group mr-1" aria-hidden="true"></i> Add to deck
+                    </button>
+                    <span id="deck-add-result" class="text-sm text-teal-600 dark:text-teal-400" role="status" aria-live="polite"></span>
+                </div>
                 {{/if}}
 
                 <div class="mt-4" id="price-history-chart" data-card-id="{{card.cardId}}" data-chart-src="/public/js/priceHistoryChart.js?v={{assetVersion}}">
@@ -262,6 +272,7 @@
 
 <script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/buyListAdd.js?v={{assetVersion}}" defer></script>
+<script src="/public/js/deckAdd.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/updateInventory.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/chartLoader.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/transactionForm.js?v={{assetVersion}}" defer></script>

--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -1,0 +1,113 @@
+<div class="content-wrapper py-6" data-deck-id="{{deckId}}">
+    <div class="flex items-start justify-between mb-2 flex-wrap gap-3">
+        <div>
+            <h1 class="page-title">{{name}}</h1>
+            <p class="page-subtitle">
+                <span class="text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
+                <span class="mx-1">&middot;</span>
+                <span id="deck-main-count">{{mainCount}}</span> maindeck
+                {{#if sideCount}}<span class="mx-1">&middot;</span><span id="deck-side-count">{{sideCount}}</span> sideboard{{/if}}
+                <span class="mx-1">&middot;</span>
+                <span id="deck-est-value" class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
+            </p>
+        </div>
+        <a href="/decks" class="btn btn-ghost text-sm">&larr; All decks</a>
+    </div>
+
+    {{#if format}}
+        <p id="deck-illegal-notice" class="text-sm text-red-600 dark:text-red-400 mb-3 {{#unless illegalCount}}hidden{{/unless}}">
+            <i class="fas fa-triangle-exclamation mr-1" aria-hidden="true"></i>
+            <span id="deck-illegal-count">{{illegalCount}}</span> card type(s) not legal in {{formatLabel}}.
+        </p>
+    {{/if}}
+
+    {{!-- Edit deck (rename / format / delete) --}}
+    <details class="section-container mb-5">
+        <summary class="cursor-pointer font-medium"><i class="fas fa-gear mr-2" aria-hidden="true"></i>Deck settings</summary>
+        <form id="deck-edit-form" class="flex flex-wrap items-end gap-3 mt-3">
+            <div class="flex-1 min-w-[12rem]">
+                <label for="deck-name-input" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Name</label>
+                <input id="deck-name-input" name="name" type="text" required maxlength="120" value="{{name}}"
+                    class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm" />
+            </div>
+            <div>
+                <label for="deck-format-input" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Format</label>
+                <select id="deck-format-input" name="format"
+                    class="rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm">
+                    {{#each formatOptions}}
+                        <option value="{{value}}" {{#if selected}}selected{{/if}}>{{label}}</option>
+                    {{/each}}
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+            <button type="button" id="deck-delete-btn" class="btn btn-ghost text-red-600 dark:text-red-400">
+                <i class="fas fa-trash mr-1" aria-hidden="true"></i> Delete deck
+            </button>
+            <span id="deck-edit-result" class="text-sm" role="status" aria-live="polite"></span>
+        </form>
+    </details>
+
+    {{#if hasCards}}
+        <div id="deck-cards">
+            {{#each mainGroups}}
+                <div class="deck-group mb-5">
+                    <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                        {{type}} <span class="text-gray-400 font-normal">(<span class="deck-group-count">{{count}}</span>)</span>
+                    </h3>
+                    <div>
+                        {{#each cards}}
+                            <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800"
+                                data-card-id="{{cardId}}" data-sideboard="false" data-unit-value="{{unitValue}}">
+                                <span class="inline-flex items-center rounded-md border border-gray-200 dark:border-midnight-700">
+                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="-1" aria-label="Decrease quantity">&minus;</button>
+                                    <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
+                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
+                                </span>
+                                <a href="{{url}}" class="flex-1 text-sm text-gray-800 dark:text-gray-100 hover:text-teal-600 dark:hover:text-teal-400 truncate">{{name}}</a>
+                                {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
+                                <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
+                                <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
+                            </div>
+                        {{/each}}
+                    </div>
+                </div>
+            {{/each}}
+
+            {{#if sideboard.length}}
+                <div class="deck-group mb-5">
+                    <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                        Sideboard <span class="text-gray-400 font-normal">(<span class="deck-group-count">{{sideCount}}</span>)</span>
+                    </h3>
+                    <div>
+                        {{#each sideboard}}
+                            <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800"
+                                data-card-id="{{cardId}}" data-sideboard="true" data-unit-value="{{unitValue}}">
+                                <span class="inline-flex items-center rounded-md border border-gray-200 dark:border-midnight-700">
+                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="-1" aria-label="Decrease quantity">&minus;</button>
+                                    <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
+                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
+                                </span>
+                                <a href="{{url}}" class="flex-1 text-sm text-gray-800 dark:text-gray-100 hover:text-teal-600 dark:hover:text-teal-400 truncate">{{name}}</a>
+                                {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
+                                <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
+                                <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
+                            </div>
+                        {{/each}}
+                    </div>
+                </div>
+            {{/if}}
+        </div>
+    {{else}}
+        <div class="section-container text-center py-12">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-300 mb-3">
+                <i class="fas fa-layer-group text-lg" aria-hidden="true"></i>
+            </div>
+            <h2 class="font-display font-bold text-lg text-gray-900 dark:text-white mb-1">This deck is empty</h2>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">Add cards from any card page with the &ldquo;Add to deck&rdquo; button.</p>
+            <a href="/sets" class="btn btn-primary text-sm px-4 py-2 mt-4">Browse sets</a>
+        </div>
+    {{/if}}
+</div>
+
+<script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>
+<script src="/public/js/deckDetail.js?v={{assetVersion}}" defer></script>

--- a/src/http/views/decks.hbs
+++ b/src/http/views/decks.hbs
@@ -1,0 +1,65 @@
+<div class="content-wrapper py-6">
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="page-title">Decks</h1>
+            <p class="page-subtitle">Build and track your decks. Estimated value uses current market prices.</p>
+        </div>
+    </div>
+
+    {{!-- New deck --}}
+    <div class="section-container mb-6">
+        <form id="deck-create-form" class="flex flex-wrap items-end gap-3">
+            <div class="flex-1 min-w-[12rem]">
+                <label for="deck-name" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Deck name</label>
+                <input id="deck-name" name="name" type="text" required maxlength="120"
+                    class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm"
+                    placeholder="e.g. Mono-Red Aggro" />
+            </div>
+            <div>
+                <label for="deck-format" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Format</label>
+                <select id="deck-format" name="format"
+                    class="rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm">
+                    {{#each formatOptions}}
+                        <option value="{{value}}" {{#if selected}}selected{{/if}}>{{label}}</option>
+                    {{/each}}
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-plus mr-1" aria-hidden="true"></i> Create deck
+            </button>
+            <span id="deck-create-result" class="text-sm" role="status" aria-live="polite"></span>
+        </form>
+    </div>
+
+    {{#if hasDecks}}
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {{#each decks}}
+                <div class="section-container" data-deck-id="{{id}}">
+                    <div class="flex items-start justify-between gap-2">
+                        <a href="{{url}}" class="font-display font-semibold text-lg text-gray-900 dark:text-white hover:text-teal-600 dark:hover:text-teal-400">{{name}}</a>
+                        <button type="button" class="deck-delete-btn text-gray-400 hover:text-red-500" data-deck-id="{{id}}" data-deck-name="{{name}}" aria-label="Delete deck">
+                            <i class="fas fa-trash" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                    <div class="mt-1 text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</div>
+                    <div class="mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
+                        <span>{{cardCount}} card{{#unless (eq cardCount 1)}}s{{/unless}}</span>
+                        <span class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
+                    </div>
+                    <div class="mt-1 text-xs text-gray-400">Updated {{updatedAt}}</div>
+                </div>
+            {{/each}}
+        </div>
+    {{else}}
+        <div class="section-container text-center py-12">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-300 mb-3">
+                <i class="fas fa-layer-group text-lg" aria-hidden="true"></i>
+            </div>
+            <h2 class="font-display font-bold text-lg text-gray-900 dark:text-white mb-1">No decks yet</h2>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">Create your first deck above, then add cards from any card page.</p>
+        </div>
+    {{/if}}
+</div>
+
+<script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>
+<script src="/public/js/decks.js?v={{assetVersion}}" defer></script>

--- a/src/http/views/partials/navbar.hbs
+++ b/src/http/views/partials/navbar.hbs
@@ -52,6 +52,10 @@
                             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 2h2l1.5 8.5h7L14 5H5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.5" cy="13.5" r="1"/><circle cx="12.5" cy="13.5" r="1"/></svg>
                             Buy List
                         </a>
+                        <a href="/decks" class="iwm-dropdown-item" role="menuitem">
+                            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l6 3-6 3-6-3 6-3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8l6 3 6-3M2 11.5l6 3 6-3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                            Decks
+                        </a>
                     </div>
                 </div>
                 <a href="/sets" class="iwm-nav-link">
@@ -197,6 +201,10 @@
         <a href="/buy-list" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 2h2l1.5 8.5h7L14 5H5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.5" cy="13.5" r="1"/><circle cx="12.5" cy="13.5" r="1"/></svg>
             Buy List
+        </a>
+        <a href="/decks" class="iwm-drawer-link">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l6 3-6 3-6-3 6-3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8l6 3 6-3M2 11.5l6 3 6-3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            Decks
         </a>
 
         <div class="iwm-drawer-section-label">Explore</div>

--- a/test/core/deck/deck-legality.policy.spec.ts
+++ b/test/core/deck/deck-legality.policy.spec.ts
@@ -1,0 +1,47 @@
+import { Format } from 'src/core/card/format.enum';
+import { Legality } from 'src/core/card/legality.entity';
+import { LegalityStatus } from 'src/core/card/legality.status.enum';
+import { DeckLegalityPolicy } from 'src/core/deck/deck-legality.policy';
+
+const legality = (format: Format, status: LegalityStatus) =>
+    new Legality({ cardId: 'c', format, status });
+
+describe('DeckLegalityPolicy.isCardLegal', () => {
+    it('allows any card when the deck has no format', () => {
+        expect(DeckLegalityPolicy.isCardLegal(null, [])).toBe(true);
+        expect(DeckLegalityPolicy.isCardLegal(undefined, undefined)).toBe(true);
+    });
+
+    it('is legal when the format entry is legal', () => {
+        expect(
+            DeckLegalityPolicy.isCardLegal(Format.Modern, [
+                legality(Format.Modern, LegalityStatus.Legal),
+            ])
+        ).toBe(true);
+    });
+
+    it('treats restricted as legal-to-include', () => {
+        expect(
+            DeckLegalityPolicy.isCardLegal(Format.Vintage, [
+                legality(Format.Vintage, LegalityStatus.Restricted),
+            ])
+        ).toBe(true);
+    });
+
+    it('is not legal when banned', () => {
+        expect(
+            DeckLegalityPolicy.isCardLegal(Format.Modern, [
+                legality(Format.Modern, LegalityStatus.Banned),
+            ])
+        ).toBe(false);
+    });
+
+    it('is not legal when there is no entry for the format', () => {
+        expect(
+            DeckLegalityPolicy.isCardLegal(Format.Modern, [
+                legality(Format.Legacy, LegalityStatus.Legal),
+            ])
+        ).toBe(false);
+        expect(DeckLegalityPolicy.isCardLegal(Format.Modern, [])).toBe(false);
+    });
+});

--- a/test/core/deck/deck-summary.policy.spec.ts
+++ b/test/core/deck/deck-summary.policy.spec.ts
@@ -1,0 +1,61 @@
+import { Card } from 'src/core/card/card.entity';
+import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { Price } from 'src/core/card/price.entity';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckSummaryPolicy } from 'src/core/deck/deck-summary.policy';
+
+function card(id: string, normal: number | null, foil: number | null): Card {
+    return new Card({
+        id,
+        imgSrc: 'x',
+        legalities: [],
+        name: id,
+        number: '1',
+        rarity: CardRarity.Common,
+        setCode: 'tst',
+        sortNumber: '1',
+        type: 'Creature',
+        prices: [new Price({ cardId: id, normal, foil, date: new Date() })],
+    });
+}
+
+function deckCard(c: Card | undefined, quantity: number, isSideboard = false): DeckCard {
+    return new DeckCard({ cardId: c?.id ?? 'x', quantity, isSideboard, card: c });
+}
+
+describe('DeckSummaryPolicy', () => {
+    describe('cardValue', () => {
+        it('uses the normal price', () => {
+            expect(DeckSummaryPolicy.cardValue(card('a', 5, 9))).toBe(5);
+        });
+        it('falls back to foil when there is no normal price', () => {
+            expect(DeckSummaryPolicy.cardValue(card('a', null, 9))).toBe(9);
+        });
+        it('is 0 when there is no card', () => {
+            expect(DeckSummaryPolicy.cardValue(undefined)).toBe(0);
+        });
+    });
+
+    describe('estimatedValue', () => {
+        it('sums quantity * value across all cards (main + side)', () => {
+            const cards = [deckCard(card('a', 5, 9), 2), deckCard(card('b', null, 3), 1, true)];
+            expect(DeckSummaryPolicy.estimatedValue(cards)).toBe(13);
+        });
+        it('is 0 for an empty deck', () => {
+            expect(DeckSummaryPolicy.estimatedValue([])).toBe(0);
+        });
+    });
+
+    describe('cardCount', () => {
+        const cards = [deckCard(card('a', 1, 1), 3), deckCard(card('b', 1, 1), 2, true)];
+        it('counts all boards by default', () => {
+            expect(DeckSummaryPolicy.cardCount(cards)).toBe(5);
+        });
+        it('counts maindeck only', () => {
+            expect(DeckSummaryPolicy.cardCount(cards, 'main')).toBe(3);
+        });
+        it('counts sideboard only', () => {
+            expect(DeckSummaryPolicy.cardCount(cards, 'side')).toBe(2);
+        });
+    });
+});

--- a/test/core/deck/deck.service.spec.ts
+++ b/test/core/deck/deck.service.spec.ts
@@ -1,0 +1,105 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Format } from 'src/core/card/format.enum';
+import { Deck } from 'src/core/deck/deck.entity';
+import { DeckService } from 'src/core/deck/deck.service';
+import { DeckRepositoryPort } from 'src/core/deck/ports/deck.repository.port';
+
+describe('DeckService', () => {
+    let service: DeckService;
+    let repo: jest.Mocked<Record<string, jest.Mock>>;
+
+    beforeEach(async () => {
+        repo = {
+            findByUser: jest.fn(),
+            findById: jest.fn(),
+            getOwnerId: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+            addCard: jest.fn(),
+            setCardQuantity: jest.fn(),
+            removeCard: jest.fn(),
+            countByUser: jest.fn(),
+        };
+        const moduleRef: TestingModule = await Test.createTestingModule({
+            providers: [DeckService, { provide: DeckRepositoryPort, useValue: repo }],
+        }).compile();
+        service = moduleRef.get(DeckService);
+    });
+
+    describe('getDeck', () => {
+        it('returns the deck when owned by the user', async () => {
+            repo.findById.mockResolvedValue(new Deck({ id: 1, userId: 7, name: 'd' }));
+            expect(await service.getDeck(1, 7)).not.toBeNull();
+        });
+        it('returns null when the deck belongs to someone else', async () => {
+            repo.findById.mockResolvedValue(new Deck({ id: 1, userId: 99, name: 'd' }));
+            expect(await service.getDeck(1, 7)).toBeNull();
+        });
+        it('returns null when the deck is missing', async () => {
+            repo.findById.mockResolvedValue(null);
+            expect(await service.getDeck(1, 7)).toBeNull();
+        });
+    });
+
+    describe('createDeck', () => {
+        it('trims the name and creates the deck', async () => {
+            repo.create.mockImplementation(async (d: Deck) => d);
+            const deck = await service.createDeck(7, '  Aggro  ', Format.Modern);
+            expect(deck.name).toBe('Aggro');
+            expect(deck.format).toBe(Format.Modern);
+        });
+        it('throws on an empty name', async () => {
+            await expect(service.createDeck(7, '   ')).rejects.toThrow('required');
+            expect(repo.create).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('addCard', () => {
+        it('checks ownership then adds', async () => {
+            repo.getOwnerId.mockResolvedValue(7);
+            await service.addCard(1, 7, 'card-1', false, 2);
+            expect(repo.addCard).toHaveBeenCalledWith(1, 'card-1', false, 2);
+        });
+        it('throws NotFound when the deck is not the user’s', async () => {
+            repo.getOwnerId.mockResolvedValue(99);
+            await expect(service.addCard(1, 7, 'card-1', false, 1)).rejects.toBeInstanceOf(
+                NotFoundException
+            );
+            expect(repo.addCard).not.toHaveBeenCalled();
+        });
+        it('no-ops on a non-positive quantity (no ownership check needed)', async () => {
+            await service.addCard(1, 7, 'card-1', false, 0);
+            expect(repo.getOwnerId).not.toHaveBeenCalled();
+            expect(repo.addCard).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('setCardQuantity', () => {
+        it('removes the card when quantity <= 0', async () => {
+            repo.getOwnerId.mockResolvedValue(7);
+            await service.setCardQuantity(1, 7, 'card-1', false, 0);
+            expect(repo.removeCard).toHaveBeenCalledWith(1, 'card-1', false);
+            expect(repo.setCardQuantity).not.toHaveBeenCalled();
+        });
+        it('sets the absolute quantity otherwise', async () => {
+            repo.getOwnerId.mockResolvedValue(7);
+            await service.setCardQuantity(1, 7, 'card-1', true, 3);
+            expect(repo.setCardQuantity).toHaveBeenCalledWith(1, 'card-1', true, 3);
+        });
+    });
+
+    describe('deleteDeck', () => {
+        it('throws NotFound when not the owner', async () => {
+            repo.getOwnerId.mockResolvedValue(99);
+            await expect(service.deleteDeck(1, 7)).rejects.toBeInstanceOf(NotFoundException);
+            expect(repo.delete).not.toHaveBeenCalled();
+        });
+        it('deletes when the owner', async () => {
+            repo.getOwnerId.mockResolvedValue(7);
+            await service.deleteDeck(1, 7);
+            expect(repo.delete).toHaveBeenCalledWith(1);
+        });
+    });
+});

--- a/test/http/api/deck/deck-api.presenter.spec.ts
+++ b/test/http/api/deck/deck-api.presenter.spec.ts
@@ -1,0 +1,73 @@
+import { Card } from 'src/core/card/card.entity';
+import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { Format } from 'src/core/card/format.enum';
+import { Legality } from 'src/core/card/legality.entity';
+import { LegalityStatus } from 'src/core/card/legality.status.enum';
+import { Price } from 'src/core/card/price.entity';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { Deck } from 'src/core/deck/deck.entity';
+import { DeckApiPresenter } from 'src/http/api/deck/deck-api.presenter';
+
+function card(id: string, type: string, normal: number, legalities: Legality[] = []): Card {
+    return new Card({
+        id,
+        imgSrc: 'a/b/c.jpg',
+        legalities,
+        name: id,
+        number: '1',
+        rarity: CardRarity.Common,
+        setCode: 'tst',
+        sortNumber: '1',
+        type,
+        prices: [new Price({ cardId: id, normal, foil: null, date: new Date() })],
+    });
+}
+
+describe('DeckApiPresenter.toDetail', () => {
+    it('maps cards, totals value, and flags legality for the deck format', () => {
+        const legal = card('a', 'Creature', 5, [
+            new Legality({ cardId: 'a', format: Format.Modern, status: LegalityStatus.Legal }),
+        ]);
+        const banned = card('b', 'Instant', 3, [
+            new Legality({ cardId: 'b', format: Format.Modern, status: LegalityStatus.Banned }),
+        ]);
+        const deck = new Deck({
+            id: 1,
+            userId: 7,
+            name: 'd',
+            format: Format.Modern,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            cards: [
+                new DeckCard({ cardId: 'a', quantity: 2, isSideboard: false, card: legal }),
+                new DeckCard({ cardId: 'b', quantity: 1, isSideboard: false, card: banned }),
+            ],
+        });
+
+        const dto = DeckApiPresenter.toDetail(deck);
+
+        expect(dto.id).toBe(1);
+        expect(dto.cardCount).toBe(3);
+        expect(dto.estimatedValue).toBe(13);
+        expect(dto.illegalCount).toBe(1);
+        expect(dto.cards.find((c) => c.cardId === 'a')?.legalInFormat).toBe(true);
+        expect(dto.cards.find((c) => c.cardId === 'b')?.legalInFormat).toBe(false);
+    });
+
+    it('leaves legalInFormat null and illegalCount 0 when the deck has no format', () => {
+        const deck = new Deck({
+            id: 1,
+            userId: 7,
+            name: 'd',
+            format: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            cards: [new DeckCard({ cardId: 'a', quantity: 1, isSideboard: false, card: card('a', 'Creature', 5) })],
+        });
+
+        const dto = DeckApiPresenter.toDetail(deck);
+
+        expect(dto.cards[0].legalInFormat).toBeNull();
+        expect(dto.illegalCount).toBe(0);
+    });
+});


### PR DESCRIPTION
Deck building MVP (roadmap 10.4) - free to create, modeled on Archidekt/ManaBox, mirroring the existing buy_list layering.

## Included
- `deck` + `deck_card` tables (migration 041); `deck_card` keyed `(deck_id, card_id, is_sideboard)` so a card can sit in main + side
- Domain entities, repository port, ORM entities, mapper, `DeckRepository`; `DeckService` (CRUD + add/remove/set-quantity) with per-deck ownership checks
- REST API `/api/v1/decks` (free tier, JwtOrApiKeyGuard)
- `/decks` list page and `/decks/:id` detail page (cards grouped by type, per-card legality flag, estimated value; AJAX qty steppers + remove, totals recomputed client-side)
- "Add to deck" control on the card detail page (pick a deck or create one inline)
- Per-card legality via the existing `legality` table (`DeckLegalityPolicy`); value via `PriceCalculationPolicy` (`DeckSummaryPolicy`)
- Navbar links (dropdown + drawer)

## Verification
- Typecheck clean; 1275 unit tests pass (27 new deck tests); migration 041 validated on Postgres 18

## Deferred follow-ups
- "Add to deck" from search results (per-row picker)
- Decklist paste/CSV import-export
- Mana-curve visualization
- Full construction rules (singleton, 4-of, deck-size minimums) - today is per-card legal/banned only