### PR TITLE
feat: portfolio analytics category drill-down + interaction-model audit (#535)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+    "attribution": {
+        "commit": "",
+        "pr": "",
+        "sessionUrl": false
+    },
+    "hooks": {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "git config user.name \"Matthew Towles\" && git config user.email \"matthewdtowles@gmail.com\""
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -329,13 +329,17 @@ Deferred from former §3.5. **MVP built 2026-06-17** - free to create (deeper an
 - [ ] **Deferred:** Mana-curve visualization + fuller price breakdown on the detail page
 - [ ] **Deferred:** Full construction-rule validation (singleton, 4-of limits, deck-size minimums) - today's check is per-card legal/banned only
 
-### 10.5 Portfolio Analytics: category drill-down + interaction-model audit (#535)
+### 10.5 Portfolio Analytics: category drill-down + interaction-model audit (#535) ✅
 
-`/portfolio/breakdown` is fully server-rendered and its rows are terminal aggregates — there's no path from a slice to the cards inside it. Add inline drill-down (click a color/rarity/type/set/cost-basis row → lazy-load the cards in that slice, with the standard hover-image card component), and write down the rationale for AJAX-vs-server-render here vs. the rest of the app (deck detail, search, inventory already do partial AJAX). Also evaluate exposing the same breakdown/filter affordance on Inventory.
+`/portfolio/breakdown` rows were terminal aggregates with no path to the cards inside them. Added inline drill-down: clicking a set/rarity/type/color/cost-basis row lazy-loads that slice's cards (standard hover-image card link, foil+non-foil quantity/value combined into one row per card).
 
-- [ ] `GET /api/v1/portfolio/breakdown/cards?by=&key=[&colors=]` (premium-gated)
-- [ ] Inline expand/collapse + lazy card load, reusing the hover-preview card row
-- [ ] Written decision: AJAX vs full-nav for dimension/filter switching; inventory-filtering opportunity
+- [x] `GET /api/v1/portfolio/breakdown/cards?by=&key=[&colors=]` (premium-gated, mirrors the breakdown auth) → `PortfolioBreakdownService.listSliceCards` / `PortfolioBreakdownRepository.listCards`. By-color drill-down re-applies the same `colors` superset filter as the aggregate, so membership/overlap semantics match the row the user clicked.
+- [x] Inline expand/collapse + lazy card load (`portfolioBreakdown.js`), reusing `renderCardLink` / `cardLink.hbs` so hover/long-press preview works for free.
+- [x] No-JS fallback: each row is a real link to `?expand=<key>`; the server renders that one slice expanded inline (`getBreakdownView(..., expandKey)`), and JS intercepts the same link to toggle without navigating — progressive enhancement, consistent with search/set-list.
+
+**Decision (B): keep dimension + color-filter switching full-nav; only drill-down is async.** The page is premium-gated server-side (`SubscriptionGuard`), dimension swaps are a single cheap aggregate query, and the URL is the shareable state. Converting the tab/chip switch to AJAX would duplicate the server's slice-rendering in JS for no real latency win and would complicate the back/forward + premium-gate story. Drill-down is the one interaction that benefits from staying on the page (you're comparing slices), so that is the only part made async — and it still degrades to full-nav with JS off. This is the opposite trade-off from deck-detail/search (which mutate or re-query on every keystroke and have no SEO/gate concerns), and that difference is the rationale for the split.
+
+**Inventory-filtering opportunity (B):** the Inventory page is the clearest "aggregate-with-no-drill-down" gap left — it lists items but can't be sliced by color/rarity/type the way analytics now can. Worth a follow-up to add color/rarity/type filter chips to Inventory backed by the same membership semantics (it already has AJAX list infra via `inventoryListAjax.js`, so this is additive). Spun out as a note here rather than blocking #535; no other page has the same gap (set/search lists are already filterable, deck detail is already item-level).
 
 ### 10.6 Deck building: in-page card search (#536)
 

--- a/src/core/portfolio/portfolio-breakdown.entity.ts
+++ b/src/core/portfolio/portfolio-breakdown.entity.ts
@@ -22,6 +22,34 @@ export const COLOR_LABELS: Record<string, string> = {
     C: 'Colorless',
 };
 
+/**
+ * A single card inside one breakdown slice (the drill-down rows). Foil and
+ * non-foil inventory of the same card are collapsed into one entry: `quantity`
+ * is the total owned and `value` is the combined current value across both.
+ * `scryfallId` is the raw id - presenters derive the image URL from it.
+ */
+export class PortfolioBreakdownCard {
+    readonly cardId: string;
+    readonly name: string;
+    readonly setCode: string;
+    readonly number: string;
+    readonly scryfallId: string;
+    readonly rarity: string;
+    readonly quantity: number;
+    readonly value: number;
+
+    constructor(init: Partial<PortfolioBreakdownCard>) {
+        this.cardId = init.cardId ?? '';
+        this.name = init.name ?? '';
+        this.setCode = init.setCode ?? '';
+        this.number = init.number ?? '';
+        this.scryfallId = init.scryfallId ?? '';
+        this.rarity = init.rarity ?? '';
+        this.quantity = init.quantity ?? 0;
+        this.value = init.value ?? 0;
+    }
+}
+
 export class PortfolioBreakdownSlice {
     readonly key: string;
     readonly label: string;

--- a/src/core/portfolio/portfolio-breakdown.service.ts
+++ b/src/core/portfolio/portfolio-breakdown.service.ts
@@ -6,6 +6,7 @@ import {
     COLOR_CODES,
     ColorCode,
     PortfolioBreakdown,
+    PortfolioBreakdownCard,
 } from './portfolio-breakdown.entity';
 import { PortfolioBreakdownRepositoryPort } from './ports/portfolio-breakdown.repository.port';
 
@@ -50,5 +51,22 @@ export class PortfolioBreakdownService {
         this.LOGGER.debug(`Get ${dimension} breakdown for user ${userId}.`);
         const slices = await this.repository.aggregate(userId, dimension, selectedColors);
         return new PortfolioBreakdown(dimension, slices);
+    }
+
+    /**
+     * The cards inside a single breakdown slice (drill-down). An empty/missing
+     * key yields no cards rather than the whole portfolio.
+     */
+    async listSliceCards(
+        userId: number,
+        dimension: BreakdownDimension,
+        key: string,
+        selectedColors: string[] = []
+    ): Promise<PortfolioBreakdownCard[]> {
+        if (!key) {
+            return [];
+        }
+        this.LOGGER.debug(`List ${dimension} slice cards (key=${key}) for user ${userId}.`);
+        return this.repository.listCards(userId, dimension, key, selectedColors);
     }
 }

--- a/src/core/portfolio/ports/portfolio-breakdown.repository.port.ts
+++ b/src/core/portfolio/ports/portfolio-breakdown.repository.port.ts
@@ -1,4 +1,8 @@
-import { BreakdownDimension, PortfolioBreakdownSlice } from '../portfolio-breakdown.entity';
+import {
+    BreakdownDimension,
+    PortfolioBreakdownCard,
+    PortfolioBreakdownSlice,
+} from '../portfolio-breakdown.entity';
 
 export const PortfolioBreakdownRepositoryPort = 'PortfolioBreakdownRepositoryPort';
 
@@ -8,4 +12,18 @@ export interface PortfolioBreakdownRepositoryPort {
         dimension: BreakdownDimension,
         selectedColors?: string[]
     ): Promise<PortfolioBreakdownSlice[]>;
+
+    /**
+     * The cards inside a single breakdown slice (drill-down). `key` is the
+     * slice key produced by {@link aggregate} for the given dimension (set
+     * code, rarity, type, cost-basis bucket, or color code). For dimension
+     * 'color', `selectedColors` carries the active superset filter so the
+     * drill-down honors the same membership semantics as the aggregate.
+     */
+    listCards(
+        userId: number,
+        dimension: BreakdownDimension,
+        key: string,
+        selectedColors?: string[]
+    ): Promise<PortfolioBreakdownCard[]>;
 }

--- a/src/database/portfolio/portfolio-breakdown.repository.ts
+++ b/src/database/portfolio/portfolio-breakdown.repository.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import {
     BreakdownDimension,
     COLOR_LABELS,
+    PortfolioBreakdownCard,
     PortfolioBreakdownSlice,
 } from 'src/core/portfolio/portfolio-breakdown.entity';
 import { PortfolioBreakdownRepositoryPort } from 'src/core/portfolio/ports/portfolio-breakdown.repository.port';
@@ -17,6 +18,38 @@ interface AggregationRow {
     itemCount: string | number;
     value: string | number;
 }
+
+interface CardRow {
+    cardId: string;
+    name: string;
+    setCode: string;
+    number: string;
+    scryfallId: string | null;
+    rarity: string;
+    quantity: string | number;
+    value: string | number;
+}
+
+// Latest price per card, joined as a LATERAL subquery (matches aggregate()).
+const LATEST_PRICE_JOIN = `
+    LEFT JOIN LATERAL (
+        SELECT p2.normal, p2.foil
+        FROM price p2
+        WHERE p2.card_id = c.id
+        ORDER BY p2.date DESC
+        LIMIT 1
+    ) p ON TRUE`;
+
+// Card-level columns shared by every drill-down query. Foil/non-foil rows of
+// the same card collapse into one entry via GROUP BY.
+const CARD_SELECT = `
+    c.id AS "cardId",
+    c.name AS "name",
+    c.set_code AS "setCode",
+    c.number AS "number",
+    c.scryfall_id AS "scryfallId",
+    c.rarity::text AS "rarity"`;
+const CARD_GROUP_BY = `c.id, c.name, c.set_code, c.number, c.scryfall_id, c.rarity`;
 
 @Injectable()
 export class PortfolioBreakdownRepository implements PortfolioBreakdownRepositoryPort {
@@ -224,5 +257,136 @@ export class PortfolioBreakdownRepository implements PortfolioBreakdownRepositor
                     value: Number(r.value) || 0,
                 })
         );
+    }
+
+    async listCards(
+        userId: number,
+        dimension: BreakdownDimension,
+        key: string,
+        selectedColors: string[] = []
+    ): Promise<PortfolioBreakdownCard[]> {
+        if (!key) {
+            return [];
+        }
+        if (dimension === 'cost-basis') {
+            return this.listCostBasisCards(userId, key);
+        }
+        if (dimension === 'color') {
+            return this.listColorCards(userId, key, selectedColors);
+        }
+
+        // The slice key is exactly the grouping expression aggregate() emitted,
+        // so we filter on the same expression to recover that slice's cards.
+        const filterExpr = this.dimensionConfig(dimension).keyExpr;
+        this.LOGGER.debug(`Listing ${dimension} cards (key=${key}) for user ${userId}.`);
+
+        const rows = (await this.inventoryRepo.query(
+            `
+            SELECT
+                ${CARD_SELECT},
+                SUM(i.quantity)::int AS "quantity",
+                COALESCE(SUM(i.quantity * (CASE WHEN i.foil THEN p.foil ELSE p.normal END)), 0)::numeric AS "value"
+            FROM inventory i
+            JOIN card c ON i.card_id = c.id
+            ${LATEST_PRICE_JOIN}
+            WHERE i.user_id = $1 AND ${filterExpr} = $2
+            GROUP BY ${CARD_GROUP_BY}
+            ORDER BY "value" DESC NULLS LAST, c.name ASC
+            `,
+            [userId, key]
+        )) as CardRow[];
+
+        return rows.map((r) => this.toCard(r));
+    }
+
+    private async listCostBasisCards(
+        userId: number,
+        bucket: string
+    ): Promise<PortfolioBreakdownCard[]> {
+        this.LOGGER.debug(`Listing cost-basis cards (bucket=${bucket}) for user ${userId}.`);
+        const rows = (await this.inventoryRepo.query(
+            `
+            SELECT
+                ${CARD_SELECT},
+                SUM(perf.quantity)::int AS "quantity",
+                COALESCE(SUM(perf.current_value), 0)::numeric AS "value"
+            FROM portfolio_card_performance perf
+            JOIN card c ON perf.card_id = c.id
+            WHERE perf.user_id = $1
+              AND (CASE
+                    WHEN perf.unrealized_gain > 0 THEN 'gain'
+                    WHEN perf.unrealized_gain < 0 THEN 'loss'
+                    ELSE 'flat'
+                  END) = $2
+            GROUP BY ${CARD_GROUP_BY}
+            ORDER BY "value" DESC NULLS LAST, c.name ASC
+            `,
+            [userId, bucket]
+        )) as CardRow[];
+
+        return rows.map((r) => this.toCard(r));
+    }
+
+    /**
+     * Cards inside one color slice. `key` is a single color code: a real color
+     * (W/U/B/R/G) keeps cards whose identity contains it; 'C' keeps colorless
+     * cards. `selectedColors` re-applies the active superset filter so the
+     * drill-down stays consistent with the aggregate row the user clicked.
+     */
+    private async listColorCards(
+        userId: number,
+        key: string,
+        selectedColors: string[]
+    ): Promise<PortfolioBreakdownCard[]> {
+        this.LOGGER.debug(`Listing color cards (key=${key}) for user ${userId}.`);
+        const params: unknown[] = [userId];
+        let membershipSql: string;
+        if (key === 'C') {
+            membershipSql = '(c.colors IS NULL OR cardinality(c.colors) = 0)';
+        } else {
+            params.push([key]);
+            membershipSql = `c.colors @> $${params.length}::text[]`;
+        }
+
+        const colored = selectedColors.filter((c) => c !== 'C');
+        let filterSql = '';
+        if (colored.length > 0) {
+            params.push(colored);
+            filterSql = `AND c.colors @> $${params.length}::text[]`;
+        } else if (selectedColors.includes('C')) {
+            filterSql = 'AND (c.colors IS NULL OR cardinality(c.colors) = 0)';
+        }
+
+        const rows = (await this.inventoryRepo.query(
+            `
+            SELECT
+                ${CARD_SELECT},
+                SUM(i.quantity)::int AS "quantity",
+                COALESCE(SUM(i.quantity * (CASE WHEN i.foil THEN p.foil ELSE p.normal END)), 0)::numeric AS "value"
+            FROM inventory i
+            JOIN card c ON i.card_id = c.id
+            ${LATEST_PRICE_JOIN}
+            WHERE i.user_id = $1 AND ${membershipSql}
+            ${filterSql}
+            GROUP BY ${CARD_GROUP_BY}
+            ORDER BY "value" DESC NULLS LAST, c.name ASC
+            `,
+            params
+        )) as CardRow[];
+
+        return rows.map((r) => this.toCard(r));
+    }
+
+    private toCard(r: CardRow): PortfolioBreakdownCard {
+        return new PortfolioBreakdownCard({
+            cardId: String(r.cardId ?? ''),
+            name: String(r.name ?? ''),
+            setCode: String(r.setCode ?? ''),
+            number: String(r.number ?? ''),
+            scryfallId: r.scryfallId ? String(r.scryfallId) : '',
+            rarity: String(r.rarity ?? ''),
+            quantity: Number(r.quantity) || 0,
+            value: Number(r.value) || 0,
+        });
     }
 }

--- a/src/http/api/portfolio/dto/portfolio-response.dto.ts
+++ b/src/http/api/portfolio/dto/portfolio-response.dto.ts
@@ -60,6 +60,38 @@ export class CardPerformanceApiDto {
     readonly roi: number;
 }
 
+export class BreakdownCardApiDto {
+    @ApiProperty()
+    readonly cardId: string;
+
+    @ApiProperty()
+    readonly name: string;
+
+    @ApiProperty()
+    readonly setCode: string;
+
+    @ApiProperty()
+    readonly number: string;
+
+    @ApiProperty({ description: 'Path to the card detail page' })
+    readonly cardUrl: string;
+
+    @ApiProperty({ description: 'Full Scryfall image URL for hover preview (may be empty)' })
+    readonly imgSrc: string;
+
+    @ApiProperty()
+    readonly rarity: string;
+
+    @ApiProperty({ description: 'Total quantity owned (foil + non-foil combined)' })
+    readonly quantity: number;
+
+    @ApiProperty({ description: 'Combined current value across foil + non-foil' })
+    readonly value: number;
+
+    @ApiProperty({ description: 'Pre-formatted value, e.g. "$12.34"' })
+    readonly valueFormatted: string;
+}
+
 export class CashFlowPeriodApiDto {
     @ApiProperty()
     readonly period: string;

--- a/src/http/api/portfolio/portfolio-api.controller.ts
+++ b/src/http/api/portfolio/portfolio-api.controller.ts
@@ -223,9 +223,9 @@ export class PortfolioApiController {
     })
     @ApiQuery({
         name: 'key',
-        required: true,
+        required: false,
         description:
-            'Slice key from the breakdown (set code, rarity, type, cost-basis bucket, or color code)',
+            'Slice key from the breakdown (set code, rarity, type, cost-basis bucket, or color code). A missing/empty key returns an empty list.',
     })
     @ApiQuery({
         name: 'colors',

--- a/src/http/api/portfolio/portfolio-api.controller.ts
+++ b/src/http/api/portfolio/portfolio-api.controller.ts
@@ -30,6 +30,7 @@ import { parseDaysParam } from 'src/http/base/query.util';
 import { PortfolioPresenter } from 'src/http/hbs/portfolio/portfolio.presenter';
 import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import {
+    BreakdownCardApiDto,
     CardPerformanceApiDto,
     CashFlowPeriodApiDto,
     PortfolioHistoryPointDto,
@@ -209,5 +210,47 @@ export class PortfolioApiController {
             selectedColors
         );
         return ApiResponseDto.ok(breakdown);
+    }
+
+    @Get('breakdown/cards')
+    @UseGuards(SubscriptionGuard)
+    @RequiresSubscription()
+    @ApiOperation({ summary: 'Get the cards inside one breakdown slice (Premium)' })
+    @ApiQuery({
+        name: 'by',
+        required: false,
+        description: 'Dimension the slice belongs to (set, rarity, type, color, cost-basis)',
+    })
+    @ApiQuery({
+        name: 'key',
+        required: true,
+        description:
+            'Slice key from the breakdown (set code, rarity, type, cost-basis bucket, or color code)',
+    })
+    @ApiQuery({
+        name: 'colors',
+        required: false,
+        description:
+            'For by=color: the active superset filter (W,U,B,R,G,C) so drill-down matches the aggregate row. Ignored for other dimensions.',
+    })
+    @ApiResponse({ status: 200, description: 'Cards in the slice' })
+    @ApiResponse({ status: 403, description: 'Premium subscription required' })
+    async getBreakdownCards(
+        @Req() req: AuthenticatedRequest,
+        @Query('key') key?: string,
+        @Query('by') by?: string,
+        @Query('colors') colors?: string
+    ): Promise<ApiResponseDto<BreakdownCardApiDto[]>> {
+        const dimension: BreakdownDimension = PortfolioBreakdownService.isDimension(by)
+            ? by
+            : 'set';
+        const selectedColors = PortfolioBreakdownService.parseColors(colors);
+        const cards = await this.breakdownService.listSliceCards(
+            req.user.id,
+            dimension,
+            key ?? '',
+            selectedColors
+        );
+        return ApiResponseDto.ok(cards.map(PortfolioPresenter.toBreakdownCard));
     }
 }

--- a/src/http/hbs/portfolio/dto/portfolio-breakdown.view.dto.ts
+++ b/src/http/hbs/portfolio/dto/portfolio-breakdown.view.dto.ts
@@ -14,6 +14,8 @@ export interface BreakdownCardView {
 
 export interface BreakdownSliceView {
     key: string;
+    /** URL/DOM-safe form of `key` for element ids + the `#slice-…` anchor. */
+    domKey: string;
     label: string;
     cardCount: number;
     itemCount: number;

--- a/src/http/hbs/portfolio/dto/portfolio-breakdown.view.dto.ts
+++ b/src/http/hbs/portfolio/dto/portfolio-breakdown.view.dto.ts
@@ -1,6 +1,17 @@
 import { BaseViewDto } from 'src/http/base/base.view.dto';
 import { BreakdownDimension } from 'src/core/portfolio/portfolio-breakdown.entity';
 
+export interface BreakdownCardView {
+    cardId: string;
+    name: string;
+    setCode: string;
+    number: string;
+    cardUrl: string;
+    imgSrc: string;
+    quantity: number;
+    valueFormatted: string;
+}
+
 export interface BreakdownSliceView {
     key: string;
     label: string;
@@ -10,6 +21,12 @@ export interface BreakdownSliceView {
     valueFormatted: string;
     percent: number;
     percentFormatted: string;
+    /** No-JS fallback: link that expands (or collapses) this slice via full nav. */
+    expandHref: string;
+    /** True when this slice is server-rendered expanded (the `expand` query param). */
+    expanded: boolean;
+    /** Cards in this slice, populated only when `expanded` is true. */
+    cards: BreakdownCardView[];
 }
 
 export interface ColorChipView {

--- a/src/http/hbs/portfolio/portfolio.controller.ts
+++ b/src/http/hbs/portfolio/portfolio.controller.ts
@@ -54,14 +54,15 @@ export class PortfolioController {
     async getBreakdown(
         @Req() req: AuthenticatedRequest,
         @Query('by') by?: string,
-        @Query('colors') colors?: string
+        @Query('colors') colors?: string,
+        @Query('expand') expand?: string
     ): Promise<PortfolioBreakdownViewDto> {
         const dimension: BreakdownDimension = PortfolioBreakdownService.isDimension(by)
             ? by
             : 'set';
         const selectedColors = PortfolioBreakdownService.parseColors(colors);
         this.LOGGER.log(`Get portfolio breakdown by ${dimension} for user ${req.user?.id}.`);
-        return this.orchestrator.getBreakdownView(req, dimension, selectedColors);
+        return this.orchestrator.getBreakdownView(req, dimension, selectedColors, expand ?? '');
     }
 
     @UseGuards(JwtAuthGuard, SubscriptionGuard)

--- a/src/http/hbs/portfolio/portfolio.orchestrator.ts
+++ b/src/http/hbs/portfolio/portfolio.orchestrator.ts
@@ -269,6 +269,7 @@ export class PortfolioOrchestrator {
                 const expanded = s.key === expandTarget;
                 return {
                     key: s.key,
+                    domKey: encodeURIComponent(s.key),
                     label: s.label,
                     cardCount: s.cardCount,
                     itemCount: s.itemCount,

--- a/src/http/hbs/portfolio/portfolio.orchestrator.ts
+++ b/src/http/hbs/portfolio/portfolio.orchestrator.ts
@@ -7,7 +7,6 @@ import {
     BreakdownDimension,
     COLOR_CODES,
     COLOR_LABELS,
-    PortfolioBreakdown,
 } from 'src/core/portfolio/portfolio-breakdown.entity';
 import { PortfolioSummaryService } from 'src/core/portfolio/portfolio-summary.service';
 import { PortfolioService } from 'src/core/portfolio/portfolio.service';
@@ -21,6 +20,7 @@ import {
 } from './dto/portfolio-value-history-response.dto';
 import {
     PortfolioBreakdownViewDto,
+    BreakdownCardView,
     BreakdownSliceView,
     ColorChipView,
 } from './dto/portfolio-breakdown.view.dto';
@@ -188,7 +188,8 @@ export class PortfolioOrchestrator {
     async getBreakdownView(
         req: AuthenticatedRequest,
         dimension: BreakdownDimension,
-        selectedColors: string[] = []
+        selectedColors: string[] = [],
+        expandKey = ''
     ): Promise<PortfolioBreakdownViewDto> {
         this.LOGGER.debug(`Get ${dimension} breakdown view for user ${req.user?.id}.`);
         try {
@@ -235,17 +236,57 @@ export class PortfolioOrchestrator {
             const totalValue = summary?.totalValue ?? 0;
             const totalItems = summary?.totalQuantity ?? 0;
 
-            const slices: BreakdownSliceView[] = breakdown.slices.map((s) => ({
-                key: s.key,
-                label: s.label,
-                cardCount: s.cardCount,
-                itemCount: s.itemCount,
-                value: s.value,
-                valueFormatted: this.formatCurrency(s.value),
-                percent: totalValue > 0 ? (s.value / totalValue) * 100 : 0,
-                percentFormatted:
-                    totalValue > 0 ? `${((s.value / totalValue) * 100).toFixed(1)}%` : '0%',
-            }));
+            // No-JS fallback: when `expand` names a real slice, server-render
+            // that slice's cards inline so drill-down works without JS. JS
+            // intercepts the same links and fetches the API instead.
+            const expandTarget = breakdown.slices.some((s) => s.key === expandKey)
+                ? expandKey
+                : '';
+            const expandedCards: BreakdownCardView[] = expandTarget
+                ? (
+                      await this.breakdownService.listSliceCards(
+                          req.user.id,
+                          dimension,
+                          expandTarget,
+                          selectedColors
+                      )
+                  ).map((card) => {
+                      const c = PortfolioPresenter.toBreakdownCard(card);
+                      return {
+                          cardId: c.cardId,
+                          name: c.name,
+                          setCode: c.setCode,
+                          number: c.number,
+                          cardUrl: c.cardUrl,
+                          imgSrc: c.imgSrc,
+                          quantity: c.quantity,
+                          valueFormatted: c.valueFormatted,
+                      };
+                  })
+                : [];
+
+            const slices: BreakdownSliceView[] = breakdown.slices.map((s) => {
+                const expanded = s.key === expandTarget;
+                return {
+                    key: s.key,
+                    label: s.label,
+                    cardCount: s.cardCount,
+                    itemCount: s.itemCount,
+                    value: s.value,
+                    valueFormatted: this.formatCurrency(s.value),
+                    percent: totalValue > 0 ? (s.value / totalValue) * 100 : 0,
+                    percentFormatted:
+                        totalValue > 0 ? `${((s.value / totalValue) * 100).toFixed(1)}%` : '0%',
+                    expandHref: this.buildExpandHref(
+                        dimension,
+                        s.key,
+                        selectedColors,
+                        expanded
+                    ),
+                    expanded,
+                    cards: expanded ? expandedCards : [],
+                };
+            });
 
             return new PortfolioBreakdownViewDto({
                 ...baseInit,
@@ -293,6 +334,28 @@ export class PortfolioOrchestrator {
                 href: `/portfolio/breakdown?${params.toString()}`,
             };
         });
+    }
+
+    /**
+     * Build the drill-down link for one slice. With JS off, following it
+     * re-renders the page with this slice expanded (or collapsed if it already
+     * is); JS intercepts the click and toggles inline instead. The `#slice-…`
+     * anchor keeps the row in view after a full-nav expand.
+     */
+    private buildExpandHref(
+        dimension: BreakdownDimension,
+        key: string,
+        selectedColors: string[],
+        expanded: boolean
+    ): string {
+        const params = new URLSearchParams({ by: dimension });
+        if (dimension === 'color' && selectedColors.length > 0) {
+            params.set('colors', selectedColors.join(','));
+        }
+        if (!expanded) {
+            params.set('expand', key);
+        }
+        return `/portfolio/breakdown?${params.toString()}#slice-${encodeURIComponent(key)}`;
     }
 
     private static readonly CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {

--- a/src/http/hbs/portfolio/portfolio.presenter.ts
+++ b/src/http/hbs/portfolio/portfolio.presenter.ts
@@ -1,7 +1,9 @@
+import { PortfolioBreakdownCard } from 'src/core/portfolio/portfolio-breakdown.entity';
 import { PortfolioCardPerformance } from 'src/core/portfolio/portfolio-card-performance.entity';
 import { PortfolioValueHistory } from 'src/core/portfolio/portfolio-value-history.entity';
 import { SetRoiAggregation } from 'src/core/portfolio/ports/portfolio-card-performance.repository.port';
 import { PortfolioSummary } from 'src/core/portfolio/portfolio-summary.entity';
+import { buildScryfallImagePath } from 'src/shared/utils/scryfall-image.util';
 import { formatUtcDate, formatUtcTimestamp } from 'src/http/base/date.util';
 import {
     BASE_IMAGE_URL,
@@ -65,6 +67,23 @@ export interface PortfolioHistoryPoint {
     totalCards: number;
 }
 
+/**
+ * A drill-down card row, ready for both the JSON API and the server-rendered
+ * fallback. Foil/non-foil quantity and value are already combined upstream.
+ */
+export interface BreakdownCardViewData {
+    cardId: string;
+    name: string;
+    setCode: string;
+    number: string;
+    cardUrl: string;
+    imgSrc: string;
+    rarity: string;
+    quantity: number;
+    value: number;
+    valueFormatted: string;
+}
+
 export class PortfolioPresenter {
     static toHistoryPoint(h: PortfolioValueHistory): PortfolioHistoryPoint {
         return {
@@ -72,6 +91,22 @@ export class PortfolioPresenter {
             totalValue: h.totalValue,
             totalCost: h.totalCost,
             totalCards: h.totalCards,
+        };
+    }
+
+    static toBreakdownCard(card: PortfolioBreakdownCard): BreakdownCardViewData {
+        const tail = buildScryfallImagePath(card.scryfallId);
+        return {
+            cardId: card.cardId,
+            name: card.name,
+            setCode: card.setCode.toUpperCase(),
+            number: card.number,
+            cardUrl: card.setCode && card.number ? buildCardUrl(card.setCode, card.number) : '',
+            imgSrc: tail ? `${BASE_IMAGE_URL}/normal/front/${tail}` : '',
+            rarity: card.rarity,
+            quantity: card.quantity,
+            value: card.value,
+            valueFormatted: toDollar(card.value),
         };
     }
 

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -7778,6 +7778,153 @@ img,
   color: rgb(107 114 128 / var(--tw-text-opacity, 1));
 }
 
+/* Drill-down: expandable slice rows (#535) */
+
+.breakdown-row-toggle {
+  display: block;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.breakdown-chevron {
+  margin-right: 0.375rem;
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-chevron:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-chevron {
+  transition: transform 0.15s ease;
+}
+
+.breakdown-row-toggle[aria-expanded='true'] .breakdown-chevron {
+  transform: rotate(90deg);
+}
+
+:where(.breakdown-cards, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+.breakdown-cards {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  border-top-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity, 1));
+  padding-top: 0.75rem;
+}
+
+.breakdown-cards:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(36 30 69 / var(--tw-border-opacity, 1));
+}
+
+:where(.breakdown-card-row, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+.breakdown-card-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border-bottom-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(249 250 251 / var(--tw-border-opacity, 1));
+  padding-top: 0.375rem;
+  padding-bottom: 0.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.breakdown-card-row:last-child {
+  border-bottom-width: 0px;
+}
+
+.breakdown-card-row:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(26 21 51 / var(--tw-border-opacity, 1));
+}
+
+.breakdown-card-name {
+  min-width: 0px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.breakdown-card-detail, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+.breakdown-card-detail {
+  display: flex;
+  flex-shrink: 0;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.breakdown-card-set {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-card-set:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-card-qty {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-card-qty:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-card-value {
+  min-width: 4rem;
+  text-align: right;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --tw-text-opacity: 1;
+  color: rgb(55 65 81 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-card-value:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-cards-loading,
+.breakdown-cards-empty {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(107 114 128 / var(--tw-text-opacity, 1));
+}
+
+.breakdown-cards-loading:is(.dark *),
+.breakdown-cards-empty:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity, 1));
+}
+
 /* Color filter chips (By Color breakdown) */
 
 :where(.flex,.breakdown-color-chip, .grid) > * {

--- a/src/http/public/js/portfolioBreakdown.js
+++ b/src/http/public/js/portfolioBreakdown.js
@@ -1,0 +1,120 @@
+/**
+ * Portfolio Analytics drill-down (#535).
+ *
+ * Each breakdown row is a real link (`.breakdown-row-toggle`) that, with JS
+ * off, navigates to `?expand=<key>` and the server renders that slice's cards
+ * inline. Here we intercept the click and toggle the cards inline instead,
+ * lazy-loading them from `/api/v1/portfolio/breakdown/cards` on first expand
+ * and caching the rendered rows thereafter.
+ *
+ * Dimension + color-filter switching stays full-nav (see ROADMAP 10.5): only
+ * drill-down is async, so the premium gate, SEO, and cheap dimension swaps all
+ * stay server-side.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    if (typeof AjaxUtils === 'undefined') return;
+
+    var list = document.querySelector('.breakdown-list[data-dimension]');
+    if (!list || list.getAttribute('data-drilldown-ready') === 'true') return;
+    list.setAttribute('data-drilldown-ready', 'true');
+
+    var dimension = list.getAttribute('data-dimension') || 'set';
+    var colors = list.getAttribute('data-colors') || '';
+
+    function cardsUrl(key) {
+        var params = new URLSearchParams();
+        params.set('by', dimension);
+        params.set('key', key);
+        if (dimension === 'color' && colors) params.set('colors', colors);
+        return '/api/v1/portfolio/breakdown/cards?' + params.toString();
+    }
+
+    function setExpanded(row, toggle, panel, expanded) {
+        toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (expanded) {
+            panel.removeAttribute('hidden');
+        } else {
+            panel.setAttribute('hidden', '');
+        }
+    }
+
+    function renderCards(cards) {
+        if (!cards || !cards.length) {
+            return '<p class="breakdown-cards-empty">No cards found in this slice.</p>';
+        }
+        var html = '';
+        for (var i = 0; i < cards.length; i++) {
+            var c = cards[i];
+            html +=
+                '<div class="breakdown-card-row">' +
+                '<span class="breakdown-card-name">' +
+                AjaxUtils.renderCardLink(c.cardUrl, c.name, c.imgSrc) +
+                '</span>' +
+                '<span class="breakdown-card-detail">' +
+                '<span class="breakdown-card-set">' +
+                AjaxUtils.escapeHtml((c.setCode || '').toUpperCase()) +
+                ' #' +
+                AjaxUtils.escapeHtml(c.number || '') +
+                '</span>' +
+                '<span class="breakdown-card-qty">' +
+                (parseInt(c.quantity, 10) || 0) +
+                '&times;</span>' +
+                '<span class="breakdown-card-value">' +
+                AjaxUtils.escapeHtml(c.valueFormatted || AjaxUtils.toDollar(c.value)) +
+                '</span>' +
+                '</span>' +
+                '</div>';
+        }
+        return html;
+    }
+
+    function loadCards(row, panel) {
+        var key = row.getAttribute('data-key');
+        panel.innerHTML =
+            '<div class="breakdown-cards-loading"><i class="fas fa-spinner fa-spin" aria-hidden="true"></i> Loading cards&hellip;</div>';
+        AjaxUtils.fetchWithGate(cardsUrl(key), { credentials: 'same-origin' })
+            .then(function (res) {
+                if (res.gated) {
+                    // Premium toast already shown; fall back to a full-nav link.
+                    panel.innerHTML = '';
+                    row.setAttribute('data-loaded', 'false');
+                    return;
+                }
+                if (!res.ok || !res.body || !res.body.success) {
+                    panel.innerHTML =
+                        '<p class="breakdown-cards-empty">Could not load cards. Please try again.</p>';
+                    row.setAttribute('data-loaded', 'false');
+                    return;
+                }
+                panel.innerHTML = renderCards(res.body.data);
+                row.setAttribute('data-loaded', 'true');
+            })
+            .catch(function () {
+                panel.innerHTML =
+                    '<p class="breakdown-cards-empty">Could not load cards. Please try again.</p>';
+                row.setAttribute('data-loaded', 'false');
+            });
+    }
+
+    list.addEventListener('click', function (e) {
+        var toggle = e.target.closest('.breakdown-row-toggle');
+        if (!toggle || !list.contains(toggle)) return;
+        e.preventDefault();
+
+        var row = toggle.closest('.breakdown-row');
+        if (!row) return;
+        var panel = row.querySelector('.breakdown-cards');
+        if (!panel) return;
+
+        var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+        if (isOpen) {
+            setExpanded(row, toggle, panel, false);
+            return;
+        }
+
+        setExpanded(row, toggle, panel, true);
+        if (row.getAttribute('data-loaded') !== 'true') {
+            loadCards(row, panel);
+        }
+    });
+});

--- a/src/http/public/js/portfolioBreakdown.js
+++ b/src/http/public/js/portfolioBreakdown.js
@@ -68,16 +68,18 @@ document.addEventListener('DOMContentLoaded', function () {
         return html;
     }
 
-    function loadCards(row, panel) {
+    function loadCards(row, toggle, panel) {
         var key = row.getAttribute('data-key');
         panel.innerHTML =
             '<div class="breakdown-cards-loading"><i class="fas fa-spinner fa-spin" aria-hidden="true"></i> Loading cards&hellip;</div>';
         AjaxUtils.fetchWithGate(cardsUrl(key), { credentials: 'same-origin' })
             .then(function (res) {
                 if (res.gated) {
-                    // Premium toast already shown; fall back to a full-nav link.
+                    // Premium toast already shown; collapse back so the UI
+                    // doesn't get stuck open-but-empty.
                     panel.innerHTML = '';
                     row.setAttribute('data-loaded', 'false');
+                    setExpanded(row, toggle, panel, false);
                     return;
                 }
                 if (!res.ok || !res.body || !res.body.success) {
@@ -114,7 +116,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         setExpanded(row, toggle, panel, true);
         if (row.getAttribute('data-loaded') !== 'true') {
-            loadCards(row, panel);
+            loadCards(row, toggle, panel);
         }
     });
 });

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -1854,6 +1854,45 @@
     @apply text-xs text-gray-500 dark:text-gray-500 mt-2;
 }
 
+/* Drill-down: expandable slice rows (#535) */
+.breakdown-row-toggle {
+    @apply block cursor-pointer;
+    text-decoration: none;
+}
+.breakdown-chevron {
+    @apply inline-block mr-1.5 text-xs text-gray-400 dark:text-gray-500;
+    transition: transform 0.15s ease;
+}
+.breakdown-row-toggle[aria-expanded='true'] .breakdown-chevron {
+    transform: rotate(90deg);
+}
+.breakdown-cards {
+    @apply mt-3 pt-3 border-t border-gray-100 dark:border-midnight-700 flex flex-col;
+}
+.breakdown-card-row {
+    @apply flex items-center justify-between gap-3 py-1.5 text-sm
+           border-b border-gray-50 dark:border-midnight-800 last:border-b-0;
+}
+.breakdown-card-name {
+    @apply min-w-0 truncate;
+}
+.breakdown-card-detail {
+    @apply flex items-baseline gap-3 shrink-0 text-xs;
+}
+.breakdown-card-set {
+    @apply font-mono text-gray-500 dark:text-gray-400;
+}
+.breakdown-card-qty {
+    @apply font-mono text-gray-500 dark:text-gray-400;
+}
+.breakdown-card-value {
+    @apply font-mono text-gray-700 dark:text-gray-300 text-right min-w-[4rem];
+}
+.breakdown-cards-loading,
+.breakdown-cards-empty {
+    @apply text-sm text-gray-500 dark:text-gray-400 py-2;
+}
+
 /* Color filter chips (By Color breakdown) */
 .breakdown-color-chip {
     @apply inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium

--- a/src/http/views/portfolioBreakdown.hbs
+++ b/src/http/views/portfolioBreakdown.hbs
@@ -84,20 +84,45 @@
             {{/if}}
 
             {{#if slices.length}}
-                <div class='breakdown-list'>
+                <div class='breakdown-list' data-dimension='{{dimension}}' data-colors='{{#each selectedColors}}{{this}}{{#unless @last}},{{/unless}}{{/each}}'>
                     {{#each slices}}
-                        <div class='breakdown-row'>
-                            <div class='breakdown-row-header'>
-                                <span class='breakdown-label'>{{label}}</span>
-                                <span class='breakdown-stats'>
-                                    <span class='breakdown-percent'>{{percentFormatted}}</span>
-                                    <span class='breakdown-value'>{{valueFormatted}}</span>
-                                </span>
+                        <div class='breakdown-row' id='slice-{{key}}' data-key='{{key}}' data-loaded='{{#if expanded}}true{{else}}false{{/if}}'>
+                            <a href='{{expandHref}}' class='breakdown-row-toggle' role='button'
+                               aria-expanded='{{#if expanded}}true{{else}}false{{/if}}'
+                               aria-controls='slice-cards-{{key}}'>
+                                <div class='breakdown-row-header'>
+                                    <span class='breakdown-label'>
+                                        <i class='fas fa-chevron-right breakdown-chevron' aria-hidden='true'></i>
+                                        {{label}}
+                                    </span>
+                                    <span class='breakdown-stats'>
+                                        <span class='breakdown-percent'>{{percentFormatted}}</span>
+                                        <span class='breakdown-value'>{{valueFormatted}}</span>
+                                    </span>
+                                </div>
+                                <div class='breakdown-bar'>
+                                    <div class='breakdown-bar-fill' style='width: {{percentFormatted}};'></div>
+                                </div>
+                                <div class='breakdown-meta'>{{cardCount}} unique &middot; {{itemCount}} item{{#unless (eq itemCount 1)}}s{{/unless}}</div>
+                            </a>
+                            <div class='breakdown-cards' id='slice-cards-{{key}}'{{#unless expanded}} hidden{{/unless}}>
+                                {{#if expanded}}
+                                    {{#if cards.length}}
+                                        {{#each cards}}
+                                            <div class='breakdown-card-row'>
+                                                <span class='breakdown-card-name'>{{> cardLink url=cardUrl name=name imgSrc=imgSrc}}</span>
+                                                <span class='breakdown-card-detail'>
+                                                    <span class='breakdown-card-set'>{{toUpperCase setCode}} #{{number}}</span>
+                                                    <span class='breakdown-card-qty'>{{quantity}}&times;</span>
+                                                    <span class='breakdown-card-value'>{{valueFormatted}}</span>
+                                                </span>
+                                            </div>
+                                        {{/each}}
+                                    {{else}}
+                                        <p class='breakdown-cards-empty'>No cards found in this slice.</p>
+                                    {{/if}}
+                                {{/if}}
                             </div>
-                            <div class='breakdown-bar'>
-                                <div class='breakdown-bar-fill' style='width: {{percentFormatted}};'></div>
-                            </div>
-                            <div class='breakdown-meta'>{{cardCount}} unique &middot; {{itemCount}} item{{#unless (eq itemCount 1)}}s{{/unless}}</div>
                         </div>
                     {{/each}}
                 </div>
@@ -167,3 +192,4 @@
         });
     })();
 </script>
+<script src="/public/js/portfolioBreakdown.js?v={{assetVersion}}" defer></script>

--- a/src/http/views/portfolioBreakdown.hbs
+++ b/src/http/views/portfolioBreakdown.hbs
@@ -86,10 +86,10 @@
             {{#if slices.length}}
                 <div class='breakdown-list' data-dimension='{{dimension}}' data-colors='{{#each selectedColors}}{{this}}{{#unless @last}},{{/unless}}{{/each}}'>
                     {{#each slices}}
-                        <div class='breakdown-row' id='slice-{{key}}' data-key='{{key}}' data-loaded='{{#if expanded}}true{{else}}false{{/if}}'>
-                            <a href='{{expandHref}}' class='breakdown-row-toggle' role='button'
+                        <div class='breakdown-row' id='slice-{{domKey}}' data-key='{{key}}' data-loaded='{{#if expanded}}true{{else}}false{{/if}}'>
+                            <a href='{{expandHref}}' class='breakdown-row-toggle'
                                aria-expanded='{{#if expanded}}true{{else}}false{{/if}}'
-                               aria-controls='slice-cards-{{key}}'>
+                               aria-controls='slice-cards-{{domKey}}'>
                                 <div class='breakdown-row-header'>
                                     <span class='breakdown-label'>
                                         <i class='fas fa-chevron-right breakdown-chevron' aria-hidden='true'></i>
@@ -105,7 +105,7 @@
                                 </div>
                                 <div class='breakdown-meta'>{{cardCount}} unique &middot; {{itemCount}} item{{#unless (eq itemCount 1)}}s{{/unless}}</div>
                             </a>
-                            <div class='breakdown-cards' id='slice-cards-{{key}}'{{#unless expanded}} hidden{{/unless}}>
+                            <div class='breakdown-cards' id='slice-cards-{{domKey}}'{{#unless expanded}} hidden{{/unless}}>
                                 {{#if expanded}}
                                     {{#if cards.length}}
                                         {{#each cards}}

--- a/test/core/portfolio/portfolio-breakdown.service.spec.ts
+++ b/test/core/portfolio/portfolio-breakdown.service.spec.ts
@@ -1,6 +1,34 @@
 import { PortfolioBreakdownService } from 'src/core/portfolio/portfolio-breakdown.service';
+import { PortfolioBreakdownCard } from 'src/core/portfolio/portfolio-breakdown.entity';
 
 describe('PortfolioBreakdownService', () => {
+    describe('listSliceCards', () => {
+        const makeService = (listCards = jest.fn()) => {
+            const repo = { aggregate: jest.fn(), listCards } as any;
+            return { service: new PortfolioBreakdownService(repo), repo };
+        };
+
+        it('returns [] without hitting the repository when key is empty', async () => {
+            const { service, repo } = makeService();
+            await expect(service.listSliceCards(1, 'set', '')).resolves.toEqual([]);
+            expect(repo.listCards).not.toHaveBeenCalled();
+        });
+
+        it('delegates to the repository with the selected colors', async () => {
+            const cards = [new PortfolioBreakdownCard({ cardId: 'c1', name: 'Card 1' })];
+            const { service, repo } = makeService(jest.fn().mockResolvedValue(cards));
+            const result = await service.listSliceCards(7, 'color', 'U', ['U', 'W']);
+            expect(result).toBe(cards);
+            expect(repo.listCards).toHaveBeenCalledWith(7, 'color', 'U', ['U', 'W']);
+        });
+
+        it('defaults selectedColors to []', async () => {
+            const { service, repo } = makeService(jest.fn().mockResolvedValue([]));
+            await service.listSliceCards(2, 'rarity', 'mythic');
+            expect(repo.listCards).toHaveBeenCalledWith(2, 'rarity', 'mythic', []);
+        });
+    });
+
     describe('isDimension', () => {
         it.each(['set', 'rarity', 'type', 'cost-basis', 'color'])(
             'accepts known dimension %s',

--- a/test/frontend/portfolioBreakdown.spec.js
+++ b/test/frontend/portfolioBreakdown.spec.js
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+if (!window.matchMedia) {
+    window.matchMedia = function () {
+        return { matches: false, addEventListener: function () {}, removeEventListener: function () {} };
+    };
+}
+
+var fetchGateImpl;
+
+window.AjaxUtils = {
+    escapeHtml: function (str) {
+        if (str == null) return '';
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    },
+    toDollar: function (amount) {
+        if (amount == null || amount === 0) return '-';
+        return '$' + Number(amount).toFixed(2);
+    },
+    renderCardLink: function (url, name, imgSrc) {
+        var html = '<a href="' + url + '" class="card-name-link"';
+        if (imgSrc) html += ' data-card-img="' + imgSrc + '"';
+        return html + '>' + name + '</a>';
+    },
+    fetchWithGate: function (url) {
+        return fetchGateImpl(url);
+    },
+};
+
+function rowHtml(key, expanded) {
+    return (
+        '<div class="breakdown-row" id="slice-' + key + '" data-key="' + key + '" data-loaded="' +
+        (expanded ? 'true' : 'false') + '">' +
+        '<a href="/portfolio/breakdown?by=set&expand=' + key + '" class="breakdown-row-toggle" ' +
+        'role="button" aria-expanded="' + (expanded ? 'true' : 'false') + '" aria-controls="slice-cards-' + key + '">' +
+        '<span class="breakdown-label">' + key + '</span>' +
+        '</a>' +
+        '<div class="breakdown-cards" id="slice-cards-' + key + '"' + (expanded ? '' : ' hidden') + '></div>' +
+        '</div>'
+    );
+}
+
+function loadScript() {
+    jest.resetModules();
+    require('../../src/http/public/js/portfolioBreakdown.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+}
+
+function clickToggle(key) {
+    document
+        .querySelector('#slice-' + key + ' .breakdown-row-toggle')
+        .dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+}
+
+beforeEach(function () {
+    fetchGateImpl = jest.fn();
+    document.body.innerHTML =
+        '<div class="breakdown-list" data-dimension="set" data-colors="">' + rowHtml('tst', false) + '</div>';
+});
+
+describe('portfolioBreakdown drill-down', function () {
+    it('lazy-loads and renders slice cards on first expand', function () {
+        var cards = [
+            { cardId: 'a', name: 'Test Angel', setCode: 'tst', number: '1', cardUrl: '/card/tst/1', imgSrc: 'img.jpg', quantity: 2, value: 10, valueFormatted: '$10.00' },
+        ];
+        fetchGateImpl.mockResolvedValue({ ok: true, gated: false, status: 200, body: { success: true, data: cards } });
+        loadScript();
+
+        clickToggle('tst');
+
+        var toggle = document.querySelector('#slice-tst .breakdown-row-toggle');
+        expect(toggle.getAttribute('aria-expanded')).toBe('true');
+        expect(document.getElementById('slice-cards-tst').hasAttribute('hidden')).toBe(false);
+        expect(fetchGateImpl).toHaveBeenCalledTimes(1);
+        expect(fetchGateImpl.mock.calls[0][0]).toBe('/api/v1/portfolio/breakdown/cards?by=set&key=tst');
+
+        return Promise.resolve().then(function () {
+            var panel = document.getElementById('slice-cards-tst');
+            expect(panel.innerHTML).toContain('Test Angel');
+            expect(panel.innerHTML).toContain('data-card-img="img.jpg"');
+            expect(panel.innerHTML).toContain('$10.00');
+            expect(document.querySelector('#slice-tst').getAttribute('data-loaded')).toBe('true');
+        });
+    });
+
+    it('collapses without refetching, then reuses cached cards on re-expand', function () {
+        fetchGateImpl.mockResolvedValue({ ok: true, gated: false, status: 200, body: { success: true, data: [] } });
+        loadScript();
+
+        clickToggle('tst');
+        return Promise.resolve().then(function () {
+            // collapse
+            clickToggle('tst');
+            var toggle = document.querySelector('#slice-tst .breakdown-row-toggle');
+            expect(toggle.getAttribute('aria-expanded')).toBe('false');
+            expect(document.getElementById('slice-cards-tst').hasAttribute('hidden')).toBe(true);
+
+            // re-expand: still loaded, no second fetch
+            clickToggle('tst');
+            expect(fetchGateImpl).toHaveBeenCalledTimes(1);
+            expect(toggle.getAttribute('aria-expanded')).toBe('true');
+        });
+    });
+
+    it('shows an error message when the fetch fails', function () {
+        fetchGateImpl.mockResolvedValue({ ok: false, gated: false, status: 500, body: null });
+        loadScript();
+
+        clickToggle('tst');
+        return Promise.resolve().then(function () {
+            var panel = document.getElementById('slice-cards-tst');
+            expect(panel.innerHTML).toContain('Could not load cards');
+            expect(document.querySelector('#slice-tst').getAttribute('data-loaded')).toBe('false');
+        });
+    });
+
+    it('includes the colors filter for the color dimension', function () {
+        document.body.innerHTML =
+            '<div class="breakdown-list" data-dimension="color" data-colors="U,W">' + rowHtml('U', false) + '</div>';
+        fetchGateImpl.mockResolvedValue({ ok: true, gated: false, status: 200, body: { success: true, data: [] } });
+        loadScript();
+
+        clickToggle('U');
+        expect(fetchGateImpl.mock.calls[0][0]).toBe(
+            '/api/v1/portfolio/breakdown/cards?by=color&key=U&colors=U%2CW'
+        );
+    });
+});

--- a/test/frontend/portfolioBreakdown.spec.js
+++ b/test/frontend/portfolioBreakdown.spec.js
@@ -119,6 +119,19 @@ describe('portfolioBreakdown drill-down', function () {
         });
     });
 
+    it('collapses back when the response is premium-gated', function () {
+        fetchGateImpl.mockResolvedValue({ ok: false, gated: true, status: 403, body: null });
+        loadScript();
+
+        clickToggle('tst');
+        return Promise.resolve().then(function () {
+            var toggle = document.querySelector('#slice-tst .breakdown-row-toggle');
+            expect(toggle.getAttribute('aria-expanded')).toBe('false');
+            expect(document.getElementById('slice-cards-tst').hasAttribute('hidden')).toBe(true);
+            expect(document.querySelector('#slice-tst').getAttribute('data-loaded')).toBe('false');
+        });
+    });
+
     it('includes the colors filter for the color dimension', function () {
         document.body.innerHTML =
             '<div class="breakdown-list" data-dimension="color" data-colors="U,W">' + rowHtml('U', false) + '</div>';

--- a/test/http/portfolio/portfolio.presenter.spec.ts
+++ b/test/http/portfolio/portfolio.presenter.spec.ts
@@ -1,3 +1,4 @@
+import { PortfolioBreakdownCard } from 'src/core/portfolio/portfolio-breakdown.entity';
 import { PortfolioCardPerformance } from 'src/core/portfolio/portfolio-card-performance.entity';
 import { PortfolioSummary } from 'src/core/portfolio/portfolio-summary.entity';
 import { PortfolioPresenter } from 'src/http/hbs/portfolio/portfolio.presenter';
@@ -193,6 +194,50 @@ describe('PortfolioPresenter', () => {
             const date = new Date('2026-03-07T14:30:00Z');
             const result = PortfolioPresenter.formatTimestamp(date);
             expect(result).toBe('2026-03-07 14:30');
+        });
+    });
+
+    describe('toBreakdownCard', () => {
+        it('derives image URL, card URL, uppercased set code and formatted value', () => {
+            const card = new PortfolioBreakdownCard({
+                cardId: 'abc',
+                name: 'Black Lotus',
+                setCode: 'lea',
+                number: '232',
+                scryfallId: 'b1e2c3d4-0000-0000-0000-000000000000',
+                rarity: 'rare',
+                quantity: 3,
+                value: 1234.5,
+            });
+
+            const result = PortfolioPresenter.toBreakdownCard(card);
+
+            expect(result.cardId).toBe('abc');
+            expect(result.name).toBe('Black Lotus');
+            expect(result.setCode).toBe('LEA');
+            expect(result.cardUrl).toBe('/card/lea/232');
+            expect(result.imgSrc).toBe(
+                'https://cards.scryfall.io/normal/front/b/1/b1e2c3d4-0000-0000-0000-000000000000.jpg'
+            );
+            expect(result.quantity).toBe(3);
+            expect(result.valueFormatted).toBe('$1,234.50');
+        });
+
+        it('falls back to empty image URL when scryfall id is missing', () => {
+            const card = new PortfolioBreakdownCard({
+                cardId: 'x',
+                name: 'No Image',
+                setCode: 'tst',
+                number: '1',
+                scryfallId: '',
+                value: 0,
+            });
+
+            const result = PortfolioPresenter.toBreakdownCard(card);
+
+            expect(result.imgSrc).toBe('');
+            expect(result.cardUrl).toBe('/card/tst/1');
+            expect(result.valueFormatted).toBe('-');
         });
     });
 });

--- a/test/integration/api-portfolio.e2e-spec.ts
+++ b/test/integration/api-portfolio.e2e-spec.ts
@@ -204,4 +204,71 @@ describe('Portfolio API (e2e)', () => {
             expect(typeof res.body.data.totalRealizedGain).toBe('number');
         });
     });
+
+    describe('GET /api/v1/portfolio/breakdown', () => {
+        it('returns set breakdown slices', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/portfolio/breakdown?by=set')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data.dimension).toBe('set');
+            const tst = res.body.data.slices.find((s: { key: string }) => s.key === 'tst');
+            expect(tst).toBeDefined();
+            expect(tst.cardCount).toBe(2);
+        });
+    });
+
+    describe('GET /api/v1/portfolio/breakdown/cards', () => {
+        it('requires authentication', async () => {
+            await request(app.getHttpServer())
+                .get('/api/v1/portfolio/breakdown/cards?by=set&key=tst')
+                .expect(401);
+        });
+
+        it('returns the cards inside a set slice with derived fields', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/portfolio/breakdown/cards?by=set&key=tst')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(Array.isArray(res.body.data)).toBe(true);
+            const ids = res.body.data.map((c: { cardId: string }) => c.cardId);
+            expect(ids).toContain(TEST_CARD_ID);
+            expect(ids).toContain(TEST_CARD_ID_2);
+
+            const angel = res.body.data.find((c: { cardId: string }) => c.cardId === TEST_CARD_ID);
+            expect(angel.name).toBe('Test Angel');
+            expect(angel.setCode).toBe('TST');
+            expect(angel.cardUrl).toBe('/card/tst/1');
+            expect(angel.imgSrc).toContain('cards.scryfall.io');
+            expect(angel.quantity).toBe(2);
+            // 2 normal copies @ $5.00
+            expect(angel.value).toBeCloseTo(10.0, 2);
+            expect(angel.valueFormatted).toBe('$10.00');
+        });
+
+        it('filters by rarity slice', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/portfolio/breakdown/cards?by=rarity&key=rare')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            const ids = res.body.data.map((c: { cardId: string }) => c.cardId);
+            expect(ids).toEqual([TEST_CARD_ID]);
+        });
+
+        it('returns an empty list when key is missing', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/portfolio/breakdown/cards?by=set')
+                .set('Authorization', bearerToken)
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data).toEqual([]);
+        });
+    });
 });


### PR DESCRIPTION
Closes #535.

## A. Drill-down (main ask)

Each `/portfolio/breakdown` row was a terminal aggregate with no path to the cards inside it. Now clicking any category row (By Set, By Rarity, By Type, By Color, By Cost Basis) expands it inline to list that slice's cards, using the standard hover-image card link. Foil + non-foil copies of a card collapse into one row (total quantity, combined value).

- **New endpoint** `GET /api/v1/portfolio/breakdown/cards?by=&key=[&colors=]` — premium-gated (mirrors the existing breakdown auth), backed by `PortfolioBreakdownService.listSliceCards` / `PortfolioBreakdownRepository.listCards`. The drill-down SQL mirrors the existing `aggregate()` queries per dimension.
- **Color overlap semantics respected** — by-color drill-down re-applies the same `colors` superset filter the aggregate used, so the card list matches the row the user clicked (a card appears under every color in its identity).
- **Reuses the card component** — `renderCardLink` (JS) and `cardLink.hbs` (SSR), so hover-on-desktop / first-tap-on-mobile image preview works for free.
- **Lazy + cached** — `portfolioBreakdown.js` fetches a slice's cards only on first expand and caches the rendered rows; collapse/re-expand does not refetch.
- **No-JS fallback** — each row is a real link to `?expand=<key>`; with JS off the server renders that one slice expanded inline (`getBreakdownView(..., expandKey)`). JS intercepts the same link and toggles without navigating. This is the same progressive-enhancement pattern as search / set-list.

## B. Interaction-model audit (written decision)

Recorded in `ROADMAP.md` 10.5:

- **Why analytics is server-rendered:** the premium gate is server-side (`SubscriptionGuard`), dimension swaps are a single cheap aggregate query, and the URL is the shareable state.
- **Decision:** keep dimension + color-filter switching full-nav; make **only drill-down** async. Converting the tab/chip switch to AJAX would duplicate the server's slice rendering in JS for no real latency win and complicate the back/forward + gate story. This is the opposite trade-off from deck-detail/search, which mutate or re-query on every keystroke and have no SEO/gate concerns — that difference is the rationale for the split.
- **Inventory opportunity:** the Inventory page is the clearest remaining "aggregate with no path to the underlying items" gap — worth a follow-up to add color/rarity/type filter chips backed by the same membership semantics (it already has AJAX list infra). No other page has the same gap.

## Tests

- Unit: `listSliceCards` (service) + `toBreakdownCard` (presenter).
- Frontend (jsdom): drill-down expand/lazy-load/cache/collapse/error + color-filter URL.
- Integration: `GET /api/v1/portfolio/breakdown/cards` (auth required, set + rarity slices, derived fields, empty-key guard).

All 1298 unit + 111 frontend tests pass locally; typecheck and lint clean on changed files. Integration tests require Docker (run in CI).

## Repo config

Also adds a `.claude/settings.json` SessionStart hook that pins the git commit author to the repo owner across fresh web sessions, and suppresses generated commit/PR attribution.