### PR TITLE
feat: in-page card search on the deck page (#536)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -341,9 +341,17 @@ Deferred from former §3.5. **MVP built 2026-06-17** - free to create (deeper an
 
 **Inventory-filtering opportunity (B):** the Inventory page is the clearest "aggregate-with-no-drill-down" gap left — it lists items but can't be sliced by color/rarity/type the way analytics now can. Worth a follow-up to add color/rarity/type filter chips to Inventory backed by the same membership semantics (it already has AJAX list infra via `inventoryListAjax.js`, so this is additive). Spun out as a note here rather than blocking #535; no other page has the same gap (set/search lists are already filterable, deck detail is already item-level).
 
-### 10.6 Deck building: in-page card search (#536)
+### 10.6 Deck building: in-page card search (#536) ✅
 
-Make adding cards happen **on the deck page** (modeled on Archidekt/ManaBox), so users never leave the deck. Results **grouped by card name** (one row per name, not per printing), card art on hover (first tap on mobile), inline add to main/sideboard via the existing `/api/v1/decks/:id/cards`. Needs a name-grouped mode on the search endpoint.
+Adding cards now happens **on the deck page** (modeled on Archidekt/ManaBox), so users never leave the deck. A debounced search box queries a new name-grouped search mode, results show one row per name with the standard hover art, and adds go straight to main/sideboard - the deck DOM + totals update in place, no full reload.
+
+- [x] `GET /api/v1/cards?q=…&groupBy=name` returns **one representative printing per distinct name** (`searchByNameGrouped` / `totalSearchByNameGrouped`, Postgres `DISTINCT ON (name)`). Representative = **newest printing** (`ORDER BY name, set.release_date DESC`) - a sensible default that's also the most likely in-print/available copy. Joins the latest price so callers can value the card.
+- [x] Grouped mode **annotates** legality instead of filtering: with a `format` param each result carries a `legal` flag (legality is name-level, so the representative's flag applies to the whole name), but illegal cards are still returned and shown flagged - a deck builder wants to see everything and decide. (`applyCatalogFilters` gained `skipLegality`; the per-printing search is unchanged.)
+- [x] Search box on `/decks/:id` (debounced, reuses `AjaxUtils.fetchWithGate`); results render the standard `.card-name-link[data-card-img]` so `cardPreview.js` gives hover/long-press art for free, in both the results list and the in-deck rows.
+- [x] Inline add to main/sideboard via the existing `POST /api/v1/decks/:id/cards`; `deckDetail.js` inserts the new row into the right type group (creating + ordering the group, mirroring the server's `TYPE_ORDER`), or increments an existing row, then recomputes value/counts/legality client-side. Steppers/remove moved to event delegation so search-added rows behave like server-rendered ones.
+- [x] Keyboard-friendly (Escape clears, focusable results) and mobile-friendly (long-press art via the shared preview); the user never leaves the deck.
+
+**Open question resolved:** which printing to bind for a multi-printing name → the **newest** printing (single representative). A later per-row printing picker stays deferred. Mana-curve / fuller analytics also stay deferred (10.4 follow-up).
 
 ### 10.7 Import public decklists + inventory buildability/gap comparison (#537)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -324,10 +324,34 @@ Deferred from former §3.5. **MVP built 2026-06-17** - free to create (deeper an
 - [x] Deck detail page (`/decks/:id`): cards grouped by primary type, per-card legality flag, estimated value; qty steppers + remove via AJAX, totals recomputed client-side
 - [x] Per-card legality check reusing the existing `legality` table (`DeckLegalityPolicy`); estimated value via `PriceCalculationPolicy` (`DeckSummaryPolicy`)
 - [x] "Add to Deck" on the **card detail** page (pick a deck or create one inline)
-- [ ] **Deferred:** "Add to Deck" from **search results** (needs a per-row picker; card-detail covers the primary add path)
-- [ ] **Deferred:** Deck import/export (paste decklist text + CSV)
+- [ ] **Deferred → §10.6:** "Add to Deck" from search — superseded by in-page deck search (#536)
+- [ ] **Deferred → §10.7:** Deck import/export — now part of public-decklist import + inventory comparison (#537)
 - [ ] **Deferred:** Mana-curve visualization + fuller price breakdown on the detail page
 - [ ] **Deferred:** Full construction-rule validation (singleton, 4-of limits, deck-size minimums) - today's check is per-card legal/banned only
+
+### 10.5 Portfolio Analytics: category drill-down + interaction-model audit (#535)
+
+`/portfolio/breakdown` is fully server-rendered and its rows are terminal aggregates — there's no path from a slice to the cards inside it. Add inline drill-down (click a color/rarity/type/set/cost-basis row → lazy-load the cards in that slice, with the standard hover-image card component), and write down the rationale for AJAX-vs-server-render here vs. the rest of the app (deck detail, search, inventory already do partial AJAX). Also evaluate exposing the same breakdown/filter affordance on Inventory.
+
+- [ ] `GET /api/v1/portfolio/breakdown/cards?by=&key=[&colors=]` (premium-gated)
+- [ ] Inline expand/collapse + lazy card load, reusing the hover-preview card row
+- [ ] Written decision: AJAX vs full-nav for dimension/filter switching; inventory-filtering opportunity
+
+### 10.6 Deck building: in-page card search (#536)
+
+Make adding cards happen **on the deck page** (modeled on Archidekt/ManaBox), so users never leave the deck. Results **grouped by card name** (one row per name, not per printing), card art on hover (first tap on mobile), inline add to main/sideboard via the existing `/api/v1/decks/:id/cards`. Needs a name-grouped mode on the search endpoint.
+
+### 10.7 Import public decklists + inventory buildability/gap comparison (#537)
+
+Import shared public decklists (paste-text first, URL/site export later) and compare them against inventory: "what can I build" (rank decks by completeness) and per-deck owned-vs-needed gap lists. Reuses `src/core/import/` parsers + the 10.4 deck model; missing cards seed the want-list. Import likely stays free (funnel); the analysis layer may be the premium pull.
+
+### 10.8 Scry: ingestion performance regression (scry#22)
+
+Full ingest regressed from **3–4 min → ~27 min**; price ingest alone **~20s → ~18min**. Within-run throughput collapses (120 → 67 cards/s) — the signature of upsert/index cost on the growing granular tables added by the per-vendor store (4 sequential DB writes per batch now vs. 1). Deep root-cause + fixes (COPY/staging upserts, take `granular_price_history` off the hot path, parallelize independent table writes, autovacuum/retention check). Tracked in scry; follow-ups spun out per finding.
+
+### 10.9 MCP: color breakdown + deck building parity (iwantmymtg-mcp#16)
+
+MCP `get_portfolio_breakdown` enum is stale (offers a non-existent `format`, missing `color` + the `colors` filter), and there are **no deck tools** (generated API types predate `/api/v1/decks`). Regenerate API types, fix the breakdown dimensions, add the deck tool group.
 
 ---
 

--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -111,6 +111,26 @@ export class CardService {
         }
     }
 
+    async searchByNameGrouped(filter: string, options: SafeQueryOptions): Promise<Card[]> {
+        this.LOGGER.debug(`Grouped search cards by name: ${filter}.`);
+        try {
+            return await this.repository.searchByNameGrouped(filter, options);
+        } catch (error) {
+            throw new Error(`Error grouped-searching cards by name "${filter}": ${error.message}`);
+        }
+    }
+
+    async totalSearchByNameGrouped(filter: string, options?: SafeQueryOptions): Promise<number> {
+        this.LOGGER.debug(`Count grouped search results for: ${filter}.`);
+        try {
+            return await this.repository.totalSearchByNameGrouped(filter, options);
+        } catch (error) {
+            throw new Error(
+                `Error counting grouped card search results for "${filter}": ${error.message}`
+            );
+        }
+    }
+
     async totalInSet(code: string, options: SafeQueryOptions): Promise<number> {
         this.LOGGER.debug(
             `Find total number of cards in set ${code}, options: ${JSON.stringify(options)}.`

--- a/src/core/card/ports/card.repository.port.ts
+++ b/src/core/card/ports/card.repository.port.ts
@@ -112,6 +112,28 @@ export interface CardRepositoryPort extends BaseRepositoryPort {
     totalSearchByName(filter: string, options?: SafeQueryOptions): Promise<number>;
 
     /**
+     * Searches cards by name, returning one representative printing per distinct
+     * name (deduplicated). The representative is the newest printing (latest set
+     * release). The latest price is joined so callers can value the card, and -
+     * when `options.format` is set - the card's legality for that format is
+     * loaded so callers can flag deck legality. Used by the deck-page in-page
+     * card search (one row per name, not per printing).
+     * @param filter Search term to match against card names.
+     * @param options Query options (pagination, catalog filters, optional format).
+     * @returns Promise resolving to one Card per matching name.
+     */
+    searchByNameGrouped(filter: string, options: SafeQueryOptions): Promise<Card[]>;
+
+    /**
+     * Counts the number of distinct card names matching a name search (the row
+     * count of {@link searchByNameGrouped}, ignoring pagination).
+     * @param filter Search term to match against card names.
+     * @param options Query options for catalog filters.
+     * @returns Promise resolving to the count of distinct names.
+     */
+    totalSearchByNameGrouped(filter: string, options?: SafeQueryOptions): Promise<number>;
+
+    /**
      * Finds all Card entities with a given name in a specific set (case-insensitive exact match).
      * Returns array - caller errors if length > 1 (ambiguous, e.g. basic lands).
      * @param name Exact card name (case-insensitive).

--- a/src/database/card/card.repository.ts
+++ b/src/database/card/card.repository.ts
@@ -242,6 +242,63 @@ export class CardRepository extends BaseRepository<CardOrmEntity> implements Car
         return count;
     }
 
+    async searchByNameGrouped(filter: string, options: SafeQueryOptions): Promise<Card[]> {
+        this.LOGGER.debug(`Grouped search by name: ${filter}.`);
+        const qb = this.repository
+            .createQueryBuilder(this.TABLE)
+            // One row per name: DISTINCT ON keeps the first row of each name in
+            // the ORDER BY, so the name-then-newest order below makes the newest
+            // printing the representative.
+            .distinctOn([`${this.TABLE}.name`])
+            .leftJoinAndSelect(`${this.TABLE}.set`, 'set')
+            .leftJoinAndSelect(
+                `${this.TABLE}.prices`,
+                'prices',
+                'prices.date = (SELECT MAX(p2.date) FROM price p2 WHERE p2.card_id = card.id)'
+            );
+
+        // When a format is supplied, load just that format's legality row (≤1
+        // per card, so DISTINCT ON still yields one row per name) so the caller
+        // can flag deck legality. Legality is name-level, so the representative's
+        // legality applies to every printing of the name.
+        if (options.format) {
+            qb.leftJoinAndSelect(
+                `${this.TABLE}.legalities`,
+                'legalities',
+                'legalities.format = :groupedFormat',
+                { groupedFormat: options.format }
+            );
+        }
+
+        this.applySearchFilter(qb, filter);
+        this.applyCatalogFilters(qb, options, { skipLegality: true });
+
+        // DISTINCT ON requires the leading ORDER BY to be the distinct expression;
+        // the release-date tiebreaker then selects the representative printing.
+        qb.orderBy(`${this.TABLE}.name`, this.ASC, this.NULLS_LAST);
+        qb.addOrderBy('set.releaseDate', this.DESC, this.NULLS_LAST);
+
+        // Raw limit/offset (not skip/take) so pagination applies to the
+        // DISTINCT ON result rather than triggering TypeORM's id-subquery path.
+        qb.limit(options.limit).offset((options.page - 1) * options.limit);
+        const results = (await qb.getMany()).map(CardMapper.toCore);
+        this.LOGGER.debug(`Grouped search found ${results.length} names for "${filter}".`);
+        return results;
+    }
+
+    async totalSearchByNameGrouped(filter: string, options?: SafeQueryOptions): Promise<number> {
+        this.LOGGER.debug(`Counting grouped search results for: ${filter}.`);
+        const qb = this.repository.createQueryBuilder(this.TABLE);
+        this.applySearchFilter(qb, filter);
+        if (options) this.applyCatalogFilters(qb, options, { skipLegality: true });
+        const raw = await qb
+            .select(`COUNT(DISTINCT ${this.TABLE}.name)`, 'cnt')
+            .getRawOne<{ cnt: string }>();
+        const count = parseInt(raw?.cnt ?? '0', 10);
+        this.LOGGER.debug(`Total grouped search results for "${filter}": ${count}.`);
+        return count;
+    }
+
     /**
      * Public catalog filters used by the RapidAPI search and per-set listings:
      * `setCode`, `rarity`, `type` substring, and `format`+`legality` (joined to
@@ -251,7 +308,7 @@ export class CardRepository extends BaseRepository<CardOrmEntity> implements Car
     private applyCatalogFilters(
         qb: SelectQueryBuilder<CardOrmEntity>,
         options: SafeQueryOptions,
-        opts: { skipSetCode?: boolean } = {}
+        opts: { skipSetCode?: boolean; skipLegality?: boolean } = {}
     ): void {
         if (!opts.skipSetCode && options.setCode) {
             qb.andWhere(`${this.TABLE}.setCode = :filterSetCode`, {
@@ -266,7 +323,10 @@ export class CardRepository extends BaseRepository<CardOrmEntity> implements Car
                 typeFilter: `%${options.type}%`,
             });
         }
-        if (options.format && options.legality) {
+        // `skipLegality` lets the grouped (deck-building) search use `format` to
+        // annotate legality without filtering out illegal cards - a deck builder
+        // wants to see every matching card and have the illegal ones flagged.
+        if (!opts.skipLegality && options.format && options.legality) {
             qb.innerJoin(
                 'legality',
                 'lg',

--- a/src/database/card/card.repository.ts
+++ b/src/database/card/card.repository.ts
@@ -274,9 +274,13 @@ export class CardRepository extends BaseRepository<CardOrmEntity> implements Car
         this.applyCatalogFilters(qb, options, { skipLegality: true });
 
         // DISTINCT ON requires the leading ORDER BY to be the distinct expression;
-        // the release-date tiebreaker then selects the representative printing.
+        // the remaining terms select the representative printing: newest set,
+        // then lowest collector number, then id as a final deterministic
+        // tiebreaker so same-name/same-release printings don't flip arbitrarily.
         qb.orderBy(`${this.TABLE}.name`, this.ASC, this.NULLS_LAST);
         qb.addOrderBy('set.releaseDate', this.DESC, this.NULLS_LAST);
+        qb.addOrderBy(`${this.TABLE}.sortNumber`, this.ASC, this.NULLS_LAST);
+        qb.addOrderBy(`${this.TABLE}.id`, this.ASC);
 
         // Raw limit/offset (not skip/take) so pagination applies to the
         // DISTINCT ON result rather than triggering TypeORM's id-subquery path.

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -66,6 +66,13 @@ export class CardApiController {
         description: 'Legality status; only meaningful with format. Defaults to "legal".',
         enum: [...LEGALITY_VALUES],
     })
+    @ApiQuery({
+        name: 'groupBy',
+        required: false,
+        description:
+            'Set to "name" to return one representative printing per distinct card name (newest printing), instead of one row per printing. With "name", a `format` param flags each result\'s legality in that format.',
+        enum: ['name'],
+    })
     @ApiQuery({ name: 'page', required: false })
     @ApiQuery({ name: 'limit', required: false })
     @ApiResponse({ status: 200, description: 'Search results (ordered by card name)' })
@@ -89,6 +96,19 @@ export class CardApiController {
         const options = new SearchQueryOptions(query);
         if (!options.q) {
             return ApiResponseDto.ok([], new PaginationMeta(1, options.limit, 0));
+        }
+
+        // groupBy=name returns one representative printing per distinct name
+        // (deck-building search); anything else keeps the per-printing default.
+        if (query.groupBy === 'name') {
+            const [grouped, groupedTotal] = await Promise.all([
+                this.cardService.searchByNameGrouped(options.q, options),
+                this.cardService.totalSearchByNameGrouped(options.q, options),
+            ]);
+            return ApiResponseDto.ok(
+                grouped.map((c) => CardApiPresenter.toGroupedCardApiResponse(c, options.format)),
+                new PaginationMeta(options.page, options.limit, groupedTotal)
+            );
         }
 
         const [cards, total] = await Promise.all([

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -92,6 +92,7 @@ export class CardApiController {
             format: true,
             legality: true,
             setCode: true,
+            groupBy: true,
         });
         const options = new SearchQueryOptions(query);
         if (!options.q) {

--- a/src/http/api/card/card-api.presenter.ts
+++ b/src/http/api/card/card-api.presenter.ts
@@ -1,6 +1,8 @@
 import { AffiliateLinkPolicy } from 'src/core/affiliate/affiliate-link.policy';
 import { Card } from 'src/core/card/card.entity';
+import { Format } from 'src/core/card/format.enum';
 import { GranularPrice } from 'src/core/card/granular-price.entity';
+import { DeckLegalityPolicy } from 'src/core/deck/deck-legality.policy';
 import { groupBuylistByFinish } from 'src/core/pricing/buylist.policy';
 import { vendorDisplayName } from 'src/core/pricing/vendor';
 import { CardBuylistApiResponseDto } from './dto/card-buylist-response.dto';
@@ -58,5 +60,19 @@ export class CardApiPresenter {
                 card.tcgplayerEtchedProductId
             ),
         };
+    }
+
+    /**
+     * Representative-printing response for the grouped (one-per-name) search.
+     * Adds the deck-legality flag for the requested format so the in-page deck
+     * search can render the "Not legal" badge on cards it inserts. Without a
+     * format the flag is omitted (legality is meaningless with no target format).
+     */
+    static toGroupedCardApiResponse(card: Card, format?: Format): CardApiResponseDto {
+        const base = this.toCardApiResponse(card);
+        if (!format) {
+            return base;
+        }
+        return { ...base, legal: DeckLegalityPolicy.isCardLegal(format, card.legalities) };
     }
 }

--- a/src/http/api/card/dto/card-response.dto.ts
+++ b/src/http/api/card/dto/card-response.dto.ts
@@ -68,6 +68,12 @@ export class CardApiResponseDto {
 
     @ApiPropertyOptional({ description: 'Affiliate-wrapped TCGPlayer purchase URL for etched finish' })
     readonly purchaseUrlTcgplayerEtched?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Whether this card is legal in the requested format. Present only in groupBy=name mode when a `format` query param is supplied.',
+    })
+    readonly legal?: boolean;
 }
 
 export class PriceHistoryPointDto {

--- a/src/http/api/shared/query-validation.ts
+++ b/src/http/api/shared/query-validation.ts
@@ -37,6 +37,10 @@ import { TRANSACTION_TYPES, parseTransactionType } from 'src/core/transaction/tr
 export const RARITY_VALUES: readonly string[] = [...PUBLIC_RARITIES];
 export const FORMAT_VALUES: readonly string[] = Object.values(Format);
 export const LEGALITY_VALUES: readonly string[] = Object.values(LegalityStatus);
+// The only supported `groupBy` mode. Validated exact (case-sensitive) so it
+// stays in lockstep with the controller's `query.groupBy === 'name'` check - a
+// typo'd value 400s instead of silently returning the per-printing default.
+export const GROUP_BY_VALUES: readonly string[] = ['name'];
 
 const SET_CODE_PATTERN = /^[a-zA-Z0-9]+$/;
 
@@ -69,6 +73,8 @@ export interface StrictQueryFlags {
     legality?: boolean;
     setCode?: boolean;
     transactionType?: boolean;
+    /** Validate `groupBy` against {@link GROUP_BY_VALUES} (exact, single value). */
+    groupBy?: boolean;
 }
 
 /**
@@ -153,6 +159,12 @@ export function validateApiQuery(query: Record<string, unknown>, flags: StrictQu
         const value = readParam(query, 'type');
         if (value !== undefined && parseTransactionType(value) === undefined) {
             throw enumError('type', value, TRANSACTION_TYPES);
+        }
+    }
+    if (flags.groupBy) {
+        const value = readParam(query, 'groupBy');
+        if (value !== undefined && !GROUP_BY_VALUES.includes(value)) {
+            throw enumError('groupBy', value, GROUP_BY_VALUES);
         }
     }
 }

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -143,6 +143,7 @@ export class DeckPageOrchestrator {
                 const cardViews = buckets.get(t)!;
                 return {
                     type: TYPE_PLURAL[t] ?? t,
+                    groupKey: t,
                     count: cardViews.reduce((sum, c) => sum + c.quantity, 0),
                     cards: cardViews,
                 };
@@ -158,6 +159,7 @@ export class DeckPageOrchestrator {
             setCode: card?.setCode ?? '',
             number: card?.number ?? '',
             url: card ? buildCardUrl(card.setCode, card.number) : '#',
+            imgSrc: card?.imgSrc ?? '',
             manaCost: card?.manaCost,
             quantity: dc.quantity,
             // Full precision; deckDetail.js rounds at display so client-recomputed

--- a/src/http/hbs/deck/dto/deck.view.dto.ts
+++ b/src/http/hbs/deck/dto/deck.view.dto.ts
@@ -35,6 +35,7 @@ export interface DeckCardView {
     setCode: string;
     number: string;
     url: string;
+    imgSrc: string;
     manaCost?: string;
     quantity: number;
     unitValue: number;
@@ -45,6 +46,9 @@ export interface DeckCardView {
 
 export interface DeckCardGroupView {
     type: string;
+    // Singular primary-type key (e.g. "Creature", "Land", "Other"); the deck-page
+    // search JS matches/creates groups by this, independent of the plural label.
+    groupKey: string;
     count: number;
     cards: DeckCardView[];
 }

--- a/src/http/public/js/deckDetail.js
+++ b/src/http/public/js/deckDetail.js
@@ -74,6 +74,17 @@ document.addEventListener('DOMContentLoaded', function () {
         return 0;
     }
 
+    // The card API response carries setCode + number but no URL, so build the
+    // detail path client-side, mirroring buildCardUrl (/card/<setCode>/<number>).
+    function cardUrl(card) {
+        return (
+            '/card/' +
+            encodeURIComponent(String(card.setCode || '').toLowerCase()) +
+            '/' +
+            encodeURIComponent(String(card.number == null ? '' : card.number))
+        );
+    }
+
     function rowQty(row) {
         return parseInt(row.querySelector('.deck-qty-val').textContent, 10) || 0;
     }
@@ -275,7 +286,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var row = buildRow({
             cardId: card.id,
             name: card.name,
-            url: card.url,
+            url: cardUrl(card),
             imgSrc: card.imgSrc,
             unitValue: unitValueOf(card),
             quantity: 1,
@@ -387,7 +398,7 @@ document.addEventListener('DOMContentLoaded', function () {
         item.setAttribute('role', 'option');
 
         var link = document.createElement('a');
-        link.href = card.url;
+        link.href = cardUrl(card);
         link.className = 'card-name-link flex-1 text-sm truncate';
         if (card.imgSrc) link.setAttribute('data-card-img', card.imgSrc);
         link.textContent = card.name;

--- a/src/http/public/js/deckDetail.js
+++ b/src/http/public/js/deckDetail.js
@@ -388,14 +388,12 @@ document.addEventListener('DOMContentLoaded', function () {
             resultsBox.innerHTML = '';
             resultsBox.classList.add('hidden');
         }
-        if (searchInput) searchInput.setAttribute('aria-expanded', 'false');
     }
 
     function buildResultItem(card) {
         var item = document.createElement('div');
         item.className =
             'deck-result flex items-center gap-2 py-1.5 border-b border-gray-100 dark:border-midnight-800';
-        item.setAttribute('role', 'option');
 
         var link = document.createElement('a');
         link.href = cardUrl(card);
@@ -470,7 +468,6 @@ document.addEventListener('DOMContentLoaded', function () {
             resultsBox.appendChild(buildResultItem(card));
         });
         resultsBox.classList.remove('hidden');
-        if (searchInput) searchInput.setAttribute('aria-expanded', 'true');
         setStatus('');
     }
 

--- a/src/http/public/js/deckDetail.js
+++ b/src/http/public/js/deckDetail.js
@@ -1,9 +1,15 @@
 /**
- * Deck detail page (10.4): quantity steppers, remove, rename/format, delete.
- * Card mutations hit /api/v1/decks/:id/cards and update the DOM in place;
- * totals (deck value, board counts, group counts, illegal count) recompute
- * client-side from data-unit-value on each row. Deck-level edits reload so the
- * server re-renders legality + grouping.
+ * Deck detail page (10.4 + 10.6 / #536): in-page card search, quantity
+ * steppers, remove, rename/format, delete.
+ *
+ * Card mutations hit /api/v1/decks/:id/cards and update the DOM in place; totals
+ * (deck value, board counts, group counts, illegal count) recompute client-side
+ * from data-unit-value on each row. The search box (#536) queries the grouped
+ * card endpoint (one row per name) and adds straight to main/sideboard, inserting
+ * the new row (creating the type group if needed) without a full reload. Card art
+ * on hover comes for free from cardPreview.js, which binds globally to any
+ * .card-name-link[data-card-img]. Deck-level edits reload so the server
+ * re-renders legality + grouping.
  */
 document.addEventListener('DOMContentLoaded', function () {
     if (typeof AjaxUtils === 'undefined') return;
@@ -11,13 +17,70 @@ document.addEventListener('DOMContentLoaded', function () {
     var root = document.querySelector('.content-wrapper[data-deck-id]');
     if (!root) return;
     var base = '/api/v1/decks/' + root.getAttribute('data-deck-id');
+    var deckFormat = (root.getAttribute('data-deck-format') || '').trim();
+
+    // Maindeck grouping order, mirrored from DeckPageOrchestrator so search-added
+    // rows land in (and create) the same groups the server renders. 'Other'
+    // sorts after the named types; 'Sideboard' always sorts last.
+    var TYPE_ORDER = [
+        'Creature',
+        'Planeswalker',
+        'Instant',
+        'Sorcery',
+        'Artifact',
+        'Enchantment',
+        'Battle',
+        'Land',
+    ];
+    var TYPE_PLURAL = {
+        Creature: 'Creatures',
+        Planeswalker: 'Planeswalkers',
+        Instant: 'Instants',
+        Sorcery: 'Sorceries',
+        Artifact: 'Artifacts',
+        Enchantment: 'Enchantments',
+        Battle: 'Battles',
+        Land: 'Lands',
+        Other: 'Other',
+        Sideboard: 'Sideboard',
+    };
+    var EM_DASH = String.fromCharCode(0x2014);
+
+    function primaryType(typeLine) {
+        var head = (typeLine || '').split(EM_DASH)[0];
+        for (var i = 0; i < TYPE_ORDER.length; i++) {
+            if (head.indexOf(TYPE_ORDER[i]) !== -1) return TYPE_ORDER[i];
+        }
+        return 'Other';
+    }
+
+    function groupOrderIndex(key) {
+        if (key === 'Sideboard') return 999;
+        var idx = TYPE_ORDER.indexOf(key);
+        return idx >= 0 ? idx : 500; // 'Other' between named types and sideboard
+    }
 
     function fmt(n) {
         return '$' + (Math.round(n * 100) / 100).toFixed(2);
     }
 
+    function unitValueOf(card) {
+        // Mirrors PriceCalculationPolicy.calculateCardValue(normal, foil, false):
+        // normal price, falling back to foil, then 0.
+        var p = card && card.prices;
+        if (!p) return 0;
+        if (p.normal != null) return p.normal;
+        if (p.foil != null) return p.foil;
+        return 0;
+    }
+
     function rowQty(row) {
         return parseInt(row.querySelector('.deck-qty-val').textContent, 10) || 0;
+    }
+
+    function setText(id, value) {
+        var el = document.getElementById(id);
+        if (el) el.textContent = value;
     }
 
     function recompute() {
@@ -35,6 +98,8 @@ document.addEventListener('DOMContentLoaded', function () {
         setText('deck-est-value', fmt(total));
         setText('deck-main-count', mainCount);
         setText('deck-side-count', sideCount);
+        var sideWrap = document.getElementById('deck-side-wrap');
+        if (sideWrap) sideWrap.classList.toggle('hidden', sideCount === 0);
 
         document.querySelectorAll('.deck-group').forEach(function (group) {
             var count = 0;
@@ -51,11 +116,6 @@ document.addEventListener('DOMContentLoaded', function () {
             setText('deck-illegal-count', badges);
             notice.classList.toggle('hidden', badges === 0);
         }
-    }
-
-    function setText(id, value) {
-        var el = document.getElementById(id);
-        if (el) el.textContent = value;
     }
 
     function updateLineValue(row, qty) {
@@ -97,57 +157,359 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
-    document.querySelectorAll('#deck-cards .deck-step').forEach(function (btn) {
-        btn.addEventListener('click', function () {
-            var row = btn.closest('[data-card-id]');
-            if (!row) return;
-            var next = rowQty(row) + (parseInt(btn.getAttribute('data-delta'), 10) || 0);
-            if (next < 0) next = 0;
-            if (isRowBusy(row)) return;
-            setRowBusy(row, true);
-            AjaxUtils.fetchWithGate(base + '/cards', {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(cardPayload(row, { quantity: next })),
-            })
-                .then(function (res) {
-                    setRowBusy(row, false);
-                    if (res.gated || !res.ok) return;
-                    if (next <= 0) {
-                        removeRow(row);
-                    } else {
-                        row.querySelector('.deck-qty-val').textContent = next;
-                        updateLineValue(row, next);
-                        recompute();
-                    }
-                })
-                .catch(function () {
-                    setRowBusy(row, false);
-                });
-        });
-    });
+    // ── Row / group construction (search-added cards) ───────────────
 
-    document.querySelectorAll('#deck-cards .deck-remove').forEach(function (btn) {
+    function buildRow(opts) {
+        // opts: { cardId, name, url, imgSrc, unitValue, quantity, isSideboard, illegal }
+        var row = document.createElement('div');
+        row.className =
+            'flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800';
+        row.setAttribute('data-card-id', opts.cardId);
+        row.setAttribute('data-sideboard', opts.isSideboard ? 'true' : 'false');
+        row.setAttribute('data-unit-value', String(opts.unitValue));
+
+        var stepper = document.createElement('span');
+        stepper.className =
+            'inline-flex items-center rounded-md border border-gray-200 dark:border-midnight-700';
+        stepper.innerHTML =
+            '<button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="-1" aria-label="Decrease quantity">−</button>' +
+            '<span class="deck-qty-val w-7 text-center text-sm font-mono">' +
+            opts.quantity +
+            '</span>' +
+            '<button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>';
+        row.appendChild(stepper);
+
+        var link = document.createElement('a');
+        link.href = opts.url;
+        link.className = 'card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate';
+        if (opts.imgSrc) link.setAttribute('data-card-img', opts.imgSrc);
+        link.textContent = opts.name;
+        row.appendChild(link);
+
+        if (opts.illegal) {
+            var badge = document.createElement('span');
+            badge.className =
+                'deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+            badge.title = 'Not legal in this format';
+            badge.textContent = 'Not legal';
+            row.appendChild(badge);
+        }
+
+        var lineValue = document.createElement('span');
+        lineValue.className =
+            'deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right';
+        lineValue.textContent = fmt(opts.quantity * opts.unitValue);
+        row.appendChild(lineValue);
+
+        var remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'deck-remove px-2 text-gray-400 hover:text-red-500';
+        remove.setAttribute('aria-label', 'Remove card');
+        remove.innerHTML = '×';
+        row.appendChild(remove);
+
+        return row;
+    }
+
+    // Find the group section for a key, creating + ordering it if absent.
+    function ensureGroup(key) {
+        var container = document.getElementById('deck-cards');
+        var existing = container.querySelector('.deck-group[data-group-type="' + key + '"]');
+        if (existing) return existing.querySelector('.deck-group-rows');
+
+        var group = document.createElement('div');
+        group.className = 'deck-group mb-5';
+        group.setAttribute('data-group-type', key);
+        var label = TYPE_PLURAL[key] || key;
+        group.innerHTML =
+            '<h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">' +
+            AjaxUtils.escapeHtml(label) +
+            ' <span class="text-gray-400 font-normal">(<span class="deck-group-count">0</span>)</span></h3>' +
+            '<div class="deck-group-rows"></div>';
+
+        // Insert before the first existing group that sorts after this one (and
+        // always before the empty-state placeholder), so the order matches the
+        // server's TYPE_ORDER rendering.
+        var newIndex = groupOrderIndex(key);
+        var groups = container.querySelectorAll('.deck-group');
+        var inserted = false;
+        for (var i = 0; i < groups.length; i++) {
+            var k = groups[i].getAttribute('data-group-type');
+            if (groupOrderIndex(k) > newIndex) {
+                container.insertBefore(group, groups[i]);
+                inserted = true;
+                break;
+            }
+        }
+        if (!inserted) {
+            var emptyState = document.getElementById('deck-empty-state');
+            container.insertBefore(group, emptyState || null);
+        }
+        return group.querySelector('.deck-group-rows');
+    }
+
+    // Insert (or bump the quantity of) a card just added via search.
+    function applyAdded(card, isSideboard) {
+        var emptyState = document.getElementById('deck-empty-state');
+        if (emptyState) emptyState.classList.add('hidden');
+
+        var board = isSideboard ? 'true' : 'false';
+        var existing = document.querySelector(
+            '#deck-cards [data-card-id="' +
+                (window.CSS && CSS.escape ? CSS.escape(card.id) : card.id) +
+                '"][data-sideboard="' +
+                board +
+                '"]'
+        );
+        if (existing) {
+            var qty = rowQty(existing) + 1;
+            existing.querySelector('.deck-qty-val').textContent = qty;
+            updateLineValue(existing, qty);
+            recompute();
+            return;
+        }
+
+        var key = isSideboard ? 'Sideboard' : primaryType(card.type);
+        var rows = ensureGroup(key);
+        var illegal = !!deckFormat && card.legal === false;
+        var row = buildRow({
+            cardId: card.id,
+            name: card.name,
+            url: card.url,
+            imgSrc: card.imgSrc,
+            unitValue: unitValueOf(card),
+            quantity: 1,
+            isSideboard: isSideboard,
+            illegal: illegal,
+        });
+        rows.appendChild(row);
+        recompute();
+    }
+
+    // ── Quantity steppers + remove (event-delegated so search-added rows work) ──
+
+    var deckCards = document.getElementById('deck-cards');
+    if (deckCards) {
+        deckCards.addEventListener('click', function (e) {
+            var stepBtn = e.target.closest ? e.target.closest('.deck-step') : null;
+            if (stepBtn && deckCards.contains(stepBtn)) {
+                onStep(stepBtn);
+                return;
+            }
+            var removeBtn = e.target.closest ? e.target.closest('.deck-remove') : null;
+            if (removeBtn && deckCards.contains(removeBtn)) {
+                onRemove(removeBtn);
+            }
+        });
+    }
+
+    function onStep(btn) {
+        var row = btn.closest('[data-card-id]');
+        if (!row) return;
+        var next = rowQty(row) + (parseInt(btn.getAttribute('data-delta'), 10) || 0);
+        if (next < 0) next = 0;
+        if (isRowBusy(row)) return;
+        setRowBusy(row, true);
+        AjaxUtils.fetchWithGate(base + '/cards', {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(cardPayload(row, { quantity: next })),
+        })
+            .then(function (res) {
+                setRowBusy(row, false);
+                if (res.gated || !res.ok) return;
+                if (next <= 0) {
+                    removeRow(row);
+                } else {
+                    row.querySelector('.deck-qty-val').textContent = next;
+                    updateLineValue(row, next);
+                    recompute();
+                }
+            })
+            .catch(function () {
+                setRowBusy(row, false);
+            });
+    }
+
+    function onRemove(btn) {
+        var row = btn.closest('[data-card-id]');
+        if (!row) return;
+        if (isRowBusy(row)) return;
+        setRowBusy(row, true);
+        AjaxUtils.fetchWithGate(base + '/cards', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(cardPayload(row)),
+        })
+            .then(function (res) {
+                setRowBusy(row, false);
+                if (res.gated || !res.ok) return;
+                removeRow(row);
+            })
+            .catch(function () {
+                setRowBusy(row, false);
+            });
+    }
+
+    // ── In-page card search (#536) ──────────────────────────────────
+
+    var searchInput = document.getElementById('deck-card-search');
+    var resultsBox = document.getElementById('deck-search-results');
+    var searchStatus = document.getElementById('deck-search-status');
+    var DEBOUNCE_MS = 250;
+    var MIN_CHARS = 2;
+    var debounceTimer = null;
+    var searchSeq = 0;
+
+    function setStatus(text) {
+        if (!searchStatus) return;
+        if (text) {
+            searchStatus.textContent = text;
+            searchStatus.classList.remove('hidden');
+        } else {
+            searchStatus.textContent = '';
+            searchStatus.classList.add('hidden');
+        }
+    }
+
+    function clearResults() {
+        if (resultsBox) {
+            resultsBox.innerHTML = '';
+            resultsBox.classList.add('hidden');
+        }
+        if (searchInput) searchInput.setAttribute('aria-expanded', 'false');
+    }
+
+    function buildResultItem(card) {
+        var item = document.createElement('div');
+        item.className =
+            'deck-result flex items-center gap-2 py-1.5 border-b border-gray-100 dark:border-midnight-800';
+        item.setAttribute('role', 'option');
+
+        var link = document.createElement('a');
+        link.href = card.url;
+        link.className = 'card-name-link flex-1 text-sm truncate';
+        if (card.imgSrc) link.setAttribute('data-card-img', card.imgSrc);
+        link.textContent = card.name;
+        item.appendChild(link);
+
+        var value = unitValueOf(card);
+        var meta = document.createElement('span');
+        meta.className = 'text-xs text-gray-400 font-mono whitespace-nowrap';
+        meta.textContent = (card.setCode ? card.setCode.toUpperCase() + ' · ' : '') + fmt(value);
+        item.appendChild(meta);
+
+        if (deckFormat && card.legal === false) {
+            var warn = document.createElement('span');
+            warn.className = 'text-xs text-red-600 dark:text-red-400 whitespace-nowrap';
+            warn.title = 'Not legal in this format';
+            warn.textContent = 'Not legal';
+            item.appendChild(warn);
+        }
+
+        item.appendChild(makeAddButton(card, false, '+ Deck', 'Add to maindeck'));
+        item.appendChild(makeAddButton(card, true, 'SB', 'Add to sideboard'));
+        return item;
+    }
+
+    function makeAddButton(card, isSideboard, label, aria) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className =
+            'deck-result-add btn btn-ghost text-xs px-2 py-0.5 whitespace-nowrap text-teal-600 dark:text-teal-400';
+        btn.textContent = label;
+        btn.setAttribute('aria-label', aria + ': ' + card.name);
         btn.addEventListener('click', function () {
-            var row = btn.closest('[data-card-id]');
-            if (!row) return;
-            if (isRowBusy(row)) return;
-            setRowBusy(row, true);
+            if (btn.disabled) return;
+            btn.disabled = true;
             AjaxUtils.fetchWithGate(base + '/cards', {
-                method: 'DELETE',
+                method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(cardPayload(row)),
+                body: JSON.stringify({ cardId: card.id, isSideboard: isSideboard, quantity: 1 }),
             })
                 .then(function (res) {
-                    setRowBusy(row, false);
-                    if (res.gated || !res.ok) return;
-                    removeRow(row);
+                    btn.disabled = false;
+                    if (res.gated) return;
+                    if (!res.ok) {
+                        setStatus('Could not add ' + card.name + '.');
+                        return;
+                    }
+                    applyAdded(card, isSideboard);
+                    setStatus(
+                        'Added ' + card.name + (isSideboard ? ' to sideboard.' : ' to maindeck.')
+                    );
                 })
                 .catch(function () {
-                    setRowBusy(row, false);
+                    btn.disabled = false;
+                    setStatus('Could not add ' + card.name + '.');
                 });
         });
-    });
+        return btn;
+    }
+
+    function renderResults(cards) {
+        if (!resultsBox) return;
+        resultsBox.innerHTML = '';
+        if (!cards.length) {
+            clearResults();
+            setStatus('No cards found.');
+            return;
+        }
+        cards.forEach(function (card) {
+            resultsBox.appendChild(buildResultItem(card));
+        });
+        resultsBox.classList.remove('hidden');
+        if (searchInput) searchInput.setAttribute('aria-expanded', 'true');
+        setStatus('');
+    }
+
+    function runSearch(term) {
+        var seq = ++searchSeq;
+        var url =
+            '/api/v1/cards?groupBy=name&limit=15&q=' +
+            encodeURIComponent(term) +
+            (deckFormat ? '&format=' + encodeURIComponent(deckFormat) : '');
+        AjaxUtils.fetchWithGate(url, { method: 'GET' })
+            .then(function (res) {
+                if (seq !== searchSeq) return; // a newer query superseded this one
+                if (res.gated) return;
+                if (!res.ok || !res.body || !res.body.data) {
+                    setStatus('Search failed. Try again.');
+                    return;
+                }
+                renderResults(res.body.data);
+            })
+            .catch(function () {
+                if (seq !== searchSeq) return;
+                setStatus('Search failed. Try again.');
+            });
+    }
+
+    if (searchInput) {
+        searchInput.addEventListener('input', function () {
+            var term = searchInput.value.trim();
+            if (debounceTimer) clearTimeout(debounceTimer);
+            if (term.length < MIN_CHARS) {
+                searchSeq++; // invalidate any in-flight query
+                clearResults();
+                setStatus('');
+                return;
+            }
+            setStatus('Searching…');
+            debounceTimer = setTimeout(function () {
+                runSearch(term);
+            }, DEBOUNCE_MS);
+        });
+
+        searchInput.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') {
+                clearResults();
+                setStatus('');
+            }
+        });
+    }
+
+    // ── Deck-level edit (rename / format) + delete ──────────────────
 
     var editForm = document.getElementById('deck-edit-form');
     var editResult = document.getElementById('deck-edit-result');

--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -55,11 +55,13 @@
         <div class="relative">
             <input id="deck-card-search" type="text" autocomplete="off" spellcheck="false"
                 placeholder="Search by card name&hellip;"
-                role="combobox" aria-expanded="false" aria-autocomplete="list" aria-controls="deck-search-results"
                 class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm" />
         </div>
         <p class="text-xs text-gray-400 mt-1">One result per card name &middot; hover (or long-press) a name for art.</p>
-        <div id="deck-search-results" role="listbox" aria-label="Card search results" class="mt-2 hidden"></div>
+        {{!-- Plain container: each result row holds a link + buttons, so the
+              listbox/option pattern doesn't apply. The role="status" region
+              below announces add results to assistive tech. --}}
+        <div id="deck-search-results" class="mt-2 hidden"></div>
         <p id="deck-search-status" class="text-sm text-gray-500 mt-2 hidden" role="status" aria-live="polite"></p>
     </div>
 

--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -1,4 +1,4 @@
-<div class="content-wrapper py-6" data-deck-id="{{deckId}}">
+<div class="content-wrapper py-6" data-deck-id="{{deckId}}" data-deck-format="{{format}}">
     <div class="flex items-start justify-between mb-2 flex-wrap gap-3">
         <div>
             <h1 class="page-title">{{name}}</h1>
@@ -6,7 +6,7 @@
                 <span class="text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
                 <span class="mx-1">&middot;</span>
                 <span id="deck-main-count">{{mainCount}}</span> maindeck
-                {{#if sideCount}}<span class="mx-1">&middot;</span><span id="deck-side-count">{{sideCount}}</span> sideboard{{/if}}
+                <span id="deck-side-wrap" {{#unless sideCount}}class="hidden"{{/unless}}><span class="mx-1">&middot;</span><span id="deck-side-count">{{sideCount}}</span> sideboard</span>
                 <span class="mx-1">&middot;</span>
                 <span id="deck-est-value" class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
             </p>
@@ -47,66 +47,81 @@
         </form>
     </details>
 
-    {{#if hasCards}}
-        <div id="deck-cards">
-            {{#each mainGroups}}
-                <div class="deck-group mb-5">
-                    <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
-                        {{type}} <span class="text-gray-400 font-normal">(<span class="deck-group-count">{{count}}</span>)</span>
-                    </h3>
-                    <div>
-                        {{#each cards}}
-                            <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800"
-                                data-card-id="{{cardId}}" data-sideboard="false" data-unit-value="{{unitValue}}">
-                                <span class="inline-flex items-center rounded-md border border-gray-200 dark:border-midnight-700">
-                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="-1" aria-label="Decrease quantity">&minus;</button>
-                                    <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
-                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
-                                </span>
-                                <a href="{{url}}" class="flex-1 text-sm text-gray-800 dark:text-gray-100 hover:text-teal-600 dark:hover:text-teal-400 truncate">{{name}}</a>
-                                {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
-                                <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
-                                <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
-                            </div>
-                        {{/each}}
-                    </div>
-                </div>
-            {{/each}}
-
-            {{#if sideboard.length}}
-                <div class="deck-group mb-5">
-                    <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
-                        Sideboard <span class="text-gray-400 font-normal">(<span class="deck-group-count">{{sideCount}}</span>)</span>
-                    </h3>
-                    <div>
-                        {{#each sideboard}}
-                            <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800"
-                                data-card-id="{{cardId}}" data-sideboard="true" data-unit-value="{{unitValue}}">
-                                <span class="inline-flex items-center rounded-md border border-gray-200 dark:border-midnight-700">
-                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="-1" aria-label="Decrease quantity">&minus;</button>
-                                    <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
-                                    <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
-                                </span>
-                                <a href="{{url}}" class="flex-1 text-sm text-gray-800 dark:text-gray-100 hover:text-teal-600 dark:hover:text-teal-400 truncate">{{name}}</a>
-                                {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
-                                <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
-                                <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
-                            </div>
-                        {{/each}}
-                    </div>
-                </div>
-            {{/if}}
+    {{!-- In-page card search (10.6 / #536): find + add cards without leaving the deck --}}
+    <div class="section-container mb-5">
+        <label for="deck-card-search" class="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            <i class="fas fa-magnifying-glass mr-1" aria-hidden="true"></i> Add cards
+        </label>
+        <div class="relative">
+            <input id="deck-card-search" type="text" autocomplete="off" spellcheck="false"
+                placeholder="Search by card name&hellip;"
+                role="combobox" aria-expanded="false" aria-autocomplete="list" aria-controls="deck-search-results"
+                class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm" />
         </div>
-    {{else}}
-        <div class="section-container text-center py-12">
+        <p class="text-xs text-gray-400 mt-1">One result per card name &middot; hover (or long-press) a name for art.</p>
+        <div id="deck-search-results" role="listbox" aria-label="Card search results" class="mt-2 hidden"></div>
+        <p id="deck-search-status" class="text-sm text-gray-500 mt-2 hidden" role="status" aria-live="polite"></p>
+    </div>
+
+    {{!-- #deck-cards is always present so the in-page search can insert rows
+          (and create type groups) without a full reload, even from empty. --}}
+    <div id="deck-cards">
+        {{#each mainGroups}}
+            <div class="deck-group mb-5" data-group-type="{{groupKey}}">
+                <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                    {{type}} <span class="text-gray-400 font-normal">(<span class="deck-group-count">{{count}}</span>)</span>
+                </h3>
+                <div class="deck-group-rows">
+                    {{#each cards}}
+                        <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800"
+                            data-card-id="{{cardId}}" data-sideboard="false" data-unit-value="{{unitValue}}">
+                            <span class="inline-flex items-center rounded-md border border-gray-200 dark:border-midnight-700">
+                                <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="-1" aria-label="Decrease quantity">&minus;</button>
+                                <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
+                                <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
+                            </span>
+                            <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                            {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
+                            <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
+                            <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
+                        </div>
+                    {{/each}}
+                </div>
+            </div>
+        {{/each}}
+
+        {{#if sideboard.length}}
+            <div class="deck-group mb-5" data-group-type="Sideboard">
+                <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                    Sideboard <span class="text-gray-400 font-normal">(<span class="deck-group-count">{{sideCount}}</span>)</span>
+                </h3>
+                <div class="deck-group-rows">
+                    {{#each sideboard}}
+                        <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800"
+                            data-card-id="{{cardId}}" data-sideboard="true" data-unit-value="{{unitValue}}">
+                            <span class="inline-flex items-center rounded-md border border-gray-200 dark:border-midnight-700">
+                                <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="-1" aria-label="Decrease quantity">&minus;</button>
+                                <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
+                                <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
+                            </span>
+                            <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                            {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
+                            <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
+                            <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
+                        </div>
+                    {{/each}}
+                </div>
+            </div>
+        {{/if}}
+
+        <div id="deck-empty-state" class="section-container text-center py-12 {{#if hasCards}}hidden{{/if}}">
             <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-300 mb-3">
                 <i class="fas fa-layer-group text-lg" aria-hidden="true"></i>
             </div>
             <h2 class="font-display font-bold text-lg text-gray-900 dark:text-white mb-1">This deck is empty</h2>
-            <p class="text-gray-600 dark:text-gray-400 text-sm">Add cards from any card page with the &ldquo;Add to deck&rdquo; button.</p>
-            <a href="/sets" class="btn btn-primary text-sm px-4 py-2 mt-4">Browse sets</a>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">Use the search above to find a card and add it straight to your deck.</p>
         </div>
-    {{/if}}
+    </div>
 </div>
 
 <script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>

--- a/test/core/card/card.service.spec.ts
+++ b/test/core/card/card.service.spec.ts
@@ -69,6 +69,8 @@ describe('CardService', () => {
         delete: jest.fn(),
         searchByName: jest.fn(),
         totalSearchByName: jest.fn(),
+        searchByNameGrouped: jest.fn(),
+        totalSearchByNameGrouped: jest.fn(),
     };
 
     const mockPriceHistoryRepository = {
@@ -293,6 +295,45 @@ describe('CardService', () => {
 
             await expect(service.totalSearchByName('Test')).rejects.toThrow(
                 'Error counting card search results for "Test"'
+            );
+        });
+    });
+
+    describe('searchByNameGrouped', () => {
+        it('should delegate to the repository grouped search', async () => {
+            const cards = [testCard];
+            repository.searchByNameGrouped.mockResolvedValue(cards);
+
+            const result = await service.searchByNameGrouped('Test', mockQueryOptions);
+
+            expect(repository.searchByNameGrouped).toHaveBeenCalledWith('Test', mockQueryOptions);
+            expect(result).toEqual(cards);
+        });
+
+        it('should throw error when repository fails', async () => {
+            repository.searchByNameGrouped.mockRejectedValue(new Error('Database error'));
+
+            await expect(
+                service.searchByNameGrouped('Test', mockQueryOptions)
+            ).rejects.toThrow('Error grouped-searching cards by name "Test"');
+        });
+    });
+
+    describe('totalSearchByNameGrouped', () => {
+        it('should return the count of distinct names', async () => {
+            repository.totalSearchByNameGrouped.mockResolvedValue(3);
+
+            const result = await service.totalSearchByNameGrouped('Test');
+
+            expect(repository.totalSearchByNameGrouped).toHaveBeenCalledWith('Test', undefined);
+            expect(result).toBe(3);
+        });
+
+        it('should throw error when repository fails', async () => {
+            repository.totalSearchByNameGrouped.mockRejectedValue(new Error('Database error'));
+
+            await expect(service.totalSearchByNameGrouped('Test')).rejects.toThrow(
+                'Error counting grouped card search results for "Test"'
             );
         });
     });

--- a/test/frontend/deckDetailSearch.spec.js
+++ b/test/frontend/deckDetailSearch.spec.js
@@ -1,0 +1,266 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Frontend unit tests for the deck-page in-page card search (#536):
+ * grouped query, inline add to main/sideboard, in-place DOM insertion +
+ * total recompute, and quantity increment on re-add.
+ */
+
+if (!window.matchMedia) {
+    window.matchMedia = function () {
+        return { matches: false, addEventListener: function () {}, removeEventListener: function () {} };
+    };
+}
+
+function escapeHtml(str) {
+    if (str == null) return '';
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(String(str)));
+    return div.innerHTML;
+}
+
+// Per-test routing for fetchWithGate. Tests push handlers keyed by a URL match.
+var fetchHandler = null;
+var fetchCalls = [];
+
+window.AjaxUtils = {
+    escapeHtml: escapeHtml,
+    fetchWithGate: function (url, options) {
+        fetchCalls.push({ url: url, options: options || {} });
+        return Promise.resolve(fetchHandler(url, options || {}));
+    },
+};
+
+function wait(ms) {
+    return new Promise(function (resolve) {
+        setTimeout(resolve, ms);
+    });
+}
+
+function flush() {
+    return new Promise(function (resolve) {
+        setTimeout(resolve, 0);
+    });
+}
+
+function setupDom(format) {
+    document.body.innerHTML =
+        '<div class="content-wrapper" data-deck-id="7" data-deck-format="' +
+        (format || '') +
+        '">' +
+        '  <p><span id="deck-main-count">0</span> maindeck' +
+        '     <span id="deck-side-wrap" class="hidden"><span>·</span><span id="deck-side-count">0</span> sideboard</span>' +
+        '     <span id="deck-est-value">$0.00</span></p>' +
+        '  <p id="deck-illegal-notice" class="hidden"><span id="deck-illegal-count">0</span></p>' +
+        '  <input id="deck-card-search" type="text" aria-expanded="false" />' +
+        '  <div id="deck-search-results" class="hidden"></div>' +
+        '  <p id="deck-search-status" class="hidden"></p>' +
+        '  <div id="deck-cards"><div id="deck-empty-state"></div></div>' +
+        '</div>';
+}
+
+function loadScript() {
+    jest.resetModules();
+    require('../../src/http/public/js/deckDetail.js');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+}
+
+function card(overrides) {
+    return Object.assign(
+        {
+            id: 'c1',
+            name: 'Grizzly Bears',
+            type: 'Creature',
+            setCode: 'lea',
+            number: '1',
+            imgSrc: 'bears.jpg',
+            url: '/card/lea/1',
+            prices: { normal: 0.25, foil: null },
+            legal: true,
+        },
+        overrides || {}
+    );
+}
+
+beforeEach(function () {
+    fetchHandler = null;
+    fetchCalls = [];
+});
+
+describe('deck-page in-page search', function () {
+    it('queries the grouped endpoint with the deck format and renders one result per name', async function () {
+        setupDom('modern');
+        loadScript();
+        fetchHandler = function () {
+            return { ok: true, gated: false, body: { data: [card()] } };
+        };
+
+        var input = document.getElementById('deck-card-search');
+        input.value = 'bears';
+        input.dispatchEvent(new Event('input'));
+        await wait(300);
+        await flush();
+
+        var searchCall = fetchCalls.find(function (c) {
+            return c.url.indexOf('groupBy=name') !== -1;
+        });
+        expect(searchCall).toBeDefined();
+        expect(searchCall.url).toContain('q=bears');
+        expect(searchCall.url).toContain('format=modern');
+
+        var results = document.querySelectorAll('#deck-search-results .deck-result');
+        expect(results.length).toBe(1);
+        var link = results[0].querySelector('.card-name-link');
+        expect(link.textContent).toBe('Grizzly Bears');
+        expect(link.getAttribute('data-card-img')).toBe('bears.jpg');
+        expect(results[0].querySelectorAll('.deck-result-add').length).toBe(2);
+        expect(document.getElementById('deck-search-results').classList.contains('hidden')).toBe(
+            false
+        );
+    });
+
+    it('does not query below the minimum character threshold', async function () {
+        setupDom('');
+        loadScript();
+        fetchHandler = function () {
+            return { ok: true, gated: false, body: { data: [] } };
+        };
+
+        var input = document.getElementById('deck-card-search');
+        input.value = 'b';
+        input.dispatchEvent(new Event('input'));
+        await wait(300);
+        await flush();
+
+        expect(fetchCalls.length).toBe(0);
+    });
+
+    it('adds a card to the maindeck: creates the type group, inserts a row, updates totals', async function () {
+        setupDom('modern');
+        loadScript();
+        fetchHandler = function (url, options) {
+            if (url.indexOf('groupBy=name') !== -1) {
+                return { ok: true, gated: false, body: { data: [card()] } };
+            }
+            // POST add
+            return { ok: true, gated: false, body: { data: { added: true } } };
+        };
+
+        var input = document.getElementById('deck-card-search');
+        input.value = 'bears';
+        input.dispatchEvent(new Event('input'));
+        await wait(300);
+        await flush();
+
+        var addBtn = document.querySelector('#deck-search-results .deck-result-add');
+        addBtn.click();
+        await flush();
+
+        var postCall = fetchCalls.find(function (c) {
+            return c.options.method === 'POST';
+        });
+        expect(postCall).toBeDefined();
+        expect(JSON.parse(postCall.options.body)).toEqual({
+            cardId: 'c1',
+            isSideboard: false,
+            quantity: 1,
+        });
+
+        var group = document.querySelector('#deck-cards .deck-group[data-group-type="Creature"]');
+        expect(group).not.toBeNull();
+        var rows = group.querySelectorAll('[data-card-id="c1"]');
+        expect(rows.length).toBe(1);
+        expect(rows[0].getAttribute('data-sideboard')).toBe('false');
+        expect(rows[0].querySelector('.deck-qty-val').textContent).toBe('1');
+
+        expect(document.getElementById('deck-main-count').textContent).toBe('1');
+        expect(document.getElementById('deck-est-value').textContent).toBe('$0.25');
+        expect(document.getElementById('deck-empty-state').classList.contains('hidden')).toBe(true);
+    });
+
+    it('increments quantity when the same card is added again', async function () {
+        setupDom('modern');
+        loadScript();
+        fetchHandler = function (url) {
+            if (url.indexOf('groupBy=name') !== -1) {
+                return { ok: true, gated: false, body: { data: [card()] } };
+            }
+            return { ok: true, gated: false, body: { data: { added: true } } };
+        };
+
+        var input = document.getElementById('deck-card-search');
+        input.value = 'bears';
+        input.dispatchEvent(new Event('input'));
+        await wait(300);
+        await flush();
+
+        var addBtn = document.querySelector('#deck-search-results .deck-result-add');
+        addBtn.click();
+        await flush();
+        addBtn.click();
+        await flush();
+
+        var rows = document.querySelectorAll('#deck-cards [data-card-id="c1"][data-sideboard="false"]');
+        expect(rows.length).toBe(1);
+        expect(rows[0].querySelector('.deck-qty-val').textContent).toBe('2');
+        expect(document.getElementById('deck-main-count').textContent).toBe('2');
+        expect(document.getElementById('deck-est-value').textContent).toBe('$0.50');
+    });
+
+    it('adds to the sideboard and reveals the sideboard count', async function () {
+        setupDom('modern');
+        loadScript();
+        fetchHandler = function (url) {
+            if (url.indexOf('groupBy=name') !== -1) {
+                return { ok: true, gated: false, body: { data: [card()] } };
+            }
+            return { ok: true, gated: false, body: { data: { added: true } } };
+        };
+
+        var input = document.getElementById('deck-card-search');
+        input.value = 'bears';
+        input.dispatchEvent(new Event('input'));
+        await wait(300);
+        await flush();
+
+        var sbBtn = document.querySelectorAll('#deck-search-results .deck-result-add')[1];
+        sbBtn.click();
+        await flush();
+
+        var sbGroup = document.querySelector('#deck-cards .deck-group[data-group-type="Sideboard"]');
+        expect(sbGroup).not.toBeNull();
+        expect(sbGroup.querySelector('[data-card-id="c1"]').getAttribute('data-sideboard')).toBe(
+            'true'
+        );
+        expect(document.getElementById('deck-side-count').textContent).toBe('1');
+        expect(document.getElementById('deck-side-wrap').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('deck-main-count').textContent).toBe('0');
+    });
+
+    it('flags an illegal card with a badge and updates the illegal notice', async function () {
+        setupDom('standard');
+        loadScript();
+        fetchHandler = function (url) {
+            if (url.indexOf('groupBy=name') !== -1) {
+                return { ok: true, gated: false, body: { data: [card({ legal: false })] } };
+            }
+            return { ok: true, gated: false, body: { data: { added: true } } };
+        };
+
+        var input = document.getElementById('deck-card-search');
+        input.value = 'bears';
+        input.dispatchEvent(new Event('input'));
+        await wait(300);
+        await flush();
+
+        document.querySelector('#deck-search-results .deck-result-add').click();
+        await flush();
+
+        var row = document.querySelector('#deck-cards [data-card-id="c1"]');
+        expect(row.querySelector('.deck-illegal-badge')).not.toBeNull();
+        expect(document.getElementById('deck-illegal-count').textContent).toBe('1');
+        expect(document.getElementById('deck-illegal-notice').classList.contains('hidden')).toBe(
+            false
+        );
+    });
+});

--- a/test/frontend/deckDetailSearch.spec.js
+++ b/test/frontend/deckDetailSearch.spec.js
@@ -65,16 +65,17 @@ function loadScript() {
     document.dispatchEvent(new Event('DOMContentLoaded'));
 }
 
+// Mirrors the real grouped card API response shape: setCode + number, but NO
+// `url` field (the client builds the detail path from setCode/number).
 function card(overrides) {
     return Object.assign(
         {
             id: 'c1',
             name: 'Grizzly Bears',
             type: 'Creature',
-            setCode: 'lea',
+            setCode: 'LEA',
             number: '1',
             imgSrc: 'bears.jpg',
-            url: '/card/lea/1',
             prices: { normal: 0.25, foil: null },
             legal: true,
         },
@@ -113,6 +114,8 @@ describe('deck-page in-page search', function () {
         var link = results[0].querySelector('.card-name-link');
         expect(link.textContent).toBe('Grizzly Bears');
         expect(link.getAttribute('data-card-img')).toBe('bears.jpg');
+        // URL is built client-side from setCode (lowercased) + number, not sent.
+        expect(link.getAttribute('href')).toBe('/card/lea/1');
         expect(results[0].querySelectorAll('.deck-result-add').length).toBe(2);
         expect(document.getElementById('deck-search-results').classList.contains('hidden')).toBe(
             false
@@ -172,6 +175,7 @@ describe('deck-page in-page search', function () {
         expect(rows.length).toBe(1);
         expect(rows[0].getAttribute('data-sideboard')).toBe('false');
         expect(rows[0].querySelector('.deck-qty-val').textContent).toBe('1');
+        expect(rows[0].querySelector('.card-name-link').getAttribute('href')).toBe('/card/lea/1');
 
         expect(document.getElementById('deck-main-count').textContent).toBe('1');
         expect(document.getElementById('deck-est-value').textContent).toBe('$0.25');

--- a/test/http/api/card/card-api.controller.spec.ts
+++ b/test/http/api/card/card-api.controller.spec.ts
@@ -50,6 +50,8 @@ describe('CardApiController', () => {
                     useValue: {
                         searchByName: jest.fn(),
                         totalSearchByName: jest.fn(),
+                        searchByNameGrouped: jest.fn(),
+                        totalSearchByNameGrouped: jest.fn(),
                         findByIdsWithPrices: jest.fn(),
                         findBySetCodeAndNumber: jest.fn(),
                         findPriceHistory: jest.fn(),
@@ -73,6 +75,78 @@ describe('CardApiController', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    describe('search', () => {
+        it('returns an empty page when no query term is supplied', async () => {
+            const result = await controller.search({});
+
+            expect(result.data).toEqual([]);
+            expect(cardService.searchByName).not.toHaveBeenCalled();
+            expect(cardService.searchByNameGrouped).not.toHaveBeenCalled();
+        });
+
+        it('uses the per-printing search by default', async () => {
+            cardService.searchByName.mockResolvedValue([createCard({ prices: [createPrice()] })]);
+            cardService.totalSearchByName.mockResolvedValue(1);
+
+            const result = await controller.search({ q: 'bolt' });
+
+            expect(cardService.searchByName).toHaveBeenCalledWith('bolt', expect.anything());
+            expect(cardService.searchByNameGrouped).not.toHaveBeenCalled();
+            expect(result.data).toHaveLength(1);
+            expect(result.data[0].legal).toBeUndefined();
+            expect(result.meta?.total).toBe(1);
+        });
+
+        it('groups by name and omits the legal flag when no format is given', async () => {
+            cardService.searchByNameGrouped.mockResolvedValue([
+                createCard({ prices: [createPrice()] }),
+            ]);
+            cardService.totalSearchByNameGrouped.mockResolvedValue(1);
+
+            const result = await controller.search({ q: 'bolt', groupBy: 'name' });
+
+            expect(cardService.searchByNameGrouped).toHaveBeenCalledWith('bolt', expect.anything());
+            expect(cardService.searchByName).not.toHaveBeenCalled();
+            expect(result.data).toHaveLength(1);
+            expect(result.data[0].legal).toBeUndefined();
+        });
+
+        it('groups by name and flags legality when a format is given', async () => {
+            cardService.searchByNameGrouped.mockResolvedValue([
+                createCard({
+                    prices: [createPrice()],
+                    legalities: [
+                        { format: 'modern', status: 'legal' } as never,
+                    ],
+                }),
+            ]);
+            cardService.totalSearchByNameGrouped.mockResolvedValue(1);
+
+            const result = await controller.search({
+                q: 'bolt',
+                groupBy: 'name',
+                format: 'modern',
+            });
+
+            expect(result.data[0].legal).toBe(true);
+        });
+
+        it('flags a card with no legality entry as not legal in the format', async () => {
+            cardService.searchByNameGrouped.mockResolvedValue([
+                createCard({ prices: [createPrice()], legalities: [] }),
+            ]);
+            cardService.totalSearchByNameGrouped.mockResolvedValue(1);
+
+            const result = await controller.search({
+                q: 'bolt',
+                groupBy: 'name',
+                format: 'standard',
+            });
+
+            expect(result.data[0].legal).toBe(false);
+        });
     });
 
     describe('getPriceHistoryById', () => {

--- a/test/http/api/card/card-api.controller.spec.ts
+++ b/test/http/api/card/card-api.controller.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Card } from 'src/core/card/card.entity';
 import { Price } from 'src/core/card/price.entity';
@@ -131,6 +131,18 @@ describe('CardApiController', () => {
             });
 
             expect(result.data[0].legal).toBe(true);
+        });
+
+        it('rejects an invalid groupBy instead of silently falling back', async () => {
+            await expect(controller.search({ q: 'bolt', groupBy: 'foo' })).rejects.toBeInstanceOf(
+                BadRequestException
+            );
+            // A case typo must not silently return per-printing results either.
+            await expect(controller.search({ q: 'bolt', groupBy: 'Name' })).rejects.toBeInstanceOf(
+                BadRequestException
+            );
+            expect(cardService.searchByName).not.toHaveBeenCalled();
+            expect(cardService.searchByNameGrouped).not.toHaveBeenCalled();
         });
 
         it('flags a card with no legality entry as not legal in the format', async () => {

--- a/test/http/api/shared/query-validation.spec.ts
+++ b/test/http/api/shared/query-validation.spec.ts
@@ -8,6 +8,7 @@ const ALL_FLAGS = {
     legality: true,
     setCode: true,
     transactionType: true,
+    groupBy: true,
 };
 
 describe('validateApiQuery', () => {
@@ -110,6 +111,17 @@ describe('validateApiQuery', () => {
             expect(err.param).toBe('setCode');
             expect(err.allowedValues).toBeUndefined();
             expect(err.message).toContain('letters and digits');
+        });
+
+        it('rejects an unknown groupBy with the allowed value list', () => {
+            const err = capture({ groupBy: 'foo' }, { groupBy: true });
+            expect(err.param).toBe('groupBy');
+            expect(err.allowedValues).toEqual(['name']);
+        });
+
+        it('rejects a case-mismatched groupBy (must equal "name" exactly)', () => {
+            const err = capture({ groupBy: 'Name' }, { groupBy: true });
+            expect(err.param).toBe('groupBy');
         });
     });
 

--- a/test/integration/api-cards.e2e-spec.ts
+++ b/test/integration/api-cards.e2e-spec.ts
@@ -183,6 +183,16 @@ describe('Cards API (e2e)', () => {
                 ).toBe(true);
             });
 
+            it('returns 400 for an invalid groupBy rather than silently falling back', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&groupBy=foo')
+                    .expect(400);
+
+                expect(res.body.success).toBe(false);
+                expect(res.body.param).toBe('groupBy');
+                expect(res.body.allowedValues).toEqual(['name']);
+            });
+
             it('annotates (does not filter out) cards illegal in the format', async () => {
                 // Non-grouped search filters format=modern to legal-only (none seeded).
                 const filtered = await request(app.getHttpServer())

--- a/test/integration/api-cards.e2e-spec.ts
+++ b/test/integration/api-cards.e2e-spec.ts
@@ -142,6 +142,65 @@ describe('Cards API (e2e)', () => {
             });
         });
 
+        describe('groupBy=name (in-page deck search)', () => {
+            it('returns one row per distinct card name with prices', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&groupBy=name')
+                    .expect(200);
+
+                expect(res.body.success).toBe(true);
+                expect(res.body.data.length).toBeGreaterThan(0);
+
+                const names = res.body.data.map((c: { name: string }) => c.name);
+                expect(new Set(names).size).toBe(names.length); // no duplicate names
+                expect(res.body.meta.total).toBe(names.length);
+                // A representative printing carries the latest price for valuation.
+                expect(res.body.data[0]).toHaveProperty('prices');
+            });
+
+            it('narrows to a single name when the query matches one card', async () => {
+                const res = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test%20Angel&groupBy=name')
+                    .expect(200);
+
+                expect(res.body.data).toHaveLength(1);
+                expect(res.body.data[0].name).toBe('Test Angel');
+            });
+
+            it('flags legality for the requested format without omitting the flag otherwise', async () => {
+                const withFormat = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&groupBy=name&format=standard')
+                    .expect(200);
+                expect(withFormat.body.data.every((c: { legal: boolean }) => c.legal === true)).toBe(
+                    true
+                );
+
+                const noFormat = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&groupBy=name')
+                    .expect(200);
+                expect(
+                    noFormat.body.data.every((c: { legal?: boolean }) => c.legal === undefined)
+                ).toBe(true);
+            });
+
+            it('annotates (does not filter out) cards illegal in the format', async () => {
+                // Non-grouped search filters format=modern to legal-only (none seeded).
+                const filtered = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&format=modern')
+                    .expect(200);
+                expect(filtered.body.data).toEqual([]);
+
+                // Grouped (deck) search keeps the cards and flags them not legal.
+                const annotated = await request(app.getHttpServer())
+                    .get('/api/v1/cards?q=Test&groupBy=name&format=modern')
+                    .expect(200);
+                expect(annotated.body.data.length).toBeGreaterThan(0);
+                expect(
+                    annotated.body.data.every((c: { legal: boolean }) => c.legal === false)
+                ).toBe(true);
+            });
+        });
+
         describe('strict filter validation', () => {
             it('returns 400 with param + allowedValues for an unknown rarity', async () => {
                 const res = await request(app.getHttpServer())


### PR DESCRIPTION
Closes #536. Also merges in the `roadmap/new-issues-535-537` branch (the §10.6/§10.7 roadmap entries for #536/#537).

## What this does

Adds **in-page card search** to the deck detail page (`/decks/:id`), modeled on Archidekt/ManaBox, so a user can find and add cards **without leaving the deck**. Search results are **grouped by card name** (one row per name), card art shows **on hover (long-press on mobile)**, and adds go straight to main/sideboard with the deck DOM + totals updating **in place — no full reload**.

This completes the deferred 10.4 item ("Add to Deck from search results") and goes further: the search lives on the deck page itself.

## Backend

- **Grouped search mode:** `GET /api/v1/cards?q=…&groupBy=name` returns **one representative printing per distinct name** (`CardRepository.searchByNameGrouped` / `totalSearchByNameGrouped`, Postgres `DISTINCT ON (name)`). The representative is the **newest printing** (`ORDER BY name, set.release_date DESC`) — a sensible single default that's also the most likely in-print copy. The latest price is joined so the client can value the card. The per-printing default search is unchanged.
- **Legality is annotated, not filtered:** with a `format` param each grouped result carries a `legal` flag (legality is name-level, so the representative's flag applies to the whole name), but illegal cards are still returned and shown flagged — a deck builder wants to see everything and decide. `applyCatalogFilters` gained a `skipLegality` option for this; without it, `format` would silently filter to legal-only because `safeLegality` defaults to `legal`.

## Frontend

- Debounced search box on `/decks/:id` reusing `AjaxUtils.fetchWithGate`. Results and in-deck rows both render the standard `.card-name-link[data-card-img]`, so the existing global `cardPreview.js` provides hover/long-press art for free.
- Inline add to main/sideboard via the existing `POST /api/v1/decks/:id/cards`. `deckDetail.js` inserts the new row into the correct type group (creating + ordering it to mirror the server's `TYPE_ORDER`) or increments an existing row, then recomputes value/board counts/group counts/legality client-side. Steppers + remove moved to **event delegation** so search-added rows behave identically to server-rendered ones.
- Keyboard-friendly (Escape clears) and mobile-friendly; the user never leaves the deck. `#deck-cards` is now always rendered (with an in-place empty state) so the first add from an empty deck doesn't need a reload.

## Open question resolved

Which printing to bind for a multi-printing name → the **newest** printing (single representative). A per-row printing picker and mana-curve/fuller analytics stay deferred (10.4 follow-up).

## Tests

- **Unit:** grouped controller paths (default vs `groupBy=name`, legality flag present/absent/true/false) + service wrappers.
- **Frontend (jsdom):** grouped query shape, min-char threshold, add-to-main (group creation + totals), quantity increment on re-add, add-to-sideboard (count reveal), illegal-card badge + notice.
- **Integration (real Postgres):** one-row-per-name + total, single-name narrowing, legality annotation present/absent, and grouped mode annotating (not filtering out) format-illegal cards.

All 1307 unit + 118 frontend tests pass; TypeScript compiles and lint is clean. Integration tests run in CI (no Docker in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QW2532AJqNX9M3v1Xvjg9h)_