### PR TITLE
feat: import public decklists + tournament catalog + inventory buildability (#537)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,42 @@ docker rmi ghcr.io/matthewdtowles/scry:latest
 
 Note that `docker-compose.prod.yml`'s `etl` service exists but is gated behind `profiles: ['etl']` and is not what cron uses — it's only there for ad-hoc `docker compose run --rm etl ...` invocations, and `remote-deploy.sh` does not pull it (`docker compose pull web` only).
 
+### Checking Scry ingest on the production server
+
+The nightly ingest runs from cron, not `docker compose`. `/etc/cron.d/i-want-my-mtg` (installed from `cron/i-want-my-mtg`) runs `/opt/scripts/scry.sh` at **02:00 UTC daily**, appending to `/var/log/i-want-my-mtg/ingestion.log`. Sibling jobs: retention (Sun 03:00 UTC -> `retention.log`), price-alert processing (02:15 UTC -> `price-alerts.log`), portfolio-summary refresh (02:30 UTC -> `portfolio.log`), log cleanup (Sun 04:00 UTC -> `cleanup.log`). All times UTC; all jobs run as user `ubuntu`.
+
+`scry.sh` sources `/home/ubuntu/.env` (which sets `DATABASE_URL`) then runs `/opt/scripts/scry <args>` (default `ingest`). **Always go through the wrapper**, never the bare `/opt/scripts/scry`, or `DATABASE_URL` is unset and it fails.
+
+```bash
+ssh ubuntu@<LIGHTSAIL_IP>          # the Lightsail static IP, same key the deploy uses
+
+# 1. Did last night's ingest run and finish? Each run opens with a
+#    "<UTC ts> Starting scry.sh with args: ingest" line.
+tail -n 100 /var/log/i-want-my-mtg/ingestion.log
+grep "Starting scry.sh" /var/log/i-want-my-mtg/ingestion.log | tail -5    # recent run times
+
+# 2. End-of-pass summary of what was written per table:
+#    "... write totals (ms/calls): price=.../... price_history=.../... granular_price=.../..."
+grep "write totals" /var/log/i-want-my-mtg/ingestion.log | tail -5
+
+# 3. Data-integrity health check (through the wrapper so DATABASE_URL is set):
+/opt/scripts/scry.sh health --detailed
+/opt/scripts/scry.sh health --price-history
+
+# 4. Confirm cron is installed and the daemon is up:
+cat /etc/cron.d/i-want-my-mtg
+systemctl status cron
+grep CRON /var/log/syslog | grep scry        # or: journalctl -u cron --since yesterday | grep scry
+
+# 5. Confirm the binary is the build from the last web deploy:
+ls -la /opt/scripts/scry                     # mtime should match the last deploy
+
+# 6. Trigger a manual ingest if needed (same path cron uses, logs to stdout):
+/opt/scripts/scry.sh ingest
+```
+
+Since §10.10 (the granular price-store cut), the `write totals` line no longer carries a `granular_price_history` field and `granular_price` calls collapse to just the CK-direct buylist writes - that is the signal the cut took effect on a nightly run.
+
 ### Deployment order (web + Scry)
 
 Scry writes tables that **this repo's migrations create**, and **this repo's deploy installs the Scry binary** (`setup-cron.sh` extracts it from `scry:latest`, *after* `run_migrations.sh` runs - see above). So when a change spans both repos (e.g. Scry starts writing a new table):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Note that `docker-compose.prod.yml`'s `etl` service exists but is gated behind `
 
 ### Checking Scry ingest on the production server
 
-The nightly ingest runs from cron, not `docker compose`. `/etc/cron.d/i-want-my-mtg` (installed from `cron/i-want-my-mtg`) runs `/opt/scripts/scry.sh` at **02:00 UTC daily**, appending to `/var/log/i-want-my-mtg/ingestion.log`. Sibling jobs: retention (Sun 03:00 UTC -> `retention.log`), price-alert processing (02:15 UTC -> `price-alerts.log`), portfolio-summary refresh (02:30 UTC -> `portfolio.log`), log cleanup (Sun 04:00 UTC -> `cleanup.log`). All times UTC; all jobs run as user `ubuntu`.
+The nightly ingest runs from cron, not `docker compose`. `/etc/cron.d/i-want-my-mtg` (installed from `cron/i-want-my-mtg`) runs `/opt/scripts/scry.sh` at **02:00 UTC daily**, appending to `/var/log/i-want-my-mtg/ingestion.log`. Sibling jobs: retention (Sun 03:00 UTC -> `retention.log`), published-deck ingest (Mon 03:30 UTC, `ingest-decks --days 8` -> `decks.log`), price-alert processing (02:15 UTC -> `price-alerts.log`), portfolio-summary refresh (02:30 UTC -> `portfolio.log`), log cleanup (Sun 04:00 UTC -> `cleanup.log`). All times UTC; all jobs run as user `ubuntu`.
 
 `scry.sh` sources `/home/ubuntu/.env` (which sets `DATABASE_URL`) then runs `/opt/scripts/scry <args>` (default `ingest`). **Always go through the wrapper**, never the bare `/opt/scripts/scry`, or `DATABASE_URL` is unset and it fails.
 
@@ -205,7 +205,7 @@ Test suites: `test/integration/*.e2e-spec.ts`. Seed data: `test/integration/seed
 
 **Local dev**: PostgreSQL 18 via Docker (docker-compose.yml). Migrations run via `docker compose run --rm migrate`.
 
-Schema defined in `docker/postgres/init/001_complete_schema.sql`. Migrations in `migrations/` (numbered sequentially). Core tables: `card`, `set`, `price`, `price_history`, `legality`, `inventory`, `user`, `pending_user`, `set_price`, `set_price_history`, `granular_price`, `granular_price_history`.
+Schema defined in `docker/postgres/init/001_complete_schema.sql`. Migrations in `migrations/` (numbered sequentially). Core tables: `card`, `set`, `price`, `price_history`, `legality`, `inventory`, `user`, `pending_user`, `set_price`, `set_price_history`, `granular_price`, `granular_price_history`, `deck`, `deck_card`, `published_deck`, `published_deck_card`. The `published_deck*` tables are a read-only tournament-deck catalog written by Scry's `ingest-decks` command (fbettega feed); the web app only reads them.
 
 ### Price History
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -355,6 +355,8 @@ Adding cards now happens **on the deck page** (modeled on Archidekt/ManaBox), so
 
 ### 10.7 Import public decklists + inventory buildability/gap comparison (#537)
 
+**Status (2026-06-19): active** — current work item now that #535/#536 have shipped; branch `537-import-decklists-buildability`. Scoping next.
+
 Import shared public decklists (paste-text first, URL/site export later) and compare them against inventory: "what can I build" (rank decks by completeness) and per-deck owned-vs-needed gap lists. Reuses `src/core/import/` parsers + the 10.4 deck model; missing cards seed the want-list. Import likely stays free (funnel); the analysis layer may be the premium pull.
 
 ### 10.8 Scry: ingestion performance regression (scry#22)
@@ -367,7 +369,9 @@ Full ingest regressed from **3–4 min → ~27 min**; price ingest alone **~20s 
 - ~82% of `granular_price` rows are **retail** (tcgplayer/CK/manapool) — **never read**; the web app only reads `granular_price` `WHERE price_type='buylist'`, vendor `cardkingdom`.
 - The MTGJSON CK buylist it does write is **88% stale** (prod: only ~12% of the 17.8k MTGJSON-only rows were refreshed today; the rest froze days/weeks ago) and is fully covered by **CK-direct** (Tier B, live, with `qty`).
 
-Decision: **go CK-direct-only for buylist; delete the rest.** Executed in §10.10. The tiered-optimization issues scry#24/#25/#26/#27/#31 are all **superseded/closed** by that cut; scry#28 (sealed re-streams `AllPrintings`, ~3.5 min) remains as the one separate, still-valid ingest item, and the umbrella scry#22 stays open until the deploy verifies.
+Decision: **go CK-direct-only for buylist; delete the rest.** Executed in §10.10. The tiered-optimization issues scry#24/#25/#26/#27/#31 are all **superseded/closed** by that cut. The one remaining ingest item was the ~3.5 min sealed `AllPrintings` re-stream (scry#28, originally scoped as a conditional-GET) - now solved by a **single pass** instead (below); scry#28 closed. Umbrella scry#22's price regression is resolved (granular cut verified 2026-06-20); it stays open only until the single-pass merges + deploys.
+
+**Single-pass card + sealed ingest (2026-06-20) - solves the sealed re-stream, closes out scry#22.** Card ingest and sealed ingest both stream the same `AllPrintings.json` and just extract different sub-trees (`cards[]` vs `sealedProduct[]`), so it was being downloaded + tokenized twice. Built a single-pass "tee" on scry branch `perf/single-pass-card-sealed-ingest`: one `CardSealedEventProcessor` forwards each JSON event to both extractors (each tracks its own depth/skip state), driven by one stream. **Wired into the pipeline** - the default `ingest` (and any run requesting both cards + sealed) now uses it; `-c` / `--sealed` alone still run standalone. Also a standalone `ingest-cards-sealed` command. Local benchmark (release, dev DB): two-pass cards (230s) + sealed (210s) = **440s** vs single pass **206s** (~3.9 min saved). Full `scry ingest` end-to-end now **~4.4 min** (was ~27 min at the regression peak): sets + single-pass cards/sealed (206s, e.g. `Sealed products: 3675 -> 3773, 98 saved`) + prices (`granular_price=0/0`, CK-direct 74.8k rows) + prune + updates, exit 0. 116 lib tests pass (incl. a tee test). **Remaining:** merge the scry PR + deploy.
 
 ### 10.9 MCP: color breakdown + deck building parity (iwantmymtg-mcp#16)
 
@@ -375,7 +379,7 @@ MCP `get_portfolio_breakdown` enum is stale (offers a non-existent `format`, mis
 
 ### 10.10 Cut the granular price store → CK-direct-only buylist (resolves 10.8)
 
-**Status (2026-06-18):** **scry#32 merged** — the cut is publishing to `scry:latest` (deploy step 1 done, correct order). **iwantmymtg#538** open + verified (migration 042 drops the table + purges, validated on fresh PG18). Remaining = merge + deploy web #538, then capture the new `write totals` to confirm. Umbrella scry#22 stays open until that verification.
+**Status (2026-06-20): VERIFIED - cut confirmed live; scry#22 closeable.** scry#32 + iwantmymtg#538 merged and deployed (the #540 deploy on 2026-06-19 extracted the post-cut binary); migration 042 dropped `granular_price_history` and purged the `qty IS NULL` rows. The 2026-06-20 post-cut run confirms all of it: the MTGJSON price pass writes **zero** granular (`ingest_all_today write totals (ms/calls): price=36814/205 price_history=32973/205 granular_price=0/0`), the `write totals` line no longer carries a `granular_price_history` field, and CK-direct is the **sole** granular writer (`ingest_cardkingdom_direct ... granular_price=65327/299`, 74,744 buylist rows saved). Price ingest is back to **~1 min** (was ~18 min). `granular_price_history` is absent from the table list; `granular_price` remains and holds CK buylist only.
 
 **Why:** see §10.8. The granular per-vendor store is mostly write-only / unread / stale; CK-direct already supplies the only consumed slice (live CK buylist). Cutting it reclaims **~9–12 min/run**, removes a 1.2 GB table + its retention, slims `save_prices`, **and** improves buylist data quality (drops stale prices currently shown to users). Spans both repos — mind the deploy order.
 
@@ -383,21 +387,21 @@ MCP `get_portfolio_breakdown` enum is stale (offers a non-existent `format`, mis
 
 **Closed as superseded:** scry#24, #25, #26, #27, #31 (PR). Umbrella scry#22 stays open until the deploy verifies; scry#28 (sealed) is the lone remaining separate ingest item.
 
-**Scry change (PR 1) — stops all the now-dead writes:**
-- [ ] `PriceEventProcessor` / `save_prices`: stop writing granular entirely (averaged `price`/`price_history` only). MTGJSON granular is unused once CK-direct owns buylist.
-- [ ] Remove **all** `granular_price_history` writes (daily `save_prices`, `save_ck_batch`, `save_price_history_only` backfill).
-- [ ] CK-direct (`save_ck_batch`): keep `granular_price` (current buylist) write; drop its history write.
-- [ ] Drop `granular_price_history` retention (`apply_granular_*_retention`) + now-unused repo methods.
-- [ ] Verify via `./scripts/test-integ.sh` (real PG) + `cargo test --lib`.
+**Scry change (PR 1, scry#32 — merged) — stops all the now-dead writes:**
+- [x] `PriceEventProcessor` / `save_prices`: stop writing granular entirely (averaged `price`/`price_history` only). MTGJSON granular is unused once CK-direct owns buylist.
+- [x] Remove **all** `granular_price_history` writes (daily `save_prices`, `save_ck_batch`, `save_price_history_only` backfill).
+- [x] CK-direct (`save_ck_batch`): keep `granular_price` (current buylist) write; drop its history write.
+- [x] Drop `granular_price_history` retention (`apply_granular_*_retention`) + now-unused repo methods.
+- [x] Verify via `./scripts/test-integ.sh` (real PG) + `cargo test --lib`.
 
-**Web change (PR 2) — drops the table + purges stale/retail rows:**
-- [ ] Migration: `DROP TABLE granular_price_history;` (+ remove from init SQL) and `DELETE FROM granular_price WHERE qty IS NULL;` (one-time purge of unread retail + stale MTGJSON buylist; CK-direct rows carry `qty`).
-- [ ] Confirm buylist feature still reads only `granular_price` `WHERE price_type='buylist'` (unchanged) — it keeps working from CK-direct rows.
+**Web change (PR 2, iwantmymtg#538 — merged) — drops the table + purges stale/retail rows:**
+- [x] Migration: `DROP TABLE granular_price_history;` (+ remove from init SQL) and `DELETE FROM granular_price WHERE qty IS NULL;` (one-time purge of unread retail + stale MTGJSON buylist; CK-direct rows carry `qty`).
+- [x] Confirm buylist feature still reads only `granular_price` `WHERE price_type='buylist'` (unchanged) — it keeps working from CK-direct rows.
 
 **Deploy order (manual — Matthew):**
 1. [x] **Publish scry first** — done: scry#32 merged → CI pushes `scry:latest`. (Safe: the old binary on the server keeps writing the soon-to-be-dropped table, harmless until web deploys.)
-2. [ ] **Deploy web second** (PR 2). Web deploy runs the migration (drops table + purge) *then* extracts the new scry binary, so by the next 2 a.m. cron nothing writes the dropped table. **Do not** hand-refresh the scry binary before the web migration, and **do not** deploy web before scry is published (it'd extract the still-old binary that writes the dropped table → next cron errors).
-3. [ ] After the next nightly run, re-check `ingest_all_today write totals` — confirm the granular lines are gone and total ingest is back to single digits.
+2. [x] **Deploy web second** (PR 2). Done: #538 merged 2026-06-18, and the #540 deploy (2026-06-19) ran the migration (dropped table + purge) *then* extracted the new scry binary, so the server now holds the post-cut binary.
+3. [x] **Verified 2026-06-20.** Post-cut run: `ingest_all_today` granular writes = 0 (`granular_price=0/0`), no `granular_price_history` field in the totals line, CK-direct the sole granular writer (`granular_price=65327/299`, 74,744 buylist rows). Price ingest ~1 min vs the prior ~18 min. `granular_price_history` confirmed absent from the live schema.
 
 **Follow-up (optional, separate):** improve CK-direct `scryfall_id` matching to recover the ~2,093 today-fresh + 3,540 unmatched CK offers, if buylist coverage warrants it. If a buylist *trend chart* is ever wanted, add CK-buylist-only history written by CK-direct (~93k rows/day, not ~480k of retail).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -355,9 +355,15 @@ Adding cards now happens **on the deck page** (modeled on Archidekt/ManaBox), so
 
 ### 10.7 Import public decklists + inventory buildability/gap comparison (#537)
 
-**Status (2026-06-19): active** — current work item now that #535/#536 have shipped; branch `537-import-decklists-buildability`. Scoping next.
+**Status (2026-06-20): built** — branch `537-import-decklists-buildability`. All free (no premium gate); matching is name-level (any printing satisfies a need), basics always count as owned.
 
-Import shared public decklists (paste-text first, URL/site export later) and compare them against inventory: "what can I build" (rank decks by completeness) and per-deck owned-vs-needed gap lists. Reuses `src/core/import/` parsers + the 10.4 deck model; missing cards seed the want-list. Import likely stays free (funnel); the analysis layer may be the premium pull.
+Four parts shipped together:
+- **A — paste-text import:** `decklist-text.parser.ts` (the `4 Lightning Bolt` / `1 Sol Ring (CMR) 263` formats, Sideboard header) + `resolveByName` on `CardImportResolver` (set-less lines resolve to the cheapest printing) + `DeckImportService`; HBS `/decks/import` form→result and API `POST /api/v1/decks/import`.
+- **B — buildability/gap:** pure `DeckGapPolicy` + `DeckBuildabilityService` (inventory aggregated by card name). `/decks` rows show completeness % + missing count (ranked); `/decks/:id` gets a gap banner, per-card owned/missing badges, and "Add missing to buy list" (`POST /api/v1/decks/:id/missing-to-buy-list`).
+- **C — tournament catalog (Scry + web):** new `published_deck` + `published_deck_card` tables (migration `043`). Scry `published_deck` module ingests the **fbettega/MTG_decklistcache** feed behind a `DecklistSource` port (first adapter `FbettegaSource`; TopDeck.gg left as a future adapter), resolves card names to representative printings, and prunes past a 90-day window. New CLI `ingest-decks --days N`; weekly Monday cron → `decks.log`.
+- **D — browse + compare:** `/published-decks` (filter by format, paginated, public) and `/published-decks/:id` (deck view + gap vs. the signed-in user's inventory, "Copy to my decks", "Add missing to buy list").
+
+**Source note:** fbettega cache is the maintained successor to Badaro's archived MTGODecklistCache; verified updating ~daily. Deploy order: publish Scry first, then deploy web (migration `043` creates the tables before the new binary runs). Deferred: URL/per-site paste import, archetype enrichment, fuzzy name matching.
 
 ### 10.8 Scry: ingestion performance regression (scry#22)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -405,6 +405,15 @@ MCP `get_portfolio_breakdown` enum is stale (offers a non-existent `format`, mis
 
 **Follow-up (optional, separate):** improve CK-direct `scryfall_id` matching to recover the ~2,093 today-fresh + 3,540 unmatched CK offers, if buylist coverage warrants it. If a buylist *trend chart* is ever wanted, add CK-buylist-only history written by CK-direct (~93k rows/day, not ~480k of retail).
 
+### 10.11 Scry: card batch ingestion is serial despite Semaphore + spawn (scry#33 review)
+
+PR #33 review (Copilot) correctly identified that `CardService::save_card_batch` acquires a semaphore permit and then immediately `.await`s the spawned task's join handle before returning. `JsonStreamParser::parse_stream` likewise awaits `on_batch` before advancing the stream. Result: `CONCURRENCY = 6` and the `Semaphore` add overhead with no benefit — batches are processed one at a time. Two options when this is revisited:
+
+- **Simplify (recommended baseline):** remove the `tokio::spawn` + `Semaphore` entirely and run batch work inline. Equivalent behavior, honest code, no overhead.
+- **Real concurrency:** restructure `parse_stream` to collect task handles (JoinSet) as the stream advances and join them after the stream ends, giving up to `CONCURRENCY` concurrent DB writes.
+
+Not blocking the single-pass PR (#33) — the serial pattern predates it and throughput is acceptable post-10.10.
+
 ---
 
 ## Appendix: Freemium model (reference)

--- a/cron/i-want-my-mtg
+++ b/cron/i-want-my-mtg
@@ -9,6 +9,9 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Price history retention cleanup (weekly, Sunday at 3 AM)
 0 3 * * 0 ubuntu /opt/scripts/scry.sh retention >> /var/log/i-want-my-mtg/retention.log 2>&1
 
+# Published tournament-deck ingest (weekly, Monday at 3:30 AM; fetches the prior 8 days)
+30 3 * * 1 ubuntu /opt/scripts/scry.sh ingest-decks --days 8 >> /var/log/i-want-my-mtg/decks.log 2>&1
+
 # Price alert processing (daily at 2:15 AM, after ingestion completes)
 15 2 * * * ubuntu curl -Sf -X POST -H "x-api-key: $(grep '^INTERNAL_API_KEY=' /home/ubuntu/.env | cut -d= -f2- | sed 's/^"//;s/"$//')" http://localhost/api/v1/price-alerts/process >> /var/log/i-want-my-mtg/price-alerts.log 2>&1
 

--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -1017,6 +1017,48 @@ CREATE INDEX idx_deck_card_card_id ON public.deck_card (card_id);
 
 
 --
+-- Name: published_deck; Type: TABLE; Schema: public
+--
+
+CREATE TABLE public.published_deck (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    source character varying NOT NULL,
+    source_uri character varying NOT NULL,
+    tournament_name character varying,
+    tournament_date date,
+    format character varying,
+    archetype character varying,
+    player character varying,
+    result character varying,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    CONSTRAINT published_deck_pkey PRIMARY KEY (id),
+    CONSTRAINT uq_published_deck_source UNIQUE (source, source_uri)
+);
+
+CREATE INDEX idx_published_deck_format_date ON public.published_deck (format, tournament_date DESC);
+
+
+--
+-- Name: published_deck_card; Type: TABLE; Schema: public
+--
+
+CREATE TABLE public.published_deck_card (
+    published_deck_id integer NOT NULL,
+    card_id character varying NOT NULL,
+    quantity integer NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    is_sideboard boolean NOT NULL DEFAULT false,
+    CONSTRAINT published_deck_card_pkey PRIMARY KEY (published_deck_id, card_id, is_sideboard),
+    CONSTRAINT fk_published_deck_card_deck FOREIGN KEY (published_deck_id)
+        REFERENCES public.published_deck(id) ON DELETE CASCADE,
+    CONSTRAINT fk_published_deck_card_card FOREIGN KEY (card_id)
+        REFERENCES public.card(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_published_deck_card_deck_id ON public.published_deck_card (published_deck_id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 

--- a/migrations/043_published_deck.sql
+++ b/migrations/043_published_deck.sql
@@ -1,0 +1,48 @@
+BEGIN;
+
+-- 10.7 (#537): published tournament decklists. A read-only catalog that Scry
+-- ingests from external tournament feeds (MTGO challenges, paper events, etc.).
+-- Kept separate from the user-owned `deck` tables so ownership queries stay
+-- clean; the web app only reads these.
+--
+-- `format` is plain text (not format_enum) because feed formats are broader than
+-- our constructed-format enum (pauper, legacy, vintage, ...). Dedup is by
+-- (source, source_uri): re-ingesting the same tournament/deck upserts in place.
+--
+-- IF NOT EXISTS guards keep this replayable (the migration set re-runs every deploy).
+
+CREATE TABLE IF NOT EXISTS public.published_deck (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    source character varying NOT NULL,
+    source_uri character varying NOT NULL,
+    tournament_name character varying,
+    tournament_date date,
+    format character varying,
+    archetype character varying,
+    player character varying,
+    result character varying,
+    created_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    updated_at timestamp with time zone NOT NULL DEFAULT NOW(),
+    CONSTRAINT published_deck_pkey PRIMARY KEY (id),
+    CONSTRAINT uq_published_deck_source UNIQUE (source, source_uri)
+);
+
+CREATE INDEX IF NOT EXISTS idx_published_deck_format_date
+    ON public.published_deck (format, tournament_date DESC);
+
+CREATE TABLE IF NOT EXISTS public.published_deck_card (
+    published_deck_id integer NOT NULL,
+    card_id character varying NOT NULL,
+    quantity integer NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    is_sideboard boolean NOT NULL DEFAULT false,
+    CONSTRAINT published_deck_card_pkey PRIMARY KEY (published_deck_id, card_id, is_sideboard),
+    CONSTRAINT fk_published_deck_card_deck FOREIGN KEY (published_deck_id)
+        REFERENCES public.published_deck(id) ON DELETE CASCADE,
+    CONSTRAINT fk_published_deck_card_card FOREIGN KEY (card_id)
+        REFERENCES public.card(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_published_deck_card_deck_id
+    ON public.published_deck_card (published_deck_id);
+
+COMMIT;

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -13,6 +13,7 @@ import { InventoryModule } from './inventory/inventory.module';
 import { OptimizerModule } from './optimizer/optimizer.module';
 import { PasswordResetModule } from './password-reset/password-reset.module';
 import { PriceAlertModule } from './price-alert/price-alert.module';
+import { PublishedDeckModule } from './published-deck/published-deck.module';
 import { SearchModule } from './search/search.module';
 import { PortfolioModule } from './portfolio/portfolio.module';
 import { SealedProductModule } from './sealed-product/sealed-product.module';
@@ -36,6 +37,7 @@ import { UserModule } from './user/user.module';
         PasswordResetModule,
         PriceAlertModule,
         PortfolioModule,
+        PublishedDeckModule,
         SealedProductModule,
         SearchModule,
         SetModule,
@@ -57,6 +59,7 @@ import { UserModule } from './user/user.module';
         PasswordResetModule,
         PriceAlertModule,
         PortfolioModule,
+        PublishedDeckModule,
         SealedProductModule,
         SearchModule,
         SetModule,

--- a/src/core/deck/deck-buildability.service.ts
+++ b/src/core/deck/deck-buildability.service.ts
@@ -1,0 +1,60 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { BuyListService } from 'src/core/buy-list/buy-list.service';
+import { InventoryRepositoryPort } from 'src/core/inventory/ports/inventory.repository.port';
+import { getLogger } from 'src/logger/global-app-logger';
+import { DeckCard } from './deck-card.entity';
+import { DeckGapPolicy, DeckGapSummary } from './deck-gap.policy';
+import { Deck } from './deck.entity';
+
+@Injectable()
+export class DeckBuildabilityService {
+    private readonly LOGGER = getLogger(DeckBuildabilityService.name);
+
+    constructor(
+        @Inject(InventoryRepositoryPort)
+        private readonly inventoryRepository: InventoryRepositoryPort,
+        @Inject(BuyListService) private readonly buyListService: BuyListService
+    ) {}
+
+    /** Inventory quantities summed by lowercased card name (name-level matching). */
+    async ownedByName(userId: number): Promise<Map<string, number>> {
+        const map = new Map<string, number>();
+        if (!userId) {
+            return map;
+        }
+        const items = await this.inventoryRepository.findAllForExport(userId);
+        for (const item of items) {
+            const name = item.card?.name?.toLowerCase();
+            if (!name) continue;
+            map.set(name, (map.get(name) ?? 0) + item.quantity);
+        }
+        return map;
+    }
+
+    /** Gap for one deck's cards against the user's inventory. */
+    async gapForDeck(cards: DeckCard[], userId: number): Promise<DeckGapSummary> {
+        return DeckGapPolicy.compute(cards, await this.ownedByName(userId));
+    }
+
+    /** Buildability summary per deck id (one inventory load), for list ranking. */
+    async summariesForDecks(decks: Deck[], userId: number): Promise<Map<number, DeckGapSummary>> {
+        const owned = await this.ownedByName(userId);
+        const out = new Map<number, DeckGapSummary>();
+        for (const deck of decks) {
+            if (deck.id != null) {
+                out.set(deck.id, DeckGapPolicy.compute(deck.cards ?? [], owned));
+            }
+        }
+        return out;
+    }
+
+    /** Seed the user's buy-list with the cards missing from a deck. Returns count added. */
+    async addMissingToBuyList(cards: DeckCard[], userId: number): Promise<number> {
+        const gap = await this.gapForDeck(cards, userId);
+        for (const { cardId, quantity } of gap.missingByCard) {
+            await this.buyListService.add(userId, cardId, false, quantity);
+        }
+        this.LOGGER.debug(`seeded buy-list with ${gap.missingByCard.length} cards for user ${userId}.`);
+        return gap.missingByCard.length;
+    }
+}

--- a/src/core/deck/deck-gap.policy.ts
+++ b/src/core/deck/deck-gap.policy.ts
@@ -1,0 +1,105 @@
+import { DeckCard } from './deck-card.entity';
+
+/** Per-card ownership attribution within a deck-vs-inventory comparison. */
+export interface DeckCardGap {
+    cardId: string;
+    isSideboard: boolean;
+    need: number;
+    owned: number;
+    missing: number;
+    /** Basic lands are treated as always owned and excluded from the totals. */
+    isBasic: boolean;
+}
+
+export interface DeckGapSummary {
+    /** Total non-basic copies the deck needs (main + sideboard). */
+    neededCount: number;
+    /** Non-basic copies the user owns, capped at what the deck needs. */
+    ownedCount: number;
+    missingCount: number;
+    /** 0-100; 100 when the deck needs nothing beyond basics. */
+    completeness: number;
+    perCard: DeckCardGap[];
+    /** Distinct missing cards aggregated by representative printing. */
+    missingByCard: { cardId: string; quantity: number }[];
+}
+
+/**
+ * Compare a deck's cards against an inventory owned-by-name map (name-level:
+ * any printing satisfies a need). Basic lands count as always owned. Need for a
+ * card name is pooled across main + sideboard, since those are physically
+ * distinct copies at a table.
+ */
+export class DeckGapPolicy {
+    static isBasic(type?: string): boolean {
+        return !!type && type.includes('Basic');
+    }
+
+    static compute(cards: DeckCard[], ownedByName: Map<string, number>): DeckGapSummary {
+        // Remaining inventory per name, drawn down as we attribute ownership.
+        const remaining = new Map<string, number>();
+        for (const [name, qty] of ownedByName) {
+            remaining.set(name, qty);
+        }
+
+        let neededCount = 0;
+        let ownedCount = 0;
+        const perCard: DeckCardGap[] = [];
+        const missingByCard = new Map<string, number>();
+
+        for (const dc of cards) {
+            const type = dc.card?.type;
+            const isBasic = DeckGapPolicy.isBasic(type);
+            const need = dc.quantity;
+
+            if (isBasic) {
+                perCard.push({
+                    cardId: dc.cardId,
+                    isSideboard: dc.isSideboard,
+                    need,
+                    owned: need,
+                    missing: 0,
+                    isBasic: true,
+                });
+                continue;
+            }
+
+            const nameKey = (dc.card?.name ?? '').toLowerCase();
+            const have = remaining.get(nameKey) ?? 0;
+            const owned = Math.min(need, have);
+            remaining.set(nameKey, have - owned);
+            const missing = need - owned;
+
+            neededCount += need;
+            ownedCount += owned;
+            if (missing > 0) {
+                missingByCard.set(dc.cardId, (missingByCard.get(dc.cardId) ?? 0) + missing);
+            }
+
+            perCard.push({
+                cardId: dc.cardId,
+                isSideboard: dc.isSideboard,
+                need,
+                owned,
+                missing,
+                isBasic: false,
+            });
+        }
+
+        const missingCount = neededCount - ownedCount;
+        const completeness =
+            neededCount === 0 ? 100 : Math.round((ownedCount / neededCount) * 100);
+
+        return {
+            neededCount,
+            ownedCount,
+            missingCount,
+            completeness,
+            perCard,
+            missingByCard: [...missingByCard.entries()].map(([cardId, quantity]) => ({
+                cardId,
+                quantity,
+            })),
+        };
+    }
+}

--- a/src/core/deck/deck-import.service.ts
+++ b/src/core/deck/deck-import.service.ts
@@ -1,0 +1,94 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Format } from 'src/core/card/format.enum';
+import { CardImportResolver } from 'src/core/import/card-import-resolver';
+import { MAX_IMPORT_ROWS } from 'src/core/import/import.constants';
+import { ImportError } from 'src/core/import/import.types';
+import { parseDecklistText } from 'src/core/import/parsers/decklist-text.parser';
+import { getLogger } from 'src/logger/global-app-logger';
+import { DeckService } from './deck.service';
+
+export interface DeckImportResult {
+    deckId: number;
+    name: string;
+    /** Total card quantity added across resolved lines. */
+    saved: number;
+    /** Lines that could not be parsed or resolved. */
+    errors: ImportError[];
+}
+
+@Injectable()
+export class DeckImportService {
+    private readonly LOGGER = getLogger(DeckImportService.name);
+
+    constructor(
+        @Inject(DeckService) private readonly deckService: DeckService,
+        @Inject(CardImportResolver) private readonly cardResolver: CardImportResolver
+    ) {}
+
+    /**
+     * Create a deck from pasted decklist text. Each line is resolved to a card
+     * (set-coded lines precisely, set-less lines by name); unresolved lines are
+     * reported but don't block the import.
+     */
+    async importDecklist(
+        userId: number,
+        name: string,
+        format: Format | null,
+        text: string
+    ): Promise<DeckImportResult> {
+        const { rows, errors } = parseDecklistText(text);
+        const cappedRows = rows.slice(0, MAX_IMPORT_ROWS);
+        if (rows.length > MAX_IMPORT_ROWS) {
+            errors.push({
+                row: 0,
+                error: `Decklist exceeds ${MAX_IMPORT_ROWS} lines; only the first ${MAX_IMPORT_ROWS} were imported`,
+            });
+        }
+
+        // Aggregate by (cardId, board) so one INSERT never touches a conflict
+        // row twice (Postgres rejects that) and duplicate lines sum cleanly.
+        const entries = new Map<string, { cardId: string; isSideboard: boolean; quantity: number }>();
+        for (const row of cappedRows) {
+            const { card, error } = await this.resolveRow(row);
+            if (error || !card) {
+                errors.push({ row: row.line, name: row.name, error: error ?? 'Card not found' });
+                continue;
+            }
+            const key = `${card.id}|${row.isSideboard}`;
+            const existing = entries.get(key);
+            if (existing) {
+                existing.quantity += row.quantity;
+            } else {
+                entries.set(key, {
+                    cardId: card.id,
+                    isSideboard: row.isSideboard,
+                    quantity: row.quantity,
+                });
+            }
+        }
+
+        const deck = await this.deckService.createDeck(userId, name, format);
+        const entryList = [...entries.values()];
+        await this.deckService.addCards(deck.id!, userId, entryList);
+
+        const saved = entryList.reduce((sum, e) => sum + e.quantity, 0);
+        this.LOGGER.debug(
+            `imported deck ${deck.id} for user ${userId}: ${saved} cards, ${errors.length} errors.`
+        );
+        return { deckId: deck.id!, name: deck.name, saved, errors };
+    }
+
+    private async resolveRow(row: { name: string; setCode?: string; number?: string }) {
+        if (row.setCode) {
+            const byPrinting = row.number
+                ? await this.cardResolver.resolveCard({ set_code: row.setCode, number: row.number })
+                : await this.cardResolver.resolveCard({ name: row.name, set_code: row.setCode });
+            if (byPrinting.card) {
+                return byPrinting;
+            }
+            // Unknown/odd set code: fall back to name-level so the line still resolves.
+            return this.cardResolver.resolveByName(row.name);
+        }
+        return this.cardResolver.resolveByName(row.name);
+    }
+}

--- a/src/core/deck/deck.module.ts
+++ b/src/core/deck/deck.module.ts
@@ -1,12 +1,16 @@
 import { Module } from '@nestjs/common';
+import { BuyListModule } from 'src/core/buy-list/buy-list.module';
+import { ImportModule } from 'src/core/import/import.module';
 import { DatabaseModule } from 'src/database/database.module';
 import { getLogger } from 'src/logger/global-app-logger';
+import { DeckBuildabilityService } from './deck-buildability.service';
+import { DeckImportService } from './deck-import.service';
 import { DeckService } from './deck.service';
 
 @Module({
-    imports: [DatabaseModule],
-    providers: [DeckService],
-    exports: [DeckService],
+    imports: [DatabaseModule, ImportModule, BuyListModule],
+    providers: [DeckService, DeckImportService, DeckBuildabilityService],
+    exports: [DeckService, DeckImportService, DeckBuildabilityService],
 })
 export class DeckModule {
     private readonly LOGGER = getLogger(DeckModule.name);

--- a/src/core/deck/deck.service.ts
+++ b/src/core/deck/deck.service.ts
@@ -74,6 +74,20 @@ export class DeckService {
         await this.repository.addCard(deckId, cardId, isSideboard, quantity);
     }
 
+    /** Bulk-add card entries (summing quantity on conflict). Used by import / clone. */
+    async addCards(
+        deckId: number,
+        userId: number,
+        entries: { cardId: string; isSideboard: boolean; quantity: number }[]
+    ): Promise<void> {
+        await this.assertOwner(deckId, userId);
+        const valid = entries.filter((e) => e.quantity > 0);
+        if (valid.length === 0) {
+            return;
+        }
+        await this.repository.addCards(deckId, valid);
+    }
+
     /** Set the absolute quantity for a card entry; quantity <= 0 removes it. */
     async setCardQuantity(
         deckId: number,

--- a/src/core/deck/ports/deck.repository.port.ts
+++ b/src/core/deck/ports/deck.repository.port.ts
@@ -31,6 +31,15 @@ export interface DeckRepositoryPort {
      */
     addCard(deckId: number, cardId: string, isSideboard: boolean, delta: number): Promise<number>;
 
+    /**
+     * Add many card entries in one statement, summing quantity on conflict
+     * (same semantics as addCard). Used by decklist import.
+     */
+    addCards(
+        deckId: number,
+        entries: { cardId: string; isSideboard: boolean; quantity: number }[]
+    ): Promise<void>;
+
     /** Set the absolute quantity for a card entry. */
     setCardQuantity(
         deckId: number,

--- a/src/core/import/card-import-resolver.ts
+++ b/src/core/import/card-import-resolver.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Card } from 'src/core/card/card.entity';
 import { CardRepositoryPort } from 'src/core/card/ports/card.repository.port';
+import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { SetRepositoryPort } from 'src/core/set/ports/set.repository.port';
 import { parseBool } from './import.types';
 
@@ -91,6 +92,46 @@ export class CardImportResolver {
         } catch (e) {
             return { card: null, error: `Lookup error: ${e.message}` };
         }
+    }
+
+    /**
+     * Resolve a card by name alone (set-less decklist line), returning a
+     * representative printing. Decklist gap math is name-level, so the exact
+     * printing is immaterial for ownership; we pick the cheapest printing that
+     * has a price so the deck's estimated value stays budget-realistic.
+     */
+    async resolveByName(name: string): Promise<CardResolveResult> {
+        try {
+            const cleaned = name?.trim();
+            if (!cleaned) {
+                return { card: null, error: 'Empty card name' };
+            }
+            const matches = await this.cardRepository.findWithName(
+                cleaned,
+                new SafeQueryOptions({ limit: '500' })
+            );
+            if (matches.length === 0) {
+                return { card: null, error: `Card not found: "${cleaned}"` };
+            }
+            return { card: this.pickRepresentative(matches), error: null };
+        } catch (e) {
+            return { card: null, error: `Lookup error: ${e.message}` };
+        }
+    }
+
+    /** Cheapest printing with a price, falling back to any (last = cheapest). */
+    private pickRepresentative(cards: Card[]): Card {
+        let best: Card | null = null;
+        let bestValue = Infinity;
+        for (const card of cards) {
+            const price = card.prices?.[0];
+            const value = price ? (price.normal ?? price.foil ?? 0) : 0;
+            if (value > 0 && value < bestValue) {
+                bestValue = value;
+                best = card;
+            }
+        }
+        return best ?? cards[cards.length - 1];
     }
 
     resolveFoil(foilValue: string | undefined, card: Card): boolean | null {

--- a/src/core/import/card-import-resolver.ts
+++ b/src/core/import/card-import-resolver.ts
@@ -119,19 +119,30 @@ export class CardImportResolver {
         }
     }
 
-    /** Cheapest printing with a price, falling back to any (last = cheapest). */
+    /**
+     * Cheapest printing with a price, deterministic on ties. `findWithName`
+     * orders by price with no secondary key, so equal/NULL prices come back in
+     * arbitrary DB order; tie-breaking on card id keeps the chosen representative
+     * (and the cardId stored in the deck) stable across imports.
+     */
     private pickRepresentative(cards: Card[]): Card {
-        let best: Card | null = null;
-        let bestValue = Infinity;
+        let best = cards[0];
+        let bestValue = this.priceValue(best);
         for (const card of cards) {
-            const price = card.prices?.[0];
-            const value = price ? (price.normal ?? price.foil ?? 0) : 0;
-            if (value > 0 && value < bestValue) {
-                bestValue = value;
+            const value = this.priceValue(card);
+            if (value < bestValue || (value === bestValue && card.id < best.id)) {
                 best = card;
+                bestValue = value;
             }
         }
-        return best ?? cards[cards.length - 1];
+        return best;
+    }
+
+    /** A printing's price for representative selection; unpriced sorts last. */
+    private priceValue(card: Card): number {
+        const price = card.prices?.[0];
+        const value = price ? (price.normal ?? price.foil ?? 0) : 0;
+        return value > 0 ? value : Infinity;
     }
 
     resolveFoil(foilValue: string | undefined, card: Card): boolean | null {

--- a/src/core/import/parsers/decklist-text.parser.ts
+++ b/src/core/import/parsers/decklist-text.parser.ts
@@ -1,0 +1,105 @@
+import { ImportError } from 'src/core/import/import.types';
+
+/** One resolvable line of a pasted decklist. */
+export interface ParsedDeckLine {
+    quantity: number;
+    name: string;
+    setCode?: string;
+    number?: string;
+    isSideboard: boolean;
+    /** 1-based source line, for error reporting. */
+    line: number;
+}
+
+export interface ParsedDecklist {
+    rows: ParsedDeckLine[];
+    errors: ImportError[];
+}
+
+// "Sideboard" header switches subsequent lines to the sideboard (optionally
+// prefixed with // or #, as some exports do).
+const SIDEBOARD_HEADER = /^(?:\/\/|#)?\s*sideboard\b/i;
+// A per-line "SB:" prefix (Magic Workstation style) marks a single sideboard line.
+const SB_PREFIX = /^SB:\s*/i;
+// An entry leads with a count: "4 Name", "4x Name", "4 x Name".
+const ENTRY = /^(\d+)\s*[xX]?\s+(.+?)\s*$/;
+// Name with an optional (SET)/[SET] code and an optional collector number,
+// e.g. "Sol Ring (CMR) 263" or "Lightning Bolt [2X2]".
+const SET_SUFFIX = /^(.*?)\s*[([]([A-Za-z0-9]{2,6})[)\]](?:\s+([A-Za-z0-9-]+))?\s*$/;
+// MTGO foil/etched markers trailing a line: "... *F*" / "... *E*".
+const FOIL_MARKER = /\s*\*[fe]\*\s*$/i;
+
+/**
+ * Parse a pasted decklist in the common text formats people share online
+ * (Arena, Moxfield, MTGGoldfish, Archidekt copy-export). Lines that don't lead
+ * with a count are treated as section headers / comments and skipped, since
+ * every common export prefixes entries with a quantity. A "Sideboard" header
+ * (or a per-line "SB:" prefix) routes cards to the sideboard.
+ *
+ * Card resolution (name -> printing) happens later in the import service; this
+ * parser only structures the text. `errors` carries lines that look like an
+ * entry (lead with digits) but can't be parsed.
+ */
+export function parseDecklistText(text: string): ParsedDecklist {
+    const rows: ParsedDeckLine[] = [];
+    const errors: ImportError[] = [];
+    let sideboard = false;
+
+    const lines = (text ?? '').split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+        const lineNum = i + 1;
+        const raw = lines[i].trim();
+        if (!raw) continue;
+
+        if (SIDEBOARD_HEADER.test(raw)) {
+            sideboard = true;
+            continue;
+        }
+
+        let body = raw;
+        let lineSideboard = sideboard;
+        if (SB_PREFIX.test(body)) {
+            body = body.replace(SB_PREFIX, '');
+            lineSideboard = true;
+        }
+
+        const entry = ENTRY.exec(body);
+        if (!entry) {
+            // Lines that begin with a digit looked like an entry but didn't
+            // parse; everything else is a header/comment we silently skip.
+            if (/^\d/.test(body)) {
+                errors.push({ row: lineNum, error: `Could not parse line: "${raw}"` });
+            }
+            continue;
+        }
+
+        const quantity = parseInt(entry[1], 10);
+        if (!quantity || quantity < 1) continue;
+
+        let remainder = entry[2].replace(FOIL_MARKER, '').trim();
+        let setCode: string | undefined;
+        let number: string | undefined;
+        const suffix = SET_SUFFIX.exec(remainder);
+        if (suffix) {
+            remainder = suffix[1].trim();
+            setCode = suffix[2].toLowerCase();
+            number = suffix[3];
+        }
+
+        if (!remainder) {
+            errors.push({ row: lineNum, error: `Missing card name on line: "${raw}"` });
+            continue;
+        }
+
+        rows.push({
+            quantity,
+            name: remainder,
+            setCode,
+            number,
+            isSideboard: lineSideboard,
+            line: lineNum,
+        });
+    }
+
+    return { rows, errors };
+}

--- a/src/core/published-deck/ports/published-deck.repository.port.ts
+++ b/src/core/published-deck/ports/published-deck.repository.port.ts
@@ -1,0 +1,26 @@
+import { PublishedDeck } from '../published-deck.entity';
+
+export const PublishedDeckRepositoryPort = 'PublishedDeckRepositoryPort';
+
+export interface PublishedDeckListFilter {
+    format?: string;
+    limit: number;
+    offset: number;
+}
+
+/**
+ * Read-only access to the published tournament-deck catalog (Scry writes it).
+ */
+export interface PublishedDeckRepositoryPort {
+    /** A page of published decks (with cards + latest price), newest tournament first. */
+    findPage(filter: PublishedDeckListFilter): Promise<PublishedDeck[]>;
+
+    /** Total decks matching the filter (for pagination). */
+    count(filter: { format?: string }): Promise<number>;
+
+    /** One published deck with its cards (+ set + legalities + latest price), or null. */
+    findById(id: number): Promise<PublishedDeck | null>;
+
+    /** Distinct non-null formats present, for the browse filter. */
+    distinctFormats(): Promise<string[]>;
+}

--- a/src/core/published-deck/published-deck.entity.ts
+++ b/src/core/published-deck/published-deck.entity.ts
@@ -1,0 +1,34 @@
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { validateInit } from 'src/core/validation.util';
+
+/**
+ * A published tournament decklist (10.7 / #537). Read-only catalog data Scry
+ * ingests from external feeds. Cards reuse the DeckCard value object so the
+ * buildability/gap policy applies unchanged.
+ */
+export class PublishedDeck {
+    readonly id?: number;
+    readonly source: string;
+    readonly sourceUri: string;
+    readonly tournamentName?: string | null;
+    readonly tournamentDate?: Date | null;
+    readonly format?: string | null;
+    readonly archetype?: string | null;
+    readonly player?: string | null;
+    readonly result?: string | null;
+    readonly cards?: DeckCard[];
+
+    constructor(init: Partial<PublishedDeck>) {
+        validateInit(init, ['source', 'sourceUri']);
+        this.id = init.id;
+        this.source = init.source;
+        this.sourceUri = init.sourceUri;
+        this.tournamentName = init.tournamentName ?? null;
+        this.tournamentDate = init.tournamentDate ?? null;
+        this.format = init.format ?? null;
+        this.archetype = init.archetype ?? null;
+        this.player = init.player ?? null;
+        this.result = init.result ?? null;
+        this.cards = init.cards;
+    }
+}

--- a/src/core/published-deck/published-deck.module.ts
+++ b/src/core/published-deck/published-deck.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/database/database.module';
+import { getLogger } from 'src/logger/global-app-logger';
+import { PublishedDeckService } from './published-deck.service';
+
+@Module({
+    imports: [DatabaseModule],
+    providers: [PublishedDeckService],
+    exports: [PublishedDeckService],
+})
+export class PublishedDeckModule {
+    private readonly LOGGER = getLogger(PublishedDeckModule.name);
+
+    constructor() {
+        this.LOGGER.log('Initialized');
+    }
+}

--- a/src/core/published-deck/published-deck.service.ts
+++ b/src/core/published-deck/published-deck.service.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { getLogger } from 'src/logger/global-app-logger';
+import { PublishedDeck } from './published-deck.entity';
+import { PublishedDeckRepositoryPort } from './ports/published-deck.repository.port';
+
+@Injectable()
+export class PublishedDeckService {
+    private readonly LOGGER = getLogger(PublishedDeckService.name);
+
+    constructor(
+        @Inject(PublishedDeckRepositoryPort)
+        private readonly repository: PublishedDeckRepositoryPort
+    ) {}
+
+    /** A page of published decks plus the total for pagination. */
+    async list(
+        format: string | undefined,
+        limit: number,
+        offset: number
+    ): Promise<{ decks: PublishedDeck[]; total: number }> {
+        const [decks, total] = await Promise.all([
+            this.repository.findPage({ format, limit, offset }),
+            this.repository.count({ format }),
+        ]);
+        return { decks, total };
+    }
+
+    async get(id: number): Promise<PublishedDeck | null> {
+        return this.repository.findById(id);
+    }
+
+    async formats(): Promise<string[]> {
+        return this.repository.distinctFormats();
+    }
+}

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -30,6 +30,10 @@ import { BuyListRepository } from './buy-list/buy-list.repository';
 import { DeckOrmEntity } from './deck/deck.orm-entity';
 import { DeckCardOrmEntity } from './deck/deck-card.orm-entity';
 import { DeckRepository } from './deck/deck.repository';
+import { PublishedDeckRepositoryPort } from 'src/core/published-deck/ports/published-deck.repository.port';
+import { PublishedDeckOrmEntity } from './published-deck/published-deck.orm-entity';
+import { PublishedDeckCardOrmEntity } from './published-deck/published-deck-card.orm-entity';
+import { PublishedDeckRepository } from './published-deck/published-deck.repository';
 import { PasswordResetOrmEntity } from './password-reset/password-reset.orm-entity';
 import { PasswordResetRepository } from './password-reset/password-reset.repository';
 import { GranularPriceOrmEntity } from './granular-price/granular-price.orm-entity';
@@ -85,6 +89,8 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
             BuyListOrmEntity,
             DeckOrmEntity,
             DeckCardOrmEntity,
+            PublishedDeckOrmEntity,
+            PublishedDeckCardOrmEntity,
             LegalityOrmEntity,
             PasswordResetOrmEntity,
             GranularPriceOrmEntity,
@@ -118,6 +124,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         { provide: InventoryRepositoryPort, useClass: InventoryRepository },
         { provide: BuyListRepositoryPort, useClass: BuyListRepository },
         { provide: DeckRepositoryPort, useClass: DeckRepository },
+        { provide: PublishedDeckRepositoryPort, useClass: PublishedDeckRepository },
         { provide: PasswordResetRepositoryPort, useClass: PasswordResetRepository },
         { provide: SetPriceHistoryRepositoryPort, useClass: SetPriceHistoryRepository },
         { provide: SetRepositoryPort, useClass: SetRepository },
@@ -146,6 +153,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         InventoryRepositoryPort,
         BuyListRepositoryPort,
         DeckRepositoryPort,
+        PublishedDeckRepositoryPort,
         PasswordResetRepositoryPort,
         SetPriceHistoryRepositoryPort,
         SetRepositoryPort,

--- a/src/database/deck/deck.repository.ts
+++ b/src/database/deck/deck.repository.ts
@@ -92,6 +92,32 @@ export class DeckRepository implements DeckRepositoryPort {
         return Number(rows[0]?.quantity ?? delta);
     }
 
+    async addCards(
+        deckId: number,
+        entries: { cardId: string; isSideboard: boolean; quantity: number }[]
+    ): Promise<void> {
+        if (entries.length === 0) {
+            return;
+        }
+        // One multi-row upsert; $1 is the deck id, each entry contributes a triplet.
+        const params: unknown[] = [deckId];
+        const values = entries
+            .map((e) => {
+                const base = params.length;
+                params.push(e.cardId, e.isSideboard, e.quantity);
+                return `($1, $${base + 1}, $${base + 2}, $${base + 3})`;
+            })
+            .join(', ');
+        await this.repository.query(
+            `INSERT INTO deck_card (deck_id, card_id, is_sideboard, quantity)
+             VALUES ${values}
+             ON CONFLICT (deck_id, card_id, is_sideboard)
+             DO UPDATE SET quantity = deck_card.quantity + EXCLUDED.quantity`,
+            params
+        );
+        await this.touch(deckId);
+    }
+
     async setCardQuantity(
         deckId: number,
         cardId: string,

--- a/src/database/published-deck/published-deck-card.orm-entity.ts
+++ b/src/database/published-deck/published-deck-card.orm-entity.ts
@@ -1,0 +1,34 @@
+import { CardOrmEntity } from 'src/database/card/card.orm-entity';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { PublishedDeckOrmEntity } from './published-deck.orm-entity';
+
+@Entity('published_deck_card')
+export class PublishedDeckCardOrmEntity {
+    @PrimaryColumn({ name: 'published_deck_id' })
+    publishedDeckId: number;
+
+    @PrimaryColumn({ name: 'card_id' })
+    cardId: string;
+
+    @PrimaryColumn({ name: 'is_sideboard', type: 'boolean' })
+    isSideboard: boolean;
+
+    @Column({ type: 'int', default: 1 })
+    quantity: number;
+
+    @ManyToOne(() => PublishedDeckOrmEntity, (deck) => deck.cards, { onDelete: 'CASCADE' })
+    @JoinColumn({
+        name: 'published_deck_id',
+        referencedColumnName: 'id',
+        foreignKeyConstraintName: 'fk_published_deck_card_deck',
+    })
+    deck: PublishedDeckOrmEntity;
+
+    @ManyToOne(() => CardOrmEntity, { onDelete: 'CASCADE' })
+    @JoinColumn({
+        name: 'card_id',
+        referencedColumnName: 'id',
+        foreignKeyConstraintName: 'fk_published_deck_card_card',
+    })
+    card: CardOrmEntity;
+}

--- a/src/database/published-deck/published-deck.mapper.ts
+++ b/src/database/published-deck/published-deck.mapper.ts
@@ -1,0 +1,32 @@
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { PublishedDeck } from 'src/core/published-deck/published-deck.entity';
+import { CardMapper } from 'src/database/card/card.mapper';
+import { PublishedDeckCardOrmEntity } from './published-deck-card.orm-entity';
+import { PublishedDeckOrmEntity } from './published-deck.orm-entity';
+
+export class PublishedDeckMapper {
+    static toCore(orm: PublishedDeckOrmEntity): PublishedDeck {
+        return new PublishedDeck({
+            id: orm.id,
+            source: orm.source,
+            sourceUri: orm.sourceUri,
+            tournamentName: orm.tournamentName,
+            // `date` columns come back as YYYY-MM-DD strings; keep them as a Date.
+            tournamentDate: orm.tournamentDate ? new Date(orm.tournamentDate) : null,
+            format: orm.format,
+            archetype: orm.archetype,
+            player: orm.player,
+            result: orm.result,
+            cards: orm.cards ? orm.cards.map((c) => PublishedDeckMapper.cardToCore(c)) : undefined,
+        });
+    }
+
+    static cardToCore(orm: PublishedDeckCardOrmEntity): DeckCard {
+        return new DeckCard({
+            cardId: orm.cardId,
+            quantity: orm.quantity,
+            isSideboard: orm.isSideboard,
+            card: orm.card ? CardMapper.toCore(orm.card) : undefined,
+        });
+    }
+}

--- a/src/database/published-deck/published-deck.orm-entity.ts
+++ b/src/database/published-deck/published-deck.orm-entity.ts
@@ -1,0 +1,35 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { PublishedDeckCardOrmEntity } from './published-deck-card.orm-entity';
+
+@Entity('published_deck')
+export class PublishedDeckOrmEntity {
+    @PrimaryGeneratedColumn('identity')
+    id: number;
+
+    @Column()
+    source: string;
+
+    @Column({ name: 'source_uri' })
+    sourceUri: string;
+
+    @Column({ name: 'tournament_name', nullable: true })
+    tournamentName: string | null;
+
+    @Column({ name: 'tournament_date', type: 'date', nullable: true })
+    tournamentDate: string | null;
+
+    @Column({ nullable: true })
+    format: string | null;
+
+    @Column({ nullable: true })
+    archetype: string | null;
+
+    @Column({ nullable: true })
+    player: string | null;
+
+    @Column({ nullable: true })
+    result: string | null;
+
+    @OneToMany(() => PublishedDeckCardOrmEntity, (c) => c.deck)
+    cards: PublishedDeckCardOrmEntity[];
+}

--- a/src/database/published-deck/published-deck.repository.ts
+++ b/src/database/published-deck/published-deck.repository.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PublishedDeck } from 'src/core/published-deck/published-deck.entity';
+import {
+    PublishedDeckListFilter,
+    PublishedDeckRepositoryPort,
+} from 'src/core/published-deck/ports/published-deck.repository.port';
+import { getLogger } from 'src/logger/global-app-logger';
+import { Repository } from 'typeorm';
+import { PublishedDeckMapper } from './published-deck.mapper';
+import { PublishedDeckOrmEntity } from './published-deck.orm-entity';
+
+const LATEST_PRICE = 'prices.date = (SELECT MAX(p2.date) FROM price p2 WHERE p2.card_id = card.id)';
+
+@Injectable()
+export class PublishedDeckRepository implements PublishedDeckRepositoryPort {
+    private readonly LOGGER = getLogger(PublishedDeckRepository.name);
+
+    constructor(
+        @InjectRepository(PublishedDeckOrmEntity)
+        private readonly repository: Repository<PublishedDeckOrmEntity>
+    ) {}
+
+    async findPage(filter: PublishedDeckListFilter): Promise<PublishedDeck[]> {
+        // Page the decks first (so limit/offset count decks, not joined rows),
+        // then load their cards + latest price for counts/value.
+        const pageQb = this.repository
+            .createQueryBuilder('deck')
+            .orderBy('deck.tournamentDate', 'DESC')
+            .addOrderBy('deck.id', 'DESC')
+            .take(filter.limit)
+            .skip(filter.offset);
+        if (filter.format) {
+            pageQb.where('deck.format = :format', { format: filter.format });
+        }
+        const ids = (await pageQb.getMany()).map((d) => d.id);
+        if (ids.length === 0) {
+            return [];
+        }
+
+        const decks = await this.repository
+            .createQueryBuilder('deck')
+            .leftJoinAndSelect('deck.cards', 'dc')
+            .leftJoinAndSelect('dc.card', 'card')
+            .leftJoinAndSelect('card.prices', 'prices', LATEST_PRICE)
+            .where('deck.id IN (:...ids)', { ids })
+            .orderBy('deck.tournamentDate', 'DESC')
+            .addOrderBy('deck.id', 'DESC')
+            .getMany();
+        return decks.map((d) => PublishedDeckMapper.toCore(d));
+    }
+
+    async count(filter: { format?: string }): Promise<number> {
+        const qb = this.repository.createQueryBuilder('deck');
+        if (filter.format) {
+            qb.where('deck.format = :format', { format: filter.format });
+        }
+        return qb.getCount();
+    }
+
+    async findById(id: number): Promise<PublishedDeck | null> {
+        const deck = await this.repository
+            .createQueryBuilder('deck')
+            .leftJoinAndSelect('deck.cards', 'dc')
+            .leftJoinAndSelect('dc.card', 'card')
+            .leftJoinAndSelect('card.set', 'set')
+            .leftJoinAndSelect('card.legalities', 'legalities')
+            .leftJoinAndSelect('card.prices', 'prices', LATEST_PRICE)
+            .where('deck.id = :id', { id })
+            .addOrderBy('card.name', 'ASC')
+            .getOne();
+        return deck ? PublishedDeckMapper.toCore(deck) : null;
+    }
+
+    async distinctFormats(): Promise<string[]> {
+        const rows = await this.repository
+            .createQueryBuilder('deck')
+            .select('DISTINCT deck.format', 'format')
+            .where('deck.format IS NOT NULL')
+            .orderBy('deck.format', 'ASC')
+            .getRawMany<{ format: string }>();
+        return rows.map((r) => r.format);
+    }
+}

--- a/src/http/api/deck/deck-api.controller.ts
+++ b/src/http/api/deck/deck-api.controller.ts
@@ -15,6 +15,8 @@ import {
     UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
+import { DeckImportService } from 'src/core/deck/deck-import.service';
 import { DeckService } from 'src/core/deck/deck.service';
 import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
@@ -26,16 +28,26 @@ import {
     DeckCardRemoveApiDto,
     DeckCardSetQuantityApiDto,
     DeckCreateApiDto,
+    DeckImportApiDto,
     DeckUpdateApiDto,
 } from './dto/deck-request-api.dto';
-import { DeckDetailApiDto, DeckSummaryApiDto } from './dto/deck-response.dto';
+import {
+    DeckDetailApiDto,
+    DeckImportApiResultDto,
+    DeckSummaryApiDto,
+} from './dto/deck-response.dto';
 
 @ApiTags('Decks')
 @ApiBearerAuth()
 @Controller('api/v1/decks')
 @UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
 export class DeckApiController {
-    constructor(@Inject(DeckService) private readonly deckService: DeckService) {}
+    constructor(
+        @Inject(DeckService) private readonly deckService: DeckService,
+        @Inject(DeckImportService) private readonly deckImportService: DeckImportService,
+        @Inject(DeckBuildabilityService)
+        private readonly buildabilityService: DeckBuildabilityService
+    ) {}
 
     @Get()
     @ApiOperation({ summary: "List the authenticated user's decks" })
@@ -56,6 +68,23 @@ export class DeckApiController {
         return ApiResponseDto.ok(DeckApiPresenter.toDetail(deck));
     }
 
+    @Post('import')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Create a deck from pasted decklist text' })
+    @ApiResponse({ status: 200, description: 'Import result with the new deck id + unresolved lines' })
+    async import(
+        @Body() dto: DeckImportApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<DeckImportApiResultDto>> {
+        const result = await this.deckImportService.importDecklist(
+            req.user.id,
+            dto.name,
+            dto.format ?? null,
+            dto.text
+        );
+        return ApiResponseDto.ok(result);
+    }
+
     @Get(':id')
     @ApiOperation({ summary: 'Get a deck with its cards' })
     @ApiResponse({ status: 200, description: 'Deck detail' })
@@ -69,6 +98,26 @@ export class DeckApiController {
             throw new NotFoundException(`Deck ${id} not found.`);
         }
         return ApiResponseDto.ok(DeckApiPresenter.toDetail(deck));
+    }
+
+    @Post(':id/missing-to-buy-list')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: "Add the deck's missing cards (vs. inventory) to the buy-list" })
+    @ApiResponse({ status: 200, description: 'Count of distinct cards added' })
+    @ApiResponse({ status: 404, description: 'Deck not found' })
+    async missingToBuyList(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ added: number }>> {
+        const deck = await this.deckService.getDeck(id, req.user.id);
+        if (!deck) {
+            throw new NotFoundException(`Deck ${id} not found.`);
+        }
+        const added = await this.buildabilityService.addMissingToBuyList(
+            deck.cards ?? [],
+            req.user.id
+        );
+        return ApiResponseDto.ok({ added });
     }
 
     @Patch(':id')

--- a/src/http/api/deck/dto/deck-request-api.dto.ts
+++ b/src/http/api/deck/dto/deck-request-api.dto.ts
@@ -26,6 +26,22 @@ export class DeckUpdateApiDto {
     readonly format?: Format;
 }
 
+/** Create a deck from pasted decklist text. */
+export class DeckImportApiDto {
+    @ApiProperty()
+    @IsString()
+    readonly name: string;
+
+    @ApiPropertyOptional({ enum: Format, description: 'Target format (omit for no format).' })
+    @IsOptional()
+    @IsEnum(Format)
+    readonly format?: Format;
+
+    @ApiProperty({ description: 'Decklist text, one entry per line (e.g. "4 Lightning Bolt").' })
+    @IsString()
+    readonly text: string;
+}
+
 /** Add a card to a deck (increments quantity for card + board). */
 export class DeckCardAddApiDto {
     @ApiProperty()

--- a/src/http/api/deck/dto/deck-response.dto.ts
+++ b/src/http/api/deck/dto/deck-response.dto.ts
@@ -73,6 +73,24 @@ export class DeckSummaryApiDto {
     readonly updatedAt: string;
 }
 
+/** Result of a decklist text import. */
+export class DeckImportApiResultDto {
+    @ApiProperty({ description: 'Id of the created deck.' })
+    readonly deckId: number;
+
+    @ApiProperty()
+    readonly name: string;
+
+    @ApiProperty({ description: 'Total card quantity added across resolved lines.' })
+    readonly saved: number;
+
+    @ApiProperty({
+        type: [Object],
+        description: 'Lines that could not be parsed or resolved ({ row, name?, error }).',
+    })
+    readonly errors: { row: number; name?: string; error: string }[];
+}
+
 /** Full deck with its cards. */
 export class DeckDetailApiDto extends DeckSummaryApiDto {
     @ApiProperty({ description: 'Count of cards not legal in the deck format (0 when no format).' })

--- a/src/http/hbs/deck/deck-grouping.ts
+++ b/src/http/hbs/deck/deck-grouping.ts
@@ -1,0 +1,30 @@
+// Shared maindeck type-grouping used by the user-deck and published-deck pages.
+export const TYPE_ORDER = [
+    'Creature',
+    'Planeswalker',
+    'Instant',
+    'Sorcery',
+    'Artifact',
+    'Enchantment',
+    'Battle',
+    'Land',
+];
+
+export const TYPE_PLURAL: Record<string, string> = {
+    Creature: 'Creatures',
+    Planeswalker: 'Planeswalkers',
+    Instant: 'Instants',
+    Sorcery: 'Sorceries',
+    Artifact: 'Artifacts',
+    Enchantment: 'Enchantments',
+    Battle: 'Battles',
+    Land: 'Lands',
+    Other: 'Other',
+};
+
+/** A card's primary type bucket, in deckbuilder display order. */
+export function primaryType(typeLine: string): string {
+    // MTGJSON type lines use an em dash (U+2014) before subtypes; take the head.
+    const head = (typeLine ?? '').split(String.fromCharCode(0x2014))[0];
+    return TYPE_ORDER.find((t) => head.includes(t)) ?? 'Other';
+}

--- a/src/http/hbs/deck/deck-page.controller.ts
+++ b/src/http/hbs/deck/deck-page.controller.ts
@@ -1,8 +1,24 @@
-import { Controller, Get, Inject, Param, ParseIntPipe, Render, Req, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    Inject,
+    Param,
+    ParseIntPipe,
+    Post,
+    Render,
+    Req,
+    UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { DeckPageOrchestrator } from './deck-page.orchestrator';
-import { DeckDetailViewDto, DeckListViewDto } from './dto/deck.view.dto';
+import {
+    DeckDetailViewDto,
+    DeckImportResultViewDto,
+    DeckImportViewDto,
+    DeckListViewDto,
+} from './dto/deck.view.dto';
 
 @Controller('decks')
 export class DeckPageController {
@@ -15,6 +31,28 @@ export class DeckPageController {
     @Render('decks')
     async list(@Req() req: AuthenticatedRequest): Promise<DeckListViewDto> {
         return this.orchestrator.buildListView(req);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @Get('import')
+    @Render('deckImport')
+    importForm(@Req() req: AuthenticatedRequest): DeckImportViewDto {
+        return this.orchestrator.buildImportView(req);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @Post('import')
+    @Render('deckImportResult')
+    async import(
+        @Body() body: { name?: string; format?: string; text?: string },
+        @Req() req: AuthenticatedRequest
+    ): Promise<DeckImportResultViewDto> {
+        return this.orchestrator.importDecklist(
+            req,
+            body.name ?? '',
+            body.format,
+            body.text ?? ''
+        );
     }
 
     @UseGuards(JwtAuthGuard)

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -1,6 +1,9 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Format } from 'src/core/card/format.enum';
+import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
 import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckCardGap, DeckGapSummary } from 'src/core/deck/deck-gap.policy';
+import { DeckImportService } from 'src/core/deck/deck-import.service';
 import { DeckLegalityPolicy } from 'src/core/deck/deck-legality.policy';
 import { DeckSummaryPolicy } from 'src/core/deck/deck-summary.policy';
 import { Deck } from 'src/core/deck/deck.entity';
@@ -9,36 +12,16 @@ import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { buildCardUrl } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
+import { primaryType, TYPE_ORDER, TYPE_PLURAL } from './deck-grouping';
 import {
     DeckCardGroupView,
     DeckCardView,
     DeckDetailViewDto,
+    DeckImportResultViewDto,
+    DeckImportViewDto,
     DeckListViewDto,
     FormatOptionView,
 } from './dto/deck.view.dto';
-
-// Maindeck grouping: pick a card's primary type, in deckbuilder display order.
-const TYPE_ORDER = [
-    'Creature',
-    'Planeswalker',
-    'Instant',
-    'Sorcery',
-    'Artifact',
-    'Enchantment',
-    'Battle',
-    'Land',
-];
-const TYPE_PLURAL: Record<string, string> = {
-    Creature: 'Creatures',
-    Planeswalker: 'Planeswalkers',
-    Instant: 'Instants',
-    Sorcery: 'Sorceries',
-    Artifact: 'Artifacts',
-    Enchantment: 'Enchantments',
-    Battle: 'Battles',
-    Land: 'Lands',
-    Other: 'Other',
-};
 
 @Injectable()
 export class DeckPageOrchestrator {
@@ -49,12 +32,78 @@ export class DeckPageOrchestrator {
         currency: 'USD',
     });
 
-    constructor(@Inject(DeckService) private readonly deckService: DeckService) {}
+    constructor(
+        @Inject(DeckService) private readonly deckService: DeckService,
+        @Inject(DeckImportService) private readonly deckImportService: DeckImportService,
+        @Inject(DeckBuildabilityService)
+        private readonly buildabilityService: DeckBuildabilityService
+    ) {}
+
+    buildImportView(req: AuthenticatedRequest): DeckImportViewDto {
+        HttpErrorHandler.validateAuthenticatedRequest(req);
+        return new DeckImportViewDto({
+            authenticated: true,
+            title: 'Import deck - I Want My MTG',
+            breadcrumbs: [
+                { label: 'Home', url: '/' },
+                { label: 'Decks', url: '/decks' },
+                { label: 'Import', url: '/decks/import' },
+            ],
+            formatOptions: this.buildFormatOptions(null),
+        });
+    }
+
+    async importDecklist(
+        req: AuthenticatedRequest,
+        name: string,
+        format: string | undefined,
+        text: string
+    ): Promise<DeckImportResultViewDto> {
+        try {
+            HttpErrorHandler.validateAuthenticatedRequest(req);
+            const fmt = Object.values(Format).includes(format as Format)
+                ? (format as Format)
+                : null;
+            const result = await this.deckImportService.importDecklist(
+                req.user.id,
+                name,
+                fmt,
+                text
+            );
+            return new DeckImportResultViewDto({
+                authenticated: true,
+                title: 'Import complete - I Want My MTG',
+                breadcrumbs: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Decks', url: '/decks' },
+                    { label: result.name, url: `/decks/${result.deckId}` },
+                ],
+                deckId: result.deckId,
+                deckName: result.name,
+                deckUrl: `/decks/${result.deckId}`,
+                saved: result.saved,
+                errorCount: result.errors.length,
+                errors: result.errors.map((e) => ({
+                    row: e.row,
+                    name: typeof e.name === 'string' ? e.name : undefined,
+                    error: e.error,
+                })),
+            });
+        } catch (error) {
+            this.LOGGER.debug(`Error importing decklist: ${error?.message}`);
+            return HttpErrorHandler.toHttpException(error, 'importDecklist');
+        }
+    }
 
     async buildListView(req: AuthenticatedRequest): Promise<DeckListViewDto> {
         try {
             HttpErrorHandler.validateAuthenticatedRequest(req);
             const decks = await this.deckService.listDecks(req.user.id);
+            const summaries = await this.buildabilityService.summariesForDecks(decks, req.user.id);
+            // Rank most-buildable first, then fall back to recency (load order).
+            const items = decks
+                .map((d) => this.toListItem(d, summaries.get(d.id!)))
+                .sort((a, b) => b.completeness - a.completeness);
             return new DeckListViewDto({
                 authenticated: true,
                 title: 'Decks - I Want My MTG',
@@ -63,7 +112,7 @@ export class DeckPageOrchestrator {
                     { label: 'Decks', url: '/decks' },
                 ],
                 hasDecks: decks.length > 0,
-                decks: decks.map((d) => this.toListItem(d)),
+                decks: items,
                 formatOptions: this.buildFormatOptions(null),
             });
         } catch (error) {
@@ -86,6 +135,12 @@ export class DeckPageOrchestrator {
                 ? cards.filter((c) => this.isIllegal(deck.format, c)).length
                 : 0;
 
+            const gap = await this.buildabilityService.gapForDeck(cards, req.user.id);
+            const gapByRow = new Map<string, DeckCardGap>();
+            for (const g of gap.perCard) {
+                gapByRow.set(`${g.cardId}|${g.isSideboard}`, g);
+            }
+
             return new DeckDetailViewDto({
                 authenticated: true,
                 title: `${deck.name} - Decks - I Want My MTG`,
@@ -99,13 +154,18 @@ export class DeckPageOrchestrator {
                 format: deck.format ?? null,
                 formatLabel: deck.format ? this.capitalize(deck.format) : 'No format',
                 formatOptions: this.buildFormatOptions(deck.format ?? null),
-                mainGroups: this.groupByType(main, deck.format ?? null),
-                sideboard: side.map((c) => this.toCardView(c, deck.format ?? null)),
+                mainGroups: this.groupByType(main, deck.format ?? null, gapByRow),
+                sideboard: side.map((c) => this.toCardView(c, deck.format ?? null, gapByRow)),
                 mainCount: DeckSummaryPolicy.cardCount(main),
                 sideCount: DeckSummaryPolicy.cardCount(side),
                 estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
                 illegalCount,
                 hasCards: cards.length > 0,
+                completeness: gap.completeness,
+                neededCount: gap.neededCount,
+                ownedCount: gap.ownedCount,
+                missingCount: gap.missingCount,
+                hasMissing: gap.missingCount > 0,
             });
         } catch (error) {
             this.LOGGER.debug(`Error building deck detail view: ${error?.message}`);
@@ -113,7 +173,7 @@ export class DeckPageOrchestrator {
         }
     }
 
-    private toListItem(deck: Deck) {
+    private toListItem(deck: Deck, gap?: DeckGapSummary) {
         const cards = deck.cards ?? [];
         return {
             id: deck.id!,
@@ -125,15 +185,22 @@ export class DeckPageOrchestrator {
                 ? deck.updatedAt.toLocaleDateString('en-US', { timeZone: 'UTC' })
                 : '',
             url: `/decks/${deck.id}`,
+            completeness: gap?.completeness ?? 0,
+            missingCount: gap?.missingCount ?? 0,
+            buildable: (gap?.missingCount ?? 0) === 0 && cards.length > 0,
         };
     }
 
-    private groupByType(cards: DeckCard[], format: Format | null): DeckCardGroupView[] {
+    private groupByType(
+        cards: DeckCard[],
+        format: Format | null,
+        gapByRow: Map<string, DeckCardGap>
+    ): DeckCardGroupView[] {
         const buckets = new Map<string, DeckCardView[]>();
         for (const dc of cards) {
-            const key = this.primaryType(dc.card?.type ?? '');
+            const key = primaryType(dc.card?.type ?? '');
             const list = buckets.get(key) ?? [];
-            list.push(this.toCardView(dc, format));
+            list.push(this.toCardView(dc, format, gapByRow));
             buckets.set(key, list);
         }
         const order = [...TYPE_ORDER, 'Other'];
@@ -150,9 +217,14 @@ export class DeckPageOrchestrator {
             });
     }
 
-    private toCardView(dc: DeckCard, format: Format | null): DeckCardView {
+    private toCardView(
+        dc: DeckCard,
+        format: Format | null,
+        gapByRow: Map<string, DeckCardGap>
+    ): DeckCardView {
         const card = dc.card;
         const unitValue = DeckSummaryPolicy.cardValue(card);
+        const gap = gapByRow.get(`${dc.cardId}|${dc.isSideboard}`);
         return {
             cardId: dc.cardId,
             name: card?.name ?? dc.cardId,
@@ -168,18 +240,14 @@ export class DeckPageOrchestrator {
             lineValue: this.formatCurrency(dc.quantity * unitValue),
             isSideboard: dc.isSideboard,
             illegal: this.isIllegal(format, dc),
+            owned: gap?.owned ?? dc.quantity,
+            missing: gap?.missing ?? 0,
+            isBasic: gap?.isBasic ?? false,
         };
     }
 
     private isIllegal(format: Format | null, dc: DeckCard): boolean {
         return !!format && !DeckLegalityPolicy.isCardLegal(format, dc.card?.legalities);
-    }
-
-    private primaryType(typeLine: string): string {
-        // MTGJSON type lines use an em dash (U+2014) before subtypes, e.g.
-        // "Legendary Creature [em dash] God"; take the part before it.
-        const head = (typeLine ?? '').split(String.fromCharCode(0x2014))[0];
-        return TYPE_ORDER.find((t) => head.includes(t)) ?? 'Other';
     }
 
     private buildFormatOptions(selected: string | null): FormatOptionView[] {

--- a/src/http/hbs/deck/dto/deck.view.dto.ts
+++ b/src/http/hbs/deck/dto/deck.view.dto.ts
@@ -14,6 +14,9 @@ export interface DeckListItemView {
     estimatedValue: string;
     updatedAt: string;
     url: string;
+    completeness: number;
+    missingCount: number;
+    buildable: boolean;
 }
 
 export class DeckListViewDto extends BaseViewDto {
@@ -26,6 +29,40 @@ export class DeckListViewDto extends BaseViewDto {
         this.decks = init.decks ?? [];
         this.hasDecks = init.hasDecks ?? false;
         this.formatOptions = init.formatOptions ?? [];
+    }
+}
+
+export class DeckImportViewDto extends BaseViewDto {
+    readonly formatOptions: FormatOptionView[];
+
+    constructor(init: Partial<DeckImportViewDto>) {
+        super(init);
+        this.formatOptions = init.formatOptions ?? [];
+    }
+}
+
+export interface DeckImportErrorView {
+    row: number;
+    name?: string;
+    error: string;
+}
+
+export class DeckImportResultViewDto extends BaseViewDto {
+    readonly deckId: number;
+    readonly deckName: string;
+    readonly deckUrl: string;
+    readonly saved: number;
+    readonly errorCount: number;
+    readonly errors: DeckImportErrorView[];
+
+    constructor(init: Partial<DeckImportResultViewDto>) {
+        super(init);
+        this.deckId = init.deckId ?? 0;
+        this.deckName = init.deckName ?? '';
+        this.deckUrl = init.deckUrl ?? '/decks';
+        this.saved = init.saved ?? 0;
+        this.errorCount = init.errorCount ?? 0;
+        this.errors = init.errors ?? [];
     }
 }
 
@@ -42,6 +79,9 @@ export interface DeckCardView {
     lineValue: string;
     isSideboard: boolean;
     illegal: boolean;
+    owned: number;
+    missing: number;
+    isBasic: boolean;
 }
 
 export interface DeckCardGroupView {
@@ -66,6 +106,11 @@ export class DeckDetailViewDto extends BaseViewDto {
     readonly estimatedValue: string;
     readonly illegalCount: number;
     readonly hasCards: boolean;
+    readonly completeness: number;
+    readonly neededCount: number;
+    readonly ownedCount: number;
+    readonly missingCount: number;
+    readonly hasMissing: boolean;
 
     constructor(init: Partial<DeckDetailViewDto>) {
         super(init);
@@ -81,5 +126,10 @@ export class DeckDetailViewDto extends BaseViewDto {
         this.estimatedValue = init.estimatedValue ?? '$0.00';
         this.illegalCount = init.illegalCount ?? 0;
         this.hasCards = init.hasCards ?? false;
+        this.completeness = init.completeness ?? 0;
+        this.neededCount = init.neededCount ?? 0;
+        this.ownedCount = init.ownedCount ?? 0;
+        this.missingCount = init.missingCount ?? 0;
+        this.hasMissing = init.hasMissing ?? false;
     }
 }

--- a/src/http/hbs/hbs.module.ts
+++ b/src/http/hbs/hbs.module.ts
@@ -30,6 +30,8 @@ import { PortfolioController } from './portfolio/portfolio.controller';
 import { PortfolioOrchestrator } from './portfolio/portfolio.orchestrator';
 import { PriceAlertPageController } from './price-alert/price-alert-page.controller';
 import { PriceAlertPageOrchestrator } from './price-alert/price-alert-page.orchestrator';
+import { PublishedDeckController } from './published-deck/published-deck.controller';
+import { PublishedDeckOrchestrator } from './published-deck/published-deck.orchestrator';
 import { SealedProductController } from './sealed-product/sealed-product.controller';
 import { SealedProductOrchestrator } from './sealed-product/sealed-product.orchestrator';
 import { SearchController } from './search/search.controller';
@@ -61,6 +63,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         NotificationPageController,
         PortfolioController,
         PriceAlertPageController,
+        PublishedDeckController,
         SealedProductController,
         SearchController,
         SetController,
@@ -83,6 +86,7 @@ import { UserOrchestrator } from './user/user.orchestrator';
         NotificationPageOrchestrator,
         PortfolioOrchestrator,
         PriceAlertPageOrchestrator,
+        PublishedDeckOrchestrator,
         SealedProductOrchestrator,
         SearchOrchestrator,
         SetOrchestrator,

--- a/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
+++ b/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
@@ -1,0 +1,108 @@
+import { BaseViewDto } from 'src/http/base/base.view.dto';
+
+export interface PublishedFormatOptionView {
+    value: string;
+    label: string;
+    selected: boolean;
+}
+
+export interface PublishedDeckListItemView {
+    id: number;
+    title: string;
+    formatLabel: string;
+    tournamentName: string;
+    date: string;
+    result: string;
+    cardCount: number;
+    estimatedValue: string;
+    url: string;
+}
+
+export class PublishedDeckListViewDto extends BaseViewDto {
+    readonly decks: PublishedDeckListItemView[];
+    readonly hasDecks: boolean;
+    readonly formats: PublishedFormatOptionView[];
+    readonly page: number;
+    readonly hasPrev: boolean;
+    readonly hasNext: boolean;
+    readonly prevUrl: string;
+    readonly nextUrl: string;
+
+    constructor(init: Partial<PublishedDeckListViewDto>) {
+        super(init);
+        this.decks = init.decks ?? [];
+        this.hasDecks = init.hasDecks ?? false;
+        this.formats = init.formats ?? [];
+        this.page = init.page ?? 1;
+        this.hasPrev = init.hasPrev ?? false;
+        this.hasNext = init.hasNext ?? false;
+        this.prevUrl = init.prevUrl ?? '';
+        this.nextUrl = init.nextUrl ?? '';
+    }
+}
+
+export interface PublishedDeckCardView {
+    name: string;
+    url: string;
+    imgSrc: string;
+    manaCost?: string;
+    quantity: number;
+    lineValue: string;
+    owned: number;
+    missing: number;
+    isBasic: boolean;
+}
+
+export interface PublishedDeckGroupView {
+    type: string;
+    count: number;
+    cards: PublishedDeckCardView[];
+}
+
+export class PublishedDeckDetailViewDto extends BaseViewDto {
+    readonly deckId: number;
+    readonly deckTitle: string;
+    readonly tournamentName: string;
+    readonly date: string;
+    readonly formatLabel: string;
+    readonly player: string;
+    readonly result: string;
+    readonly sourceUri: string;
+    readonly mainGroups: PublishedDeckGroupView[];
+    readonly sideboard: PublishedDeckCardView[];
+    readonly mainCount: number;
+    readonly sideCount: number;
+    readonly estimatedValue: string;
+    readonly hasCards: boolean;
+    // Gap vs. the signed-in user's collection (omitted/zero for anonymous).
+    readonly showGap: boolean;
+    readonly completeness: number;
+    readonly neededCount: number;
+    readonly ownedCount: number;
+    readonly missingCount: number;
+    readonly hasMissing: boolean;
+
+    constructor(init: Partial<PublishedDeckDetailViewDto>) {
+        super(init);
+        this.deckId = init.deckId ?? 0;
+        this.deckTitle = init.deckTitle ?? '';
+        this.tournamentName = init.tournamentName ?? '';
+        this.date = init.date ?? '';
+        this.formatLabel = init.formatLabel ?? '';
+        this.player = init.player ?? '';
+        this.result = init.result ?? '';
+        this.sourceUri = init.sourceUri ?? '';
+        this.mainGroups = init.mainGroups ?? [];
+        this.sideboard = init.sideboard ?? [];
+        this.mainCount = init.mainCount ?? 0;
+        this.sideCount = init.sideCount ?? 0;
+        this.estimatedValue = init.estimatedValue ?? '$0.00';
+        this.hasCards = init.hasCards ?? false;
+        this.showGap = init.showGap ?? false;
+        this.completeness = init.completeness ?? 0;
+        this.neededCount = init.neededCount ?? 0;
+        this.ownedCount = init.ownedCount ?? 0;
+        this.missingCount = init.missingCount ?? 0;
+        this.hasMissing = init.hasMissing ?? false;
+    }
+}

--- a/src/http/hbs/published-deck/published-deck.controller.ts
+++ b/src/http/hbs/published-deck/published-deck.controller.ts
@@ -1,0 +1,75 @@
+import {
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Inject,
+    Param,
+    ParseIntPipe,
+    Post,
+    Query,
+    Render,
+    Req,
+    Res,
+    UseGuards,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
+import { OptionalAuthGuard } from 'src/http/auth/optional-auth.guard';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { PublishedDeckOrchestrator } from './published-deck.orchestrator';
+import {
+    PublishedDeckDetailViewDto,
+    PublishedDeckListViewDto,
+} from './dto/published-deck.view.dto';
+
+@Controller('published-decks')
+export class PublishedDeckController {
+    constructor(
+        @Inject(PublishedDeckOrchestrator)
+        private readonly orchestrator: PublishedDeckOrchestrator
+    ) {}
+
+    @UseGuards(OptionalAuthGuard)
+    @Get()
+    @Render('publishedDecks')
+    async list(
+        @Req() req: AuthenticatedRequest,
+        @Query('format') format?: string,
+        @Query('page') page?: string
+    ): Promise<PublishedDeckListViewDto> {
+        return this.orchestrator.buildListView(req, format || undefined, parseInt(page ?? '1', 10));
+    }
+
+    @UseGuards(OptionalAuthGuard)
+    @Get(':id')
+    @Render('publishedDeckDetail')
+    async detail(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req: AuthenticatedRequest
+    ): Promise<PublishedDeckDetailViewDto> {
+        return this.orchestrator.buildDetailView(req, id);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @Post(':id/clone')
+    async clone(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req: AuthenticatedRequest,
+        @Res() res: Response
+    ): Promise<void> {
+        const deckId = await this.orchestrator.cloneToUserDeck(req, id);
+        res.redirect(`/decks/${deckId}`);
+    }
+
+    @UseGuards(JwtAuthGuard)
+    @Post(':id/missing-to-buy-list')
+    @HttpCode(HttpStatus.OK)
+    async missingToBuyList(
+        @Param('id', ParseIntPipe) id: number,
+        @Req() req: AuthenticatedRequest
+    ): Promise<{ added: number }> {
+        const added = await this.orchestrator.addMissingToBuyList(req, id);
+        return { added };
+    }
+}

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -1,0 +1,248 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckGapPolicy, DeckCardGap } from 'src/core/deck/deck-gap.policy';
+import { DeckService } from 'src/core/deck/deck.service';
+import { DeckSummaryPolicy } from 'src/core/deck/deck-summary.policy';
+import { PublishedDeck } from 'src/core/published-deck/published-deck.entity';
+import { PublishedDeckService } from 'src/core/published-deck/published-deck.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { buildCardUrl } from 'src/http/base/http.util';
+import { HttpErrorHandler } from 'src/http/http.error.handler';
+import { getLogger } from 'src/logger/global-app-logger';
+import { primaryType, TYPE_ORDER, TYPE_PLURAL } from '../deck/deck-grouping';
+import {
+    PublishedDeckCardView,
+    PublishedDeckDetailViewDto,
+    PublishedDeckGroupView,
+    PublishedDeckListViewDto,
+    PublishedFormatOptionView,
+} from './dto/published-deck.view.dto';
+
+const PAGE_SIZE = 24;
+
+@Injectable()
+export class PublishedDeckOrchestrator {
+    private readonly LOGGER = getLogger(PublishedDeckOrchestrator.name);
+
+    private static readonly CURRENCY = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+    });
+
+    constructor(
+        @Inject(PublishedDeckService) private readonly publishedDeckService: PublishedDeckService,
+        @Inject(DeckBuildabilityService)
+        private readonly buildabilityService: DeckBuildabilityService,
+        @Inject(DeckService) private readonly deckService: DeckService
+    ) {}
+
+    async buildListView(
+        req: AuthenticatedRequest,
+        format: string | undefined,
+        page: number
+    ): Promise<PublishedDeckListViewDto> {
+        try {
+            const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
+            const offset = (safePage - 1) * PAGE_SIZE;
+            const [{ decks, total }, formats] = await Promise.all([
+                this.publishedDeckService.list(format, PAGE_SIZE, offset),
+                this.publishedDeckService.formats(),
+            ]);
+            const baseUrl = format ? `/published-decks?format=${encodeURIComponent(format)}&` : '/published-decks?';
+            return new PublishedDeckListViewDto({
+                authenticated: !!req.user,
+                indexable: true,
+                title: 'Tournament decks - I Want My MTG',
+                metaDescription:
+                    'Browse published tournament decklists and see which ones you can build from your collection.',
+                breadcrumbs: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Tournament decks', url: '/published-decks' },
+                ],
+                decks: decks.map((d) => this.toListItem(d)),
+                hasDecks: decks.length > 0,
+                formats: this.buildFormatOptions(formats, format),
+                page: safePage,
+                hasPrev: safePage > 1,
+                hasNext: offset + decks.length < total,
+                prevUrl: `${baseUrl}page=${safePage - 1}`,
+                nextUrl: `${baseUrl}page=${safePage + 1}`,
+            });
+        } catch (error) {
+            this.LOGGER.debug(`Error building published deck list: ${error?.message}`);
+            return HttpErrorHandler.toHttpException(error, 'buildListView');
+        }
+    }
+
+    async buildDetailView(
+        req: AuthenticatedRequest,
+        id: number
+    ): Promise<PublishedDeckDetailViewDto> {
+        try {
+            const deck = await this.publishedDeckService.get(id);
+            if (!deck) {
+                throw new Error(`Published deck ${id} not found.`);
+            }
+            const cards = deck.cards ?? [];
+            const main = cards.filter((c) => !c.isSideboard);
+            const side = cards.filter((c) => c.isSideboard);
+
+            const userId = req.user?.id;
+            const gap = userId
+                ? await this.buildabilityService.gapForDeck(cards, userId)
+                : null;
+            const gapByRow = new Map<string, DeckCardGap>();
+            for (const g of gap?.perCard ?? []) {
+                gapByRow.set(`${g.cardId}|${g.isSideboard}`, g);
+            }
+
+            const title = this.deckTitle(deck);
+            return new PublishedDeckDetailViewDto({
+                authenticated: !!userId,
+                indexable: true,
+                title: `${title} - Tournament decks - I Want My MTG`,
+                breadcrumbs: [
+                    { label: 'Home', url: '/' },
+                    { label: 'Tournament decks', url: '/published-decks' },
+                    { label: title, url: `/published-decks/${deck.id}` },
+                ],
+                deckId: deck.id!,
+                deckTitle: title,
+                tournamentName: deck.tournamentName ?? '',
+                date: this.formatDate(deck.tournamentDate),
+                formatLabel: deck.format ? this.capitalize(deck.format) : 'Unknown format',
+                player: deck.player ?? '',
+                result: deck.result ?? '',
+                sourceUri: deck.sourceUri,
+                mainGroups: this.groupByType(main, gapByRow),
+                sideboard: side.map((c) => this.toCardView(c, gapByRow)),
+                mainCount: DeckSummaryPolicy.cardCount(main),
+                sideCount: DeckSummaryPolicy.cardCount(side),
+                estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
+                hasCards: cards.length > 0,
+                showGap: !!gap,
+                completeness: gap?.completeness ?? 0,
+                neededCount: gap?.neededCount ?? 0,
+                ownedCount: gap?.ownedCount ?? 0,
+                missingCount: gap?.missingCount ?? 0,
+                hasMissing: (gap?.missingCount ?? 0) > 0,
+            });
+        } catch (error) {
+            this.LOGGER.debug(`Error building published deck detail: ${error?.message}`);
+            return HttpErrorHandler.toHttpException(error, 'buildDetailView');
+        }
+    }
+
+    /** Copy a published deck into the user's own decks; returns the new deck id. */
+    async cloneToUserDeck(req: AuthenticatedRequest, id: number): Promise<number> {
+        HttpErrorHandler.validateAuthenticatedRequest(req);
+        const source = await this.publishedDeckService.get(id);
+        if (!source) {
+            throw new Error(`Published deck ${id} not found.`);
+        }
+        const deck = await this.deckService.createDeck(req.user.id, this.deckTitle(source));
+        const entries = (source.cards ?? []).map((c) => ({
+            cardId: c.cardId,
+            isSideboard: c.isSideboard,
+            quantity: c.quantity,
+        }));
+        await this.deckService.addCards(deck.id!, req.user.id, entries);
+        return deck.id!;
+    }
+
+    /** Seed the user's buy-list with the cards they're missing for this deck. */
+    async addMissingToBuyList(req: AuthenticatedRequest, id: number): Promise<number> {
+        HttpErrorHandler.validateAuthenticatedRequest(req);
+        const deck = await this.publishedDeckService.get(id);
+        if (!deck) {
+            throw new Error(`Published deck ${id} not found.`);
+        }
+        return this.buildabilityService.addMissingToBuyList(deck.cards ?? [], req.user.id);
+    }
+
+    private toListItem(deck: PublishedDeck) {
+        const cards = deck.cards ?? [];
+        return {
+            id: deck.id!,
+            title: this.deckTitle(deck),
+            formatLabel: deck.format ? this.capitalize(deck.format) : 'Unknown',
+            tournamentName: deck.tournamentName ?? '',
+            date: this.formatDate(deck.tournamentDate),
+            result: deck.result ?? '',
+            cardCount: DeckSummaryPolicy.cardCount(cards),
+            estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
+            url: `/published-decks/${deck.id}`,
+        };
+    }
+
+    private groupByType(
+        cards: DeckCard[],
+        gapByRow: Map<string, DeckCardGap>
+    ): PublishedDeckGroupView[] {
+        const buckets = new Map<string, PublishedDeckCardView[]>();
+        for (const dc of cards) {
+            const key = primaryType(dc.card?.type ?? '');
+            const list = buckets.get(key) ?? [];
+            list.push(this.toCardView(dc, gapByRow));
+            buckets.set(key, list);
+        }
+        const order = [...TYPE_ORDER, 'Other'];
+        return order
+            .filter((t) => buckets.has(t))
+            .map((t) => {
+                const cardViews = buckets.get(t)!;
+                return {
+                    type: TYPE_PLURAL[t] ?? t,
+                    count: cardViews.reduce((sum, c) => sum + c.quantity, 0),
+                    cards: cardViews,
+                };
+            });
+    }
+
+    private toCardView(dc: DeckCard, gapByRow: Map<string, DeckCardGap>): PublishedDeckCardView {
+        const card = dc.card;
+        const unitValue = DeckSummaryPolicy.cardValue(card);
+        const gap = gapByRow.get(`${dc.cardId}|${dc.isSideboard}`);
+        return {
+            name: card?.name ?? dc.cardId,
+            url: card ? buildCardUrl(card.setCode, card.number) : '#',
+            imgSrc: card?.imgSrc ?? '',
+            manaCost: card?.manaCost,
+            quantity: dc.quantity,
+            lineValue: this.formatCurrency(dc.quantity * unitValue),
+            owned: gap?.owned ?? 0,
+            missing: gap?.missing ?? 0,
+            isBasic: gap?.isBasic ?? DeckGapPolicy.isBasic(card?.type),
+        };
+    }
+
+    private deckTitle(deck: PublishedDeck): string {
+        return deck.archetype || deck.player || deck.tournamentName || 'Tournament deck';
+    }
+
+    private buildFormatOptions(
+        formats: string[],
+        selected: string | undefined
+    ): PublishedFormatOptionView[] {
+        const options: PublishedFormatOptionView[] = [
+            { value: '', label: 'All formats', selected: !selected },
+        ];
+        for (const f of formats) {
+            options.push({ value: f, label: this.capitalize(f), selected: f === selected });
+        }
+        return options;
+    }
+
+    private formatDate(date?: Date | null): string {
+        return date ? date.toLocaleDateString('en-US', { timeZone: 'UTC' }) : '';
+    }
+
+    private capitalize(value: string): string {
+        return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+    }
+
+    private formatCurrency(value: number): string {
+        return PublishedDeckOrchestrator.CURRENCY.format(value || 0);
+    }
+}

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -114,7 +114,7 @@ export class PublishedDeckOrchestrator {
                 formatLabel: deck.format ? this.capitalize(deck.format) : 'Unknown format',
                 player: deck.player ?? '',
                 result: deck.result ?? '',
-                sourceUri: deck.sourceUri,
+                sourceUri: this.safeExternalUrl(deck.sourceUri),
                 mainGroups: this.groupByType(main, gapByRow),
                 sideboard: side.map((c) => this.toCardView(c, gapByRow)),
                 mainCount: DeckSummaryPolicy.cardCount(main),
@@ -219,6 +219,21 @@ export class PublishedDeckOrchestrator {
 
     private deckTitle(deck: PublishedDeck): string {
         return deck.archetype || deck.player || deck.tournamentName || 'Tournament deck';
+    }
+
+    /**
+     * `sourceUri` comes from an external feed and is rendered into an href, so
+     * only allow http(s) - a `javascript:` URL would survive Handlebars escaping
+     * and execute on click. Anything else becomes '' (the view omits the link).
+     */
+    private safeExternalUrl(uri: string | null | undefined): string {
+        if (!uri) return '';
+        try {
+            const parsed = new URL(uri);
+            return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? uri : '';
+        } catch {
+            return '';
+        }
     }
 
     private buildFormatOptions(

--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -21,6 +21,32 @@
         </p>
     {{/if}}
 
+    {{#if hasCards}}
+    {{!-- Buildability vs. your collection (name-level; basics count as owned) --}}
+    <div class="section-container mb-5">
+        <div class="flex items-center justify-between flex-wrap gap-2 mb-2">
+            <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200">
+                <i class="fas fa-boxes-stacked mr-1 text-purple-500" aria-hidden="true"></i> Your collection
+            </h3>
+            {{#if hasMissing}}
+                <button type="button" id="deck-buylist-missing" class="btn btn-secondary text-sm">
+                    <i class="fas fa-cart-plus mr-1" aria-hidden="true"></i> Add {{missingCount}} missing to buy list
+                </button>
+            {{else}}
+                <span class="text-sm text-teal-600 dark:text-teal-400 font-semibold"><i class="fas fa-check mr-1" aria-hidden="true"></i> You can build this deck</span>
+            {{/if}}
+        </div>
+        <div class="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400 mb-1">
+            <span>You own <span class="font-semibold text-gray-900 dark:text-gray-100">{{ownedCount}}</span> of {{neededCount}} non-basic cards</span>
+            <span class="font-semibold">{{completeness}}%</span>
+        </div>
+        <div class="h-2 w-full rounded-full bg-gray-200 dark:bg-midnight-700 overflow-hidden">
+            <div class="h-full rounded-full {{#if hasMissing}}bg-purple-500{{else}}bg-teal-500{{/if}}" style="width: {{completeness}}%"></div>
+        </div>
+        <span id="deck-buylist-result" class="text-sm mt-2 inline-block" role="status" aria-live="polite"></span>
+    </div>
+    {{/if}}
+
     {{!-- Edit deck (rename / format / delete) --}}
     <details class="section-container mb-5">
         <summary class="cursor-pointer font-medium"><i class="fas fa-gear mr-2" aria-hidden="true"></i>Deck settings</summary>
@@ -84,6 +110,7 @@
                             </span>
                             <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
                             {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
+                            {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400" title="Basic land">Basic</span>{{else}}<span class="text-xs px-2 py-0.5 rounded-full bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300" title="You own enough"><i class="fas fa-check" aria-hidden="true"></i></span>{{/if}}
                             <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
                             <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
                         </div>
@@ -108,6 +135,7 @@
                             </span>
                             <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
                             {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
+                            {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400" title="Basic land">Basic</span>{{else}}<span class="text-xs px-2 py-0.5 rounded-full bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300" title="You own enough"><i class="fas fa-check" aria-hidden="true"></i></span>{{/if}}
                             <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
                             <button type="button" class="deck-remove px-2 text-gray-400 hover:text-red-500" aria-label="Remove card">&times;</button>
                         </div>
@@ -128,3 +156,35 @@
 
 <script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>
 <script src="/public/js/deckDetail.js?v={{assetVersion}}" defer></script>
+<script>
+(function () {
+    var btn = document.getElementById('deck-buylist-missing');
+    if (!btn) return;
+    var deckId = document.querySelector('[data-deck-id]').getAttribute('data-deck-id');
+    var result = document.getElementById('deck-buylist-result');
+    btn.addEventListener('click', function () {
+        btn.disabled = true;
+        result.textContent = 'Adding…';
+        result.className = 'text-sm mt-2 inline-block text-gray-500';
+        fetch('/api/v1/decks/' + deckId + '/missing-to-buy-list', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+        })
+            .then(function (r) {
+                if (!r.ok) throw new Error('Request failed');
+                return r.json();
+            })
+            .then(function (body) {
+                var added = (body && body.data && body.data.added) || 0;
+                result.textContent = added + ' card' + (added === 1 ? '' : 's') + ' added to your buy list.';
+                result.className = 'text-sm mt-2 inline-block text-teal-600 dark:text-teal-400';
+            })
+            .catch(function () {
+                btn.disabled = false;
+                result.textContent = 'Could not add to buy list. Please try again.';
+                result.className = 'text-sm mt-2 inline-block text-red-600 dark:text-red-400';
+            });
+    });
+})();
+</script>

--- a/src/http/views/deckImport.hbs
+++ b/src/http/views/deckImport.hbs
@@ -1,0 +1,40 @@
+<div class="content-wrapper py-6">
+    <div class="mb-4">
+        <h1 class="page-title">Import a decklist</h1>
+        <p class="page-subtitle">Paste a decklist (one card per line, e.g. <code>4 Lightning Bolt</code>). Set codes like <code>(2X2)</code> are optional. A <code>Sideboard</code> line routes the rest to the sideboard.</p>
+    </div>
+
+    <div class="section-container">
+        <form method="post" action="/decks/import" class="space-y-4">
+            <div class="flex flex-wrap items-end gap-3">
+                <div class="flex-1 min-w-[12rem]">
+                    <label for="deck-name" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Deck name</label>
+                    <input id="deck-name" name="name" type="text" required maxlength="120"
+                        class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm"
+                        placeholder="e.g. Mono-Red Aggro" />
+                </div>
+                <div>
+                    <label for="deck-format" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Format</label>
+                    <select id="deck-format" name="format"
+                        class="rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm">
+                        {{#each formatOptions}}
+                            <option value="{{value}}" {{#if selected}}selected{{/if}}>{{label}}</option>
+                        {{/each}}
+                    </select>
+                </div>
+            </div>
+            <div>
+                <label for="deck-text" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Decklist</label>
+                <textarea id="deck-text" name="text" required rows="16"
+                    class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm font-mono"
+                    placeholder="4 Lightning Bolt&#10;4 Monastery Swiftspear&#10;20 Mountain&#10;&#10;Sideboard&#10;2 Pyroblast"></textarea>
+            </div>
+            <div class="flex gap-3">
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-file-import mr-1" aria-hidden="true"></i> Import deck
+                </button>
+                <a href="/decks" class="btn btn-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/http/views/deckImportResult.hbs
+++ b/src/http/views/deckImportResult.hbs
@@ -1,0 +1,52 @@
+<section class="border border-gray-200 dark:border-midnight-700 rounded-xl sm:m-0 md:m-4">
+    <section class="text-center bg-teal-50 dark:bg-midnight-900 mb-4 rounded-t-lg py-4">
+        <h3 class="page-title">Import complete</h3>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">{{deckName}}</p>
+    </section>
+    <div class="content-wrapper py-6 px-4">
+        <div class="max-w-md mx-auto">
+            <div class="space-y-3 text-center mb-6">
+                <p class="text-gray-700 dark:text-gray-300 text-lg">
+                    <span class="font-semibold text-teal-600 dark:text-teal-400">{{saved}}</span>
+                    card{{#if (gt saved 1)}}s{{/if}} added
+                </p>
+                {{#if errorCount}}
+                <p class="text-red-600 dark:text-red-400">
+                    {{errorCount}} line{{#if (gt errorCount 1)}}s{{/if}} could not be imported
+                </p>
+                {{/if}}
+            </div>
+
+            {{#if errorCount}}
+            <div class="mb-6">
+                <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-2">Unresolved lines:</h4>
+                <div class="overflow-auto max-h-64 border border-red-200 dark:border-red-800 rounded">
+                    <table class="table-container w-full text-sm">
+                        <thead>
+                            <tr class="table-header-row">
+                                <th class="table-header text-left">Line</th>
+                                <th class="table-header text-left">Name</th>
+                                <th class="table-header text-left">Reason</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{#each errors}}
+                            <tr class="table-row">
+                                <td class="table-cell">{{this.row}}</td>
+                                <td class="table-cell">{{this.name}}</td>
+                                <td class="table-cell text-red-600 dark:text-red-400">{{this.error}}</td>
+                            </tr>
+                            {{/each}}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            {{/if}}
+
+            <div class="flex gap-3 justify-center">
+                <a href="{{deckUrl}}" class="btn btn-primary">View deck</a>
+                <a href="/decks/import" class="btn btn-secondary">Import another</a>
+            </div>
+        </div>
+    </div>
+</section>

--- a/src/http/views/decks.hbs
+++ b/src/http/views/decks.hbs
@@ -4,6 +4,14 @@
             <h1 class="page-title">Decks</h1>
             <p class="page-subtitle">Build and track your decks. Estimated value uses current market prices.</p>
         </div>
+        <div class="flex gap-2">
+            <a href="/published-decks" class="btn btn-secondary">
+                <i class="fas fa-trophy mr-1" aria-hidden="true"></i> Browse tournament decks
+            </a>
+            <a href="/decks/import" class="btn btn-secondary">
+                <i class="fas fa-file-import mr-1" aria-hidden="true"></i> Import decklist
+            </a>
+        </div>
     </div>
 
     {{!-- New deck --}}
@@ -46,6 +54,21 @@
                         <span>{{cardCount}} card{{#unless (eq cardCount 1)}}s{{/unless}}</span>
                         <span class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
                     </div>
+                    {{#if cardCount}}
+                    <div class="mt-2">
+                        <div class="flex items-center justify-between text-xs mb-1">
+                            <span class="text-gray-500 dark:text-gray-400">You own {{completeness}}%</span>
+                            {{#if buildable}}
+                                <span class="text-teal-600 dark:text-teal-400 font-semibold"><i class="fas fa-check mr-0.5" aria-hidden="true"></i> Buildable</span>
+                            {{else}}
+                                <span class="text-gray-500 dark:text-gray-400">{{missingCount}} missing</span>
+                            {{/if}}
+                        </div>
+                        <div class="h-1.5 w-full rounded-full bg-gray-200 dark:bg-midnight-700 overflow-hidden">
+                            <div class="h-full rounded-full {{#if buildable}}bg-teal-500{{else}}bg-purple-500{{/if}}" style="width: {{completeness}}%"></div>
+                        </div>
+                    </div>
+                    {{/if}}
                     <div class="mt-1 text-xs text-gray-400">Updated {{updatedAt}}</div>
                 </div>
             {{/each}}

--- a/src/http/views/publishedDeckDetail.hbs
+++ b/src/http/views/publishedDeckDetail.hbs
@@ -1,0 +1,127 @@
+<div class="content-wrapper py-6" data-published-deck-id="{{deckId}}">
+    <div class="flex items-start justify-between mb-2 flex-wrap gap-3">
+        <div>
+            <h1 class="page-title">{{deckTitle}}</h1>
+            <p class="page-subtitle">
+                <span class="text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
+                {{#if tournamentName}}<span class="mx-1">&middot;</span>{{tournamentName}}{{/if}}
+                {{#if date}}<span class="mx-1">&middot;</span>{{date}}{{/if}}
+                {{#if result}}<span class="mx-1">&middot;</span>{{result}}{{/if}}
+                <span class="mx-1">&middot;</span>
+                <span class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
+            </p>
+            {{#if player}}<p class="text-sm text-gray-500 mt-1">Piloted by {{player}}</p>{{/if}}
+        </div>
+        <a href="/published-decks" class="btn btn-ghost text-sm">&larr; All decks</a>
+    </div>
+
+    <div class="flex flex-wrap gap-2 mb-5">
+        <form method="post" action="/published-decks/{{deckId}}/clone">
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-copy mr-1" aria-hidden="true"></i> Copy to my decks
+            </button>
+        </form>
+        {{#if sourceUri}}
+            <a href="{{sourceUri}}" target="_blank" rel="nofollow noopener" class="btn btn-secondary">
+                <i class="fas fa-external-link-alt mr-1" aria-hidden="true"></i> Source
+            </a>
+        {{/if}}
+    </div>
+
+    {{#if showGap}}
+    <div class="section-container mb-5">
+        <div class="flex items-center justify-between flex-wrap gap-2 mb-2">
+            <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200">
+                <i class="fas fa-boxes-stacked mr-1 text-purple-500" aria-hidden="true"></i> Your collection
+            </h3>
+            {{#if hasMissing}}
+                <button type="button" id="pd-buylist-missing" class="btn btn-secondary text-sm">
+                    <i class="fas fa-cart-plus mr-1" aria-hidden="true"></i> Add {{missingCount}} missing to buy list
+                </button>
+            {{else}}
+                <span class="text-sm text-teal-600 dark:text-teal-400 font-semibold"><i class="fas fa-check mr-1" aria-hidden="true"></i> You can build this deck</span>
+            {{/if}}
+        </div>
+        <div class="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400 mb-1">
+            <span>You own <span class="font-semibold text-gray-900 dark:text-gray-100">{{ownedCount}}</span> of {{neededCount}} non-basic cards</span>
+            <span class="font-semibold">{{completeness}}%</span>
+        </div>
+        <div class="h-2 w-full rounded-full bg-gray-200 dark:bg-midnight-700 overflow-hidden">
+            <div class="h-full rounded-full {{#if hasMissing}}bg-purple-500{{else}}bg-teal-500{{/if}}" style="width: {{completeness}}%"></div>
+        </div>
+        <span id="pd-buylist-result" class="text-sm mt-2 inline-block" role="status" aria-live="polite"></span>
+    </div>
+    {{else}}
+    <div class="section-container mb-5 text-sm text-gray-600 dark:text-gray-400">
+        <a href="/auth/login" class="text-teal-600 dark:text-teal-400 font-semibold">Sign in</a> to see which of these cards you already own.
+    </div>
+    {{/if}}
+
+    {{#each mainGroups}}
+        <div class="mb-5">
+            <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                {{type}} <span class="text-gray-400 font-normal">({{count}})</span>
+            </h3>
+            <div>
+                {{#each cards}}
+                    <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800">
+                        <span class="w-7 text-center text-sm font-mono text-gray-500">{{quantity}}</span>
+                        <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                        {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400">Basic</span>{{/if}}
+                        <span class="text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
+                    </div>
+                {{/each}}
+            </div>
+        </div>
+    {{/each}}
+
+    {{#if sideboard.length}}
+        <div class="mb-5">
+            <h3 class="font-display font-semibold text-gray-700 dark:text-gray-200 mb-2">
+                Sideboard <span class="text-gray-400 font-normal">({{sideCount}})</span>
+            </h3>
+            <div>
+                {{#each sideboard}}
+                    <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800">
+                        <span class="w-7 text-center text-sm font-mono text-gray-500">{{quantity}}</span>
+                        <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                        {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400">Basic</span>{{/if}}
+                        <span class="text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
+                    </div>
+                {{/each}}
+            </div>
+        </div>
+    {{/if}}
+</div>
+
+<script src="/public/js/ajaxUtils.js?v={{assetVersion}}" defer></script>
+<script src="/public/js/cardPreview.js?v={{assetVersion}}" defer></script>
+<script>
+(function () {
+    var btn = document.getElementById('pd-buylist-missing');
+    if (!btn) return;
+    var deckId = document.querySelector('[data-published-deck-id]').getAttribute('data-published-deck-id');
+    var result = document.getElementById('pd-buylist-result');
+    btn.addEventListener('click', function () {
+        btn.disabled = true;
+        result.textContent = 'Adding…';
+        result.className = 'text-sm mt-2 inline-block text-gray-500';
+        fetch('/published-decks/' + deckId + '/missing-to-buy-list', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+        })
+            .then(function (r) { if (!r.ok) throw new Error('failed'); return r.json(); })
+            .then(function (body) {
+                var added = (body && body.added) || 0;
+                result.textContent = added + ' card' + (added === 1 ? '' : 's') + ' added to your buy list.';
+                result.className = 'text-sm mt-2 inline-block text-teal-600 dark:text-teal-400';
+            })
+            .catch(function () {
+                btn.disabled = false;
+                result.textContent = 'Could not add to buy list. Please try again.';
+                result.className = 'text-sm mt-2 inline-block text-red-600 dark:text-red-400';
+            });
+    });
+})();
+</script>

--- a/src/http/views/publishedDecks.hbs
+++ b/src/http/views/publishedDecks.hbs
@@ -1,0 +1,55 @@
+<div class="content-wrapper py-6">
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="page-title">Tournament decks</h1>
+            <p class="page-subtitle">Published tournament decklists. Sign in to see which ones you can build from your collection.</p>
+        </div>
+        <a href="/decks" class="btn btn-ghost text-sm">&larr; My decks</a>
+    </div>
+
+    <form method="get" action="/published-decks" class="section-container mb-6 flex flex-wrap items-end gap-3">
+        <div>
+            <label for="format" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Format</label>
+            <select id="format" name="format" onchange="this.form.submit()"
+                class="rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm">
+                {{#each formats}}
+                    <option value="{{value}}" {{#if selected}}selected{{/if}}>{{label}}</option>
+                {{/each}}
+            </select>
+        </div>
+        <noscript><button type="submit" class="btn btn-secondary">Filter</button></noscript>
+    </form>
+
+    {{#if hasDecks}}
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {{#each decks}}
+                <a href="{{url}}" class="section-container block hover:border-teal-400 dark:hover:border-teal-500 transition-colors">
+                    <div class="flex items-start justify-between gap-2">
+                        <span class="font-display font-semibold text-lg text-gray-900 dark:text-white">{{title}}</span>
+                        <span class="text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold whitespace-nowrap">{{formatLabel}}</span>
+                    </div>
+                    {{#if tournamentName}}<div class="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">{{tournamentName}}</div>{{/if}}
+                    <div class="mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
+                        <span>{{#if result}}{{result}}{{else}}{{cardCount}} cards{{/if}}</span>
+                        <span class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
+                    </div>
+                    {{#if date}}<div class="mt-1 text-xs text-gray-400">{{date}}</div>{{/if}}
+                </a>
+            {{/each}}
+        </div>
+
+        <div class="flex items-center justify-between mt-6">
+            {{#if hasPrev}}<a href="{{prevUrl}}" class="btn btn-secondary">&larr; Newer</a>{{else}}<span></span>{{/if}}
+            <span class="text-sm text-gray-500">Page {{page}}</span>
+            {{#if hasNext}}<a href="{{nextUrl}}" class="btn btn-secondary">Older &rarr;</a>{{else}}<span></span>{{/if}}
+        </div>
+    {{else}}
+        <div class="section-container text-center py-12">
+            <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-300 mb-3">
+                <i class="fas fa-trophy text-lg" aria-hidden="true"></i>
+            </div>
+            <h2 class="font-display font-bold text-lg text-gray-900 dark:text-white mb-1">No tournament decks yet</h2>
+            <p class="text-gray-600 dark:text-gray-400 text-sm">Check back soon - decklists are ingested from recent tournament results.</p>
+        </div>
+    {{/if}}
+</div>

--- a/test/core/deck/deck-buildability.service.spec.ts
+++ b/test/core/deck/deck-buildability.service.spec.ts
@@ -1,0 +1,57 @@
+import { Card } from 'src/core/card/card.entity';
+import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+
+function card(id: string, name: string, type = 'Instant'): Card {
+    return new Card({
+        id,
+        name,
+        imgSrc: 'i.jpg',
+        legalities: [],
+        number: '1',
+        rarity: CardRarity.Common,
+        setCode: 'set',
+        sortNumber: '1',
+        type,
+    });
+}
+
+describe('DeckBuildabilityService', () => {
+    let service: DeckBuildabilityService;
+    let inventoryRepo: { findAllForExport: jest.Mock };
+    let buyList: { add: jest.Mock };
+
+    beforeEach(() => {
+        inventoryRepo = { findAllForExport: jest.fn() };
+        buyList = { add: jest.fn().mockResolvedValue(undefined) };
+        service = new DeckBuildabilityService(inventoryRepo as any, buyList as any);
+    });
+
+    it('aggregates inventory by lowercased card name across printings', async () => {
+        inventoryRepo.findAllForExport.mockResolvedValue([
+            { quantity: 2, card: card('a', 'Lightning Bolt') },
+            { quantity: 1, card: card('b', 'Lightning Bolt') },
+            { quantity: 3, card: card('c', 'Counterspell') },
+        ]);
+
+        const owned = await service.ownedByName(5);
+
+        expect(owned.get('lightning bolt')).toBe(3);
+        expect(owned.get('counterspell')).toBe(3);
+    });
+
+    it('adds each missing card to the buy-list with its missing quantity', async () => {
+        inventoryRepo.findAllForExport.mockResolvedValue([
+            { quantity: 1, card: card('bolt', 'Lightning Bolt') },
+        ]);
+        const cards: DeckCard[] = [
+            new DeckCard({ cardId: 'bolt', quantity: 4, isSideboard: false, card: card('bolt', 'Lightning Bolt') }),
+        ];
+
+        const added = await service.addMissingToBuyList(cards, 5);
+
+        expect(added).toBe(1);
+        expect(buyList.add).toHaveBeenCalledWith(5, 'bolt', false, 3);
+    });
+});

--- a/test/core/deck/deck-gap.policy.spec.ts
+++ b/test/core/deck/deck-gap.policy.spec.ts
@@ -1,0 +1,78 @@
+import { Card } from 'src/core/card/card.entity';
+import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckGapPolicy } from 'src/core/deck/deck-gap.policy';
+
+function deckCard(
+    cardId: string,
+    name: string,
+    quantity: number,
+    opts: { isSideboard?: boolean; type?: string } = {}
+): DeckCard {
+    const card = new Card({
+        id: cardId,
+        name,
+        imgSrc: 'i.jpg',
+        legalities: [],
+        number: '1',
+        rarity: CardRarity.Common,
+        setCode: 'set',
+        sortNumber: '1',
+        type: opts.type ?? 'Instant',
+    });
+    return new DeckCard({ cardId, quantity, isSideboard: opts.isSideboard ?? false, card });
+}
+
+describe('DeckGapPolicy', () => {
+    it('counts owned cards name-level and reports the gap', () => {
+        const cards = [deckCard('bolt1', 'Lightning Bolt', 4)];
+        const owned = new Map([['lightning bolt', 3]]);
+
+        const gap = DeckGapPolicy.compute(cards, owned);
+
+        expect(gap.neededCount).toBe(4);
+        expect(gap.ownedCount).toBe(3);
+        expect(gap.missingCount).toBe(1);
+        expect(gap.completeness).toBe(75);
+        expect(gap.missingByCard).toEqual([{ cardId: 'bolt1', quantity: 1 }]);
+    });
+
+    it('treats basic lands as always owned and excludes them from totals', () => {
+        const cards = [
+            deckCard('forest', 'Forest', 20, { type: 'Basic Land — Forest' }),
+            deckCard('bolt', 'Lightning Bolt', 4),
+        ];
+        const owned = new Map([['lightning bolt', 4]]);
+
+        const gap = DeckGapPolicy.compute(cards, owned);
+
+        expect(gap.neededCount).toBe(4); // basics excluded
+        expect(gap.completeness).toBe(100);
+        const forestRow = gap.perCard.find((c) => c.cardId === 'forest')!;
+        expect(forestRow).toMatchObject({ isBasic: true, owned: 20, missing: 0 });
+    });
+
+    it('pools a name across main and sideboard so total copies are required', () => {
+        const cards = [
+            deckCard('bolt', 'Lightning Bolt', 4),
+            deckCard('bolt', 'Lightning Bolt', 1, { isSideboard: true }),
+        ];
+        const owned = new Map([['lightning bolt', 4]]);
+
+        const gap = DeckGapPolicy.compute(cards, owned);
+
+        expect(gap.neededCount).toBe(5);
+        expect(gap.ownedCount).toBe(4);
+        expect(gap.missingCount).toBe(1);
+        // The shortfall lands on the sideboard copy (main attributed first).
+        const side = gap.perCard.find((c) => c.isSideboard)!;
+        expect(side.missing).toBe(1);
+    });
+
+    it('is 100% complete when the deck needs nothing beyond basics', () => {
+        const cards = [deckCard('plains', 'Plains', 40, { type: 'Basic Land — Plains' })];
+        const gap = DeckGapPolicy.compute(cards, new Map());
+        expect(gap.completeness).toBe(100);
+        expect(gap.missingCount).toBe(0);
+    });
+});

--- a/test/core/deck/deck-import.service.spec.ts
+++ b/test/core/deck/deck-import.service.spec.ts
@@ -1,0 +1,90 @@
+import { Card } from 'src/core/card/card.entity';
+import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { Format } from 'src/core/card/format.enum';
+import { DeckImportService } from 'src/core/deck/deck-import.service';
+
+function makeCard(id: string, name: string): Card {
+    return new Card({
+        id,
+        name,
+        imgSrc: 'img.jpg',
+        legalities: [],
+        number: '1',
+        rarity: CardRarity.Common,
+        setCode: 'set',
+        sortNumber: '0001',
+        type: 'Instant',
+    });
+}
+
+describe('DeckImportService', () => {
+    let service: DeckImportService;
+    let deckService: { createDeck: jest.Mock; addCards: jest.Mock };
+    let resolver: { resolveByName: jest.Mock; resolveCard: jest.Mock };
+
+    beforeEach(() => {
+        deckService = {
+            createDeck: jest.fn().mockResolvedValue({ id: 7, name: 'My Deck' }),
+            addCards: jest.fn().mockResolvedValue(undefined),
+        };
+        resolver = {
+            resolveByName: jest.fn(),
+            resolveCard: jest.fn(),
+        };
+        service = new DeckImportService(deckService as any, resolver as any);
+    });
+
+    it('resolves set-less lines by name and creates the deck with the cards', async () => {
+        resolver.resolveByName.mockImplementation((name: string) =>
+            Promise.resolve({ card: makeCard(name, name), error: null })
+        );
+
+        const result = await service.importDecklist(
+            1,
+            'My Deck',
+            Format.Modern,
+            '4 Lightning Bolt\n2 Counterspell'
+        );
+
+        expect(deckService.createDeck).toHaveBeenCalledWith(1, 'My Deck', Format.Modern);
+        expect(deckService.addCards).toHaveBeenCalledWith(7, 1, [
+            { cardId: 'Lightning Bolt', isSideboard: false, quantity: 4 },
+            { cardId: 'Counterspell', isSideboard: false, quantity: 2 },
+        ]);
+        expect(result).toMatchObject({ deckId: 7, saved: 6, errors: [] });
+    });
+
+    it('reports unresolved lines but still imports the rest', async () => {
+        resolver.resolveByName.mockImplementation((name: string) =>
+            name === 'Bogus'
+                ? Promise.resolve({ card: null, error: 'Card not found: "Bogus"' })
+                : Promise.resolve({ card: makeCard(name, name), error: null })
+        );
+
+        const result = await service.importDecklist(1, 'D', null, '4 Lightning Bolt\n1 Bogus');
+
+        expect(result.saved).toBe(4);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toMatchObject({ name: 'Bogus' });
+    });
+
+    it('uses precise resolution for set-coded lines, falling back to name', async () => {
+        resolver.resolveCard.mockResolvedValue({ card: null, error: 'unknown set' });
+        resolver.resolveByName.mockResolvedValue({ card: makeCard('c', 'Sol Ring'), error: null });
+
+        await service.importDecklist(1, 'D', null, '1 Sol Ring (ZZZ) 5');
+
+        expect(resolver.resolveCard).toHaveBeenCalledWith({ set_code: 'zzz', number: '5' });
+        expect(resolver.resolveByName).toHaveBeenCalledWith('Sol Ring');
+    });
+
+    it('aggregates duplicate card+board lines into one entry', async () => {
+        resolver.resolveByName.mockResolvedValue({ card: makeCard('bolt', 'Lightning Bolt'), error: null });
+
+        await service.importDecklist(1, 'D', null, '2 Lightning Bolt\n2 Lightning Bolt');
+
+        expect(deckService.addCards).toHaveBeenCalledWith(7, 1, [
+            { cardId: 'bolt', isSideboard: false, quantity: 4 },
+        ]);
+    });
+});

--- a/test/core/import/card-import-resolver.spec.ts
+++ b/test/core/import/card-import-resolver.spec.ts
@@ -77,15 +77,28 @@ describe('CardImportResolver', () => {
             expect(result.card?.id).toBe('cheap');
         });
 
-        it('falls back to the last printing when none are priced', async () => {
+        it('falls back deterministically (smallest id) when none are priced', async () => {
             mockCardRepo.findWithName.mockResolvedValue([
-                makeCard({ id: 'a' }),
                 makeCard({ id: 'b' }),
+                makeCard({ id: 'a' }),
             ]);
 
             const result = await resolver.resolveByName('Lightning Bolt');
 
-            expect(result.card?.id).toBe('b');
+            // No prices -> tie broken by id so the pick is stable regardless of
+            // the DB's (unordered) row order.
+            expect(result.card?.id).toBe('a');
+        });
+
+        it('breaks price ties on card id for a stable representative', async () => {
+            mockCardRepo.findWithName.mockResolvedValue([
+                priced('zeta', 2),
+                priced('alpha', 2),
+            ]);
+
+            const result = await resolver.resolveByName('Lightning Bolt');
+
+            expect(result.card?.id).toBe('alpha');
         });
 
         it('errors when the name matches nothing', async () => {

--- a/test/core/import/card-import-resolver.spec.ts
+++ b/test/core/import/card-import-resolver.spec.ts
@@ -31,6 +31,7 @@ describe('CardImportResolver', () => {
         findById: jest.fn(),
         findBySetCodeAndNumber: jest.fn(),
         findByNameAndSetCode: jest.fn(),
+        findWithName: jest.fn(),
         findBySet: jest.fn(),
         save: jest.fn(),
         delete: jest.fn(),
@@ -57,6 +58,51 @@ describe('CardImportResolver', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+    });
+
+    describe('resolveByName', () => {
+        const priced = (id: string, normal: number | null) =>
+            makeCard({ id, prices: [{ cardId: id, normal, foil: null, date: new Date() } as any] });
+
+        it('picks the cheapest printing that has a price', async () => {
+            mockCardRepo.findWithName.mockResolvedValue([
+                priced('expensive', 10),
+                priced('cheap', 2),
+                priced('mid', 5),
+            ]);
+
+            const result = await resolver.resolveByName('Lightning Bolt');
+
+            expect(result.error).toBeNull();
+            expect(result.card?.id).toBe('cheap');
+        });
+
+        it('falls back to the last printing when none are priced', async () => {
+            mockCardRepo.findWithName.mockResolvedValue([
+                makeCard({ id: 'a' }),
+                makeCard({ id: 'b' }),
+            ]);
+
+            const result = await resolver.resolveByName('Lightning Bolt');
+
+            expect(result.card?.id).toBe('b');
+        });
+
+        it('errors when the name matches nothing', async () => {
+            mockCardRepo.findWithName.mockResolvedValue([]);
+
+            const result = await resolver.resolveByName('Notacard');
+
+            expect(result.card).toBeNull();
+            expect(result.error).toContain('Card not found');
+        });
+
+        it('errors on an empty name without hitting the repo', async () => {
+            const result = await resolver.resolveByName('   ');
+
+            expect(result.card).toBeNull();
+            expect(mockCardRepo.findWithName).not.toHaveBeenCalled();
+        });
     });
 
     describe('resolveCard', () => {

--- a/test/core/import/parsers/decklist-text.parser.spec.ts
+++ b/test/core/import/parsers/decklist-text.parser.spec.ts
@@ -1,0 +1,53 @@
+import { parseDecklistText } from 'src/core/import/parsers/decklist-text.parser';
+
+describe('parseDecklistText', () => {
+    it('parses plain "4 Name" and "4x Name" counts', () => {
+        const { rows, errors } = parseDecklistText('4 Lightning Bolt\n2x Counterspell');
+        expect(errors).toEqual([]);
+        expect(rows).toEqual([
+            { quantity: 4, name: 'Lightning Bolt', setCode: undefined, number: undefined, isSideboard: false, line: 1 },
+            { quantity: 2, name: 'Counterspell', setCode: undefined, number: undefined, isSideboard: false, line: 2 },
+        ]);
+    });
+
+    it('extracts a (SET) code and optional collector number', () => {
+        const { rows } = parseDecklistText('1 Sol Ring (CMR)\n1 Sol Ring (CMR) 263\n4 Lightning Bolt [2X2]');
+        expect(rows[0]).toMatchObject({ name: 'Sol Ring', setCode: 'cmr', number: undefined });
+        expect(rows[1]).toMatchObject({ name: 'Sol Ring', setCode: 'cmr', number: '263' });
+        expect(rows[2]).toMatchObject({ name: 'Lightning Bolt', setCode: '2x2' });
+    });
+
+    it('routes lines after a Sideboard header to the sideboard', () => {
+        const { rows } = parseDecklistText('4 Lightning Bolt\n\nSideboard\n2 Pyroblast');
+        expect(rows[0]).toMatchObject({ name: 'Lightning Bolt', isSideboard: false });
+        expect(rows[1]).toMatchObject({ name: 'Pyroblast', isSideboard: true });
+    });
+
+    it('honors a per-line SB: prefix', () => {
+        const { rows } = parseDecklistText('SB: 2 Pyroblast');
+        expect(rows[0]).toMatchObject({ name: 'Pyroblast', isSideboard: true, quantity: 2 });
+    });
+
+    it('skips blank lines and non-quantity section headers without error', () => {
+        const { rows, errors } = parseDecklistText('Commander\n1 Atraxa, Praetors’ Voice\n\nDeck\n1 Sol Ring\nCreatures (1)');
+        expect(errors).toEqual([]);
+        expect(rows.map((r) => r.name)).toEqual(['Atraxa, Praetors’ Voice', 'Sol Ring']);
+    });
+
+    it('strips MTGO foil markers', () => {
+        const { rows } = parseDecklistText('4 Lightning Bolt (2X2) 117 *F*');
+        expect(rows[0]).toMatchObject({ name: 'Lightning Bolt', setCode: '2x2', number: '117' });
+    });
+
+    it('flags a digit-led line it cannot parse', () => {
+        const { rows, errors } = parseDecklistText('4\n3 Real Card');
+        expect(rows).toHaveLength(1);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].row).toBe(1);
+    });
+
+    it('ignores a zero quantity', () => {
+        const { rows } = parseDecklistText('0 Lightning Bolt');
+        expect(rows).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #537. All free (no premium gate); name-level matching (any printing satisfies a need); basic lands always count as owned.

## Part A - paste-text import
- `decklist-text.parser.ts` (the `4 Lightning Bolt` / `1 Sol Ring (CMR) 263` formats, Sideboard header, MTGO foil markers) + `resolveByName` on `CardImportResolver` (set-less lines -> cheapest printing) + `DeckImportService`.
- HBS `/decks/import` (form -> result with unresolved lines) and API `POST /api/v1/decks/import`.

## Part B - buildability / gap
- Pure `DeckGapPolicy` + `DeckBuildabilityService` (inventory summed by card name).
- `/decks` rows show completeness % + missing count (ranked); `/decks/:id` gap banner, per-card owned/Need/Basic badges, and "Add missing to buy list" (`POST /api/v1/decks/:id/missing-to-buy-list`).

## Part C - tournament catalog (Scry + web)
- Migration `043` -> `published_deck` + `published_deck_card` (read-only catalog).
- Scry side in matthewdtowles/scry#34: `ingest-decks` reads the fbettega feed behind a `DecklistSource` port. Weekly Monday cron -> `decks.log`.

## Part D - browse + compare
- `/published-decks` (public, format filter, paginated) + `/published-decks/:id` (gap vs inventory, "Copy to my decks", buy-list seed).

## Verification
- Typecheck clean; 1332/1332 unit tests pass. Migration applied locally, app boots, pages render. Real Scry run ingested 601 decks (42 unresolved lines), idempotent at 597 decks / 18,006 rows.

**Deploy order:** publish Scry (matthewdtowles/scry#34) first, then deploy this (migration 043 must create the tables before the new binary runs).