### PR TITLE
feat: deck list card text on hover, mana cost column, deck colors

### DIFF
--- a/src/http/hbs/deck/deck-mana.ts
+++ b/src/http/hbs/deck/deck-mana.ts
@@ -1,0 +1,48 @@
+// Mana helpers shared by the deck detail view: parse a mana-cost string into
+// the token shape the manaCost.hbs partial renders, and roll a deck's mana
+// costs up into the distinct colors it contains.
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { ManaToken } from 'src/http/hbs/card/dto/card.response.dto';
+
+// WUBRG, the canonical color order; deck color pips render in this order.
+const COLOR_ORDER = ['w', 'u', 'b', 'r', 'g'];
+
+/** Parse "{2}{W}{U}" into mana tokens; handles split costs ("a // b") and half pips. */
+export function parseManaTokens(manaCost?: string): ManaToken[] {
+    if (!manaCost || typeof manaCost !== 'string') {
+        return [];
+    }
+    const raw = manaCost.trim();
+    if (raw === '') return [];
+    const faceParts = raw.split(' // ');
+    const tokens: ManaToken[] = [];
+    for (let i = 0; i < faceParts.length; ++i) {
+        const matches = Array.from(faceParts[i].trim().matchAll(/\{([^}]+)\}/g)).map((m) => m[1]);
+        for (const sym of matches) {
+            const lower = sym.toLowerCase().replace('/', '');
+            if (lower.startsWith('h')) {
+                tokens.push({ symbol: lower.substring(1), isHalf: true });
+            } else {
+                tokens.push({ symbol: lower });
+            }
+        }
+        if (i + 1 < faceParts.length) {
+            tokens.push({ sep: ' // ' });
+        }
+    }
+    return tokens;
+}
+
+/** Distinct WUBRG colors present across all the deck's mana costs, in WUBRG order. */
+export function deckColors(cards: DeckCard[]): string[] {
+    const present = new Set<string>();
+    for (const dc of cards) {
+        const cost = dc.card?.manaCost;
+        if (!cost) continue;
+        const lower = cost.toLowerCase();
+        for (const color of COLOR_ORDER) {
+            if (lower.includes(color)) present.add(color);
+        }
+    }
+    return COLOR_ORDER.filter((c) => present.has(c));
+}

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -13,6 +13,7 @@ import { buildCardUrl } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
 import { primaryType, TYPE_ORDER, TYPE_PLURAL } from './deck-grouping';
+import { deckColors, parseManaTokens } from './deck-mana';
 import {
     DeckCardGroupView,
     DeckCardView,
@@ -156,6 +157,7 @@ export class DeckPageOrchestrator {
                 formatOptions: this.buildFormatOptions(deck.format ?? null),
                 mainGroups: this.groupByType(main, deck.format ?? null, gapByRow),
                 sideboard: side.map((c) => this.toCardView(c, deck.format ?? null, gapByRow)),
+                deckColors: deckColors(cards),
                 mainCount: DeckSummaryPolicy.cardCount(main),
                 sideCount: DeckSummaryPolicy.cardCount(side),
                 estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
@@ -231,8 +233,8 @@ export class DeckPageOrchestrator {
             setCode: card?.setCode ?? '',
             number: card?.number ?? '',
             url: card ? buildCardUrl(card.setCode, card.number) : '#',
-            imgSrc: card?.imgSrc ?? '',
-            manaCost: card?.manaCost,
+            manaCost: parseManaTokens(card?.manaCost),
+            oracleText: card?.oracleText,
             quantity: dc.quantity,
             // Full precision; deckDetail.js rounds at display so client-recomputed
             // totals match the server's multiply-then-round lineValue/estimatedValue.

--- a/src/http/hbs/deck/dto/deck.view.dto.ts
+++ b/src/http/hbs/deck/dto/deck.view.dto.ts
@@ -1,4 +1,5 @@
 import { BaseViewDto } from 'src/http/base/base.view.dto';
+import { ManaToken } from 'src/http/hbs/card/dto/card.response.dto';
 
 export interface FormatOptionView {
     value: string;
@@ -72,8 +73,8 @@ export interface DeckCardView {
     setCode: string;
     number: string;
     url: string;
-    imgSrc: string;
-    manaCost?: string;
+    manaCost: ManaToken[];
+    oracleText?: string;
     quantity: number;
     unitValue: number;
     lineValue: string;
@@ -101,6 +102,7 @@ export class DeckDetailViewDto extends BaseViewDto {
     readonly formatOptions: FormatOptionView[];
     readonly mainGroups: DeckCardGroupView[];
     readonly sideboard: DeckCardView[];
+    readonly deckColors: string[];
     readonly mainCount: number;
     readonly sideCount: number;
     readonly estimatedValue: string;
@@ -121,6 +123,7 @@ export class DeckDetailViewDto extends BaseViewDto {
         this.formatOptions = init.formatOptions ?? [];
         this.mainGroups = init.mainGroups ?? [];
         this.sideboard = init.sideboard ?? [];
+        this.deckColors = init.deckColors ?? [];
         this.mainCount = init.mainCount ?? 0;
         this.sideCount = init.sideCount ?? 0;
         this.estimatedValue = init.estimatedValue ?? '$0.00';

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -1014,6 +1014,10 @@ img,
   margin-left: 0.375rem;
 }
 
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
 .ml-4 {
   margin-left: 1rem;
 }
@@ -1116,6 +1120,10 @@ img,
 
 .hidden {
   display: none;
+}
+
+.h-1\.5 {
+  height: 0.375rem;
 }
 
 .h-12 {
@@ -1676,6 +1684,11 @@ img,
   border-color: rgb(44 200 202 / var(--tw-border-opacity, 1));
 }
 
+.bg-amber-100 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 243 199 / var(--tw-bg-opacity, 1));
+}
+
 .bg-amber-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(255 251 235 / var(--tw-bg-opacity, 1));
@@ -1744,6 +1757,11 @@ img,
 .bg-purple-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(250 246 254 / var(--tw-bg-opacity, 1));
+}
+
+.bg-purple-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(169 93 224 / var(--tw-bg-opacity, 1));
 }
 
 .bg-red-100 {
@@ -2247,6 +2265,11 @@ img,
 .text-orange-600 {
   --tw-text-opacity: 1;
   color: rgb(234 88 12 / var(--tw-text-opacity, 1));
+}
+
+.text-purple-500 {
+  --tw-text-opacity: 1;
+  color: rgb(169 93 224 / var(--tw-text-opacity, 1));
 }
 
 .text-purple-600 {
@@ -3548,6 +3571,36 @@ img,
   --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.card-preview-text {
+  width: 16rem;
+  max-width: 16rem;
+  white-space: pre-line;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  line-height: 1.375;
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(31 41 55 / var(--tw-text-opacity, 1));
+}
+
+.dark .card-preview-text {
+  --tw-border-opacity: 1;
+  border-color: rgb(46 39 88 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(26 21 51 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(243 244 246 / var(--tw-text-opacity, 1));
 }
 
 .card-image-wrapper {
@@ -8361,6 +8414,10 @@ img,
 
 .dark\:bg-amber-900\/20:is(.dark *) {
   background-color: rgb(120 53 15 / 0.2);
+}
+
+.dark\:bg-amber-900\/40:is(.dark *) {
+  background-color: rgb(120 53 15 / 0.4);
 }
 
 .dark\:bg-blue-900\/30:is(.dark *) {

--- a/src/http/public/js/cardPreview.js
+++ b/src/http/public/js/cardPreview.js
@@ -1,8 +1,10 @@
 /**
  * Card image preview - hover on desktop, long-press on mobile.
  *
- * Desktop: mouseover/mouseout on .card-name-link[data-card-img] shows a
- *          floating preview image near the link.
+ * Desktop: mouseover/mouseout on a .card-name-link shows a floating preview
+ *          near the link: the card art for links carrying data-card-img, or
+ *          the card's rules text for links carrying data-card-text (used by
+ *          the deck pages, where a deck entry is a card name, not a printing).
  *
  * Mobile:  Touch-and-hold (500 ms) shows the preview while the finger is
  *          down.  Lifting the finger dismisses the preview and suppresses
@@ -12,6 +14,7 @@
 (function () {
     var preview = null;
     var previewImg = null;
+    var previewText = null;
     var activeLink = null;
     var isTouchDevice = false;
     var initialized = false;
@@ -34,15 +37,29 @@
         previewImg.width = 256;
         previewImg.height = 357;
         preview.appendChild(previewImg);
+        previewText = document.createElement('div');
+        previewText.className = 'card-preview-text';
+        preview.appendChild(previewText);
         document.body.appendChild(preview);
     }
 
     function showPreview(link) {
+        if (!preview) return;
         var imgUrl = link.getAttribute('data-card-img');
-        if (!imgUrl || !preview) return;
+        var text = link.getAttribute('data-card-text');
+        if (imgUrl) {
+            previewImg.src = imgUrl;
+            previewImg.alt = link.textContent || '';
+            previewImg.style.display = '';
+            previewText.style.display = 'none';
+        } else if (text) {
+            previewText.textContent = text;
+            previewText.style.display = '';
+            previewImg.style.display = 'none';
+        } else {
+            return;
+        }
         activeLink = link;
-        previewImg.src = imgUrl;
-        previewImg.alt = link.textContent || '';
         preview.style.display = 'block';
         positionPreview(link);
     }
@@ -51,22 +68,23 @@
         if (!preview) return;
         preview.style.display = 'none';
         previewImg.src = '';
+        previewText.textContent = '';
         activeLink = null;
     }
 
     function positionPreview(link) {
         var rect = link.getBoundingClientRect();
-        var imgWidth = 256;
-        var imgHeight = 357;
+        var width = preview.offsetWidth || 256;
+        var height = preview.offsetHeight || 357;
         var top;
-        if (rect.top >= imgHeight + 8) {
-            top = rect.top - imgHeight - 8;
+        if (rect.top >= height + 8) {
+            top = rect.top - height - 8;
         } else {
             top = rect.bottom + 8;
         }
         var left = rect.left;
-        if (left + imgWidth > window.innerWidth) {
-            left = window.innerWidth - imgWidth - 8;
+        if (left + width > window.innerWidth) {
+            left = window.innerWidth - width - 8;
         }
         if (left < 8) left = 8;
         preview.style.top = top + 'px';
@@ -76,7 +94,7 @@
     function closestCardLink(event) {
         var el = event.target;
         if (el && el.nodeType !== 1) el = el.parentElement;
-        return el ? el.closest('.card-name-link[data-card-img]') : null;
+        return el ? el.closest('.card-name-link[data-card-img], .card-name-link[data-card-text]') : null;
     }
 
     // ── Desktop: hover ──────────────────────────────────────────────

--- a/src/http/public/js/deckDetail.js
+++ b/src/http/public/js/deckDetail.js
@@ -6,9 +6,9 @@
  * (deck value, board counts, group counts, illegal count) recompute client-side
  * from data-unit-value on each row. The search box (#536) queries the grouped
  * card endpoint (one row per name) and adds straight to main/sideboard, inserting
- * the new row (creating the type group if needed) without a full reload. Card art
- * on hover comes for free from cardPreview.js, which binds globally to any
- * .card-name-link[data-card-img]. Deck-level edits reload so the server
+ * the new row (creating the type group if needed) without a full reload. Card
+ * rules text on hover comes for free from cardPreview.js, which binds globally
+ * to any .card-name-link[data-card-text]. Deck-level edits reload so the server
  * re-renders legality + grouping.
  */
 document.addEventListener('DOMContentLoaded', function () {
@@ -62,6 +62,18 @@ document.addEventListener('DOMContentLoaded', function () {
 
     function fmt(n) {
         return '$' + (Math.round(n * 100) / 100).toFixed(2);
+    }
+
+    // Render a "{2}{W}{U}" mana-cost string as mana-font icons, mirroring the
+    // server's manaCost.hbs partial so search-added rows match the rendered rows.
+    function renderManaCost(manaCost) {
+        if (!manaCost) return '';
+        return manaCost.replace(/\/\/|\{([^}]+)\}/g, function (match, symbol) {
+            if (!symbol) return '<span class="mana-sep">' + AjaxUtils.escapeHtml(match) + '</span>';
+            var lower = symbol.toLowerCase().replace('/', '');
+            var isHalf = lower.startsWith('h');
+            return '<i class="ms ms-cost ms-shadow ms-' + lower + (isHalf ? ' ms-half' : '') + '"></i>';
+        });
     }
 
     function unitValueOf(card) {
@@ -171,7 +183,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // ── Row / group construction (search-added cards) ───────────────
 
     function buildRow(opts) {
-        // opts: { cardId, name, url, imgSrc, unitValue, quantity, isSideboard, illegal }
+        // opts: { cardId, name, url, oracleText, manaCost, unitValue, quantity, isSideboard, illegal }
         var row = document.createElement('div');
         row.className =
             'flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800';
@@ -193,9 +205,14 @@ document.addEventListener('DOMContentLoaded', function () {
         var link = document.createElement('a');
         link.href = opts.url;
         link.className = 'card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate';
-        if (opts.imgSrc) link.setAttribute('data-card-img', opts.imgSrc);
+        if (opts.oracleText) link.setAttribute('data-card-text', opts.oracleText);
         link.textContent = opts.name;
         row.appendChild(link);
+
+        var mana = document.createElement('span');
+        mana.className = 'deck-mana whitespace-nowrap text-sm';
+        mana.innerHTML = renderManaCost(opts.manaCost);
+        row.appendChild(mana);
 
         if (opts.illegal) {
             var badge = document.createElement('span');
@@ -287,7 +304,8 @@ document.addEventListener('DOMContentLoaded', function () {
             cardId: card.id,
             name: card.name,
             url: cardUrl(card),
-            imgSrc: card.imgSrc,
+            oracleText: card.oracleText,
+            manaCost: card.manaCost,
             unitValue: unitValueOf(card),
             quantity: 1,
             isSideboard: isSideboard,
@@ -398,7 +416,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var link = document.createElement('a');
         link.href = cardUrl(card);
         link.className = 'card-name-link flex-1 text-sm truncate';
-        if (card.imgSrc) link.setAttribute('data-card-img', card.imgSrc);
+        if (card.oracleText) link.setAttribute('data-card-text', card.oracleText);
         link.textContent = card.name;
         item.appendChild(link);
 

--- a/src/http/public/js/deckDetail.js
+++ b/src/http/public/js/deckDetail.js
@@ -72,6 +72,9 @@ document.addEventListener('DOMContentLoaded', function () {
             if (!symbol) return '<span class="mana-sep">' + AjaxUtils.escapeHtml(match) + '</span>';
             var lower = symbol.toLowerCase().replace('/', '');
             var isHalf = lower.startsWith('h');
+            // Strip the leading 'h' so half symbols match the server tokenization
+            // (manaCost.hbs renders {HW} as ms-w ms-half, not ms-hw).
+            if (isHalf) lower = lower.substring(1);
             return '<i class="ms ms-cost ms-shadow ms-' + lower + (isHalf ? ' ms-half' : '') + '"></i>';
         });
     }

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -428,6 +428,15 @@
     @apply w-64 h-auto rounded-lg shadow-lg;
 }
 
+.card-preview-text {
+    @apply w-64 max-w-[16rem] rounded-lg shadow-lg p-3 text-sm leading-snug whitespace-pre-line;
+    @apply bg-white text-gray-800 border border-gray-200;
+}
+
+.dark .card-preview-text {
+    @apply bg-midnight-800 text-gray-100 border-midnight-600;
+}
+
 .card-image-wrapper {
     @apply overflow-hidden rounded-lg max-w-xs mx-auto;
     cursor: zoom-in;

--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -3,7 +3,7 @@
         <div>
             <h1 class="page-title">
                 {{name}}
-                {{#if deckColors}}
+                {{#if deckColors.length}}
                     <span class="deck-colors ml-2 align-middle" title="Colors in this deck">
                         {{#each deckColors}}<i class="ms ms-cost ms-shadow ms-{{this}}"></i>{{/each}}
                     </span>

--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -1,7 +1,14 @@
 <div class="content-wrapper py-6" data-deck-id="{{deckId}}" data-deck-format="{{format}}">
     <div class="flex items-start justify-between mb-2 flex-wrap gap-3">
         <div>
-            <h1 class="page-title">{{name}}</h1>
+            <h1 class="page-title">
+                {{name}}
+                {{#if deckColors}}
+                    <span class="deck-colors ml-2 align-middle" title="Colors in this deck">
+                        {{#each deckColors}}<i class="ms ms-cost ms-shadow ms-{{this}}"></i>{{/each}}
+                    </span>
+                {{/if}}
+            </h1>
             <p class="page-subtitle">
                 <span class="text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
                 <span class="mx-1">&middot;</span>
@@ -83,7 +90,7 @@
                 placeholder="Search by card name&hellip;"
                 class="w-full rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm" />
         </div>
-        <p class="text-xs text-gray-400 mt-1">One result per card name &middot; hover (or long-press) a name for art.</p>
+        <p class="text-xs text-gray-400 mt-1">One result per card name &middot; hover (or long-press) a name for its card text.</p>
         {{!-- Plain container: each result row holds a link + buttons, so the
               listbox/option pattern doesn't apply. The role="status" region
               below announces add results to assistive tech. --}}
@@ -108,7 +115,8 @@
                                 <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
                                 <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
                             </span>
-                            <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                            <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if oracleText}} data-card-text="{{oracleText}}"{{/if}}>{{name}}</a>
+                            <span class="deck-mana whitespace-nowrap text-sm">{{>manaCost card=this}}</span>
                             {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
                             {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400" title="Basic land">Basic</span>{{else}}<span class="text-xs px-2 py-0.5 rounded-full bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300" title="You own enough"><i class="fas fa-check" aria-hidden="true"></i></span>{{/if}}
                             <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
@@ -133,7 +141,8 @@
                                 <span class="deck-qty-val w-7 text-center text-sm font-mono">{{quantity}}</span>
                                 <button type="button" class="deck-step px-2 py-0.5 text-gray-500 hover:text-teal-600 dark:hover:text-teal-400" data-delta="1" aria-label="Increase quantity">+</button>
                             </span>
-                            <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                            <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if oracleText}} data-card-text="{{oracleText}}"{{/if}}>{{name}}</a>
+                            <span class="deck-mana whitespace-nowrap text-sm">{{>manaCost card=this}}</span>
                             {{#if illegal}}<span class="deck-illegal-badge text-xs px-2 py-0.5 rounded-full bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300" title="Not legal in this format">Not legal</span>{{/if}}
                             {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400" title="Basic land">Basic</span>{{else}}<span class="text-xs px-2 py-0.5 rounded-full bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300" title="You own enough"><i class="fas fa-check" aria-hidden="true"></i></span>{{/if}}
                             <span class="deck-line-value text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>

--- a/test/frontend/deckDetailSearch.spec.js
+++ b/test/frontend/deckDetailSearch.spec.js
@@ -76,6 +76,8 @@ function card(overrides) {
             setCode: 'LEA',
             number: '1',
             imgSrc: 'bears.jpg',
+            manaCost: '{1}{G}',
+            oracleText: 'Grizzly Bears has no abilities.',
             prices: { normal: 0.25, foil: null },
             legal: true,
         },
@@ -113,7 +115,8 @@ describe('deck-page in-page search', function () {
         expect(results.length).toBe(1);
         var link = results[0].querySelector('.card-name-link');
         expect(link.textContent).toBe('Grizzly Bears');
-        expect(link.getAttribute('data-card-img')).toBe('bears.jpg');
+        expect(link.getAttribute('data-card-img')).toBeNull();
+        expect(link.getAttribute('data-card-text')).toBe('Grizzly Bears has no abilities.');
         // URL is built client-side from setCode (lowercased) + number, not sent.
         expect(link.getAttribute('href')).toBe('/card/lea/1');
         expect(results[0].querySelectorAll('.deck-result-add').length).toBe(2);
@@ -176,6 +179,10 @@ describe('deck-page in-page search', function () {
         expect(rows[0].getAttribute('data-sideboard')).toBe('false');
         expect(rows[0].querySelector('.deck-qty-val').textContent).toBe('1');
         expect(rows[0].querySelector('.card-name-link').getAttribute('href')).toBe('/card/lea/1');
+        expect(rows[0].querySelector('.card-name-link').getAttribute('data-card-text')).toBe(
+            'Grizzly Bears has no abilities.'
+        );
+        expect(rows[0].querySelectorAll('.deck-mana .ms').length).toBe(2);
 
         expect(document.getElementById('deck-main-count').textContent).toBe('1');
         expect(document.getElementById('deck-est-value').textContent).toBe('$0.25');


### PR DESCRIPTION
## Summary
On the deck detail page, hovering a card showed a broken image (the row set `data-card-img` to a raw `imgSrc` without the scryfall URL prefix). This swaps that hover for the card's rules text, adds a mana cost column, and shows the deck's color identity.

## Changes
- **Hover shows card text** - `cardPreview.js` now renders a text panel for links carrying `data-card-text` (still renders art for `data-card-img` elsewhere); positioning measures the actual panel size. New `.card-preview-text` style. Deck rows + in-page search results carry `data-card-text` (oracle text) instead of the broken `data-card-img`.
- **Mana cost column** - each deck row renders mana symbols (server-side via the existing `manaCost.hbs` partial; client-side for search-added rows via a `renderManaCost` helper). New `deck-mana.ts` parses the mana string into the token shape the partial expects.
- **Deck colors** - `deckColors()` rolls every card's mana cost up into the distinct WUBRG colors present, rendered as mana pips next to the deck title.

## Notes
Deck colors are derived from mana costs only (the `Card` entity has no color-identity field), so a colorless-cost card won't contribute a pip.

## Verification
- `tsc --noEmit`: clean
- Deck unit tests: 54 passed
- Frontend tests: 118 passed (updated `deckDetailSearch.spec.js` for the new `data-card-text` + mana cell)