### PR TITLE
fix: render mana symbols on the deck detail page

### DIFF
--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -1,3 +1,4 @@
+<link href="/public/css/mana.css?v={{assetVersion}}" rel="stylesheet" type="text/css" />
 <div class="content-wrapper py-6" data-deck-id="{{deckId}}" data-deck-format="{{format}}">
     <div class="flex items-start justify-between mb-2 flex-wrap gap-3">
         <div>


### PR DESCRIPTION
## Problem
After #542 merged, the deck detail page showed no mana symbols - neither the deck-color pips next to the title nor the per-card mana cost column.

## Cause
The mana font CSS (`mana.css`, generated by `build:mana`) is linked **per-page**, not in the shared layout. `card.hbs`, `set.hbs`, and `inventoryBinder.hbs` each include it; `deckDetail.hbs` did not. So the `ms-*` icon classes rendered with no font behind them and were invisible.

## Fix
Add the same `mana.css` `<link>` to `deckDetail.hbs`, matching the other pages. One line; no logic change.