### PR TITLE
feat: deck color pips on all deck listings

### DIFF
--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -187,6 +187,7 @@ export class DeckPageOrchestrator {
                 ? deck.updatedAt.toLocaleDateString('en-US', { timeZone: 'UTC' })
                 : '',
             url: `/decks/${deck.id}`,
+            colors: deckColors(cards),
             completeness: gap?.completeness ?? 0,
             missingCount: gap?.missingCount ?? 0,
             buildable: (gap?.missingCount ?? 0) === 0 && cards.length > 0,

--- a/src/http/hbs/deck/dto/deck.view.dto.ts
+++ b/src/http/hbs/deck/dto/deck.view.dto.ts
@@ -15,6 +15,7 @@ export interface DeckListItemView {
     estimatedValue: string;
     updatedAt: string;
     url: string;
+    colors: string[];
     completeness: number;
     missingCount: number;
     buildable: boolean;

--- a/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
+++ b/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
@@ -16,6 +16,7 @@ export interface PublishedDeckListItemView {
     cardCount: number;
     estimatedValue: string;
     url: string;
+    colors: string[];
 }
 
 export class PublishedDeckListViewDto extends BaseViewDto {
@@ -62,6 +63,7 @@ export interface PublishedDeckGroupView {
 export class PublishedDeckDetailViewDto extends BaseViewDto {
     readonly deckId: number;
     readonly deckTitle: string;
+    readonly deckColors: string[];
     readonly tournamentName: string;
     readonly date: string;
     readonly formatLabel: string;
@@ -86,6 +88,7 @@ export class PublishedDeckDetailViewDto extends BaseViewDto {
         super(init);
         this.deckId = init.deckId ?? 0;
         this.deckTitle = init.deckTitle ?? '';
+        this.deckColors = init.deckColors ?? [];
         this.tournamentName = init.tournamentName ?? '';
         this.date = init.date ?? '';
         this.formatLabel = init.formatLabel ?? '';

--- a/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
+++ b/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
@@ -1,4 +1,5 @@
 import { BaseViewDto } from 'src/http/base/base.view.dto';
+import { ManaToken } from 'src/http/hbs/card/dto/card.response.dto';
 
 export interface PublishedFormatOptionView {
     value: string;
@@ -45,8 +46,8 @@ export class PublishedDeckListViewDto extends BaseViewDto {
 export interface PublishedDeckCardView {
     name: string;
     url: string;
-    imgSrc: string;
-    manaCost?: string;
+    manaCost: ManaToken[];
+    oracleText?: string;
     quantity: number;
     lineValue: string;
     owned: number;

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -11,6 +11,7 @@ import { buildCardUrl } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
 import { primaryType, TYPE_ORDER, TYPE_PLURAL } from '../deck/deck-grouping';
+import { deckColors } from '../deck/deck-mana';
 import {
     PublishedDeckCardView,
     PublishedDeckDetailViewDto,
@@ -109,6 +110,7 @@ export class PublishedDeckOrchestrator {
                 ],
                 deckId: deck.id!,
                 deckTitle: title,
+                deckColors: deckColors(cards),
                 tournamentName: deck.tournamentName ?? '',
                 date: this.formatDate(deck.tournamentDate),
                 formatLabel: deck.format ? this.capitalize(deck.format) : 'Unknown format',
@@ -173,6 +175,7 @@ export class PublishedDeckOrchestrator {
             cardCount: DeckSummaryPolicy.cardCount(cards),
             estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
             url: `/published-decks/${deck.id}`,
+            colors: deckColors(cards),
         };
     }
 

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -11,7 +11,7 @@ import { buildCardUrl } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
 import { primaryType, TYPE_ORDER, TYPE_PLURAL } from '../deck/deck-grouping';
-import { deckColors } from '../deck/deck-mana';
+import { deckColors, parseManaTokens } from '../deck/deck-mana';
 import {
     PublishedDeckCardView,
     PublishedDeckDetailViewDto,
@@ -210,8 +210,8 @@ export class PublishedDeckOrchestrator {
         return {
             name: card?.name ?? dc.cardId,
             url: card ? buildCardUrl(card.setCode, card.number) : '#',
-            imgSrc: card?.imgSrc ?? '',
-            manaCost: card?.manaCost,
+            manaCost: parseManaTokens(card?.manaCost),
+            oracleText: card?.oracleText,
             quantity: dc.quantity,
             lineValue: this.formatCurrency(dc.quantity * unitValue),
             owned: gap?.owned ?? 0,

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -1014,10 +1014,6 @@ img,
   margin-left: 0.375rem;
 }
 
-.ml-2 {
-  margin-left: 0.5rem;
-}
-
 .ml-4 {
   margin-left: 1rem;
 }

--- a/src/http/views/deckDetail.hbs
+++ b/src/http/views/deckDetail.hbs
@@ -2,14 +2,7 @@
 <div class="content-wrapper py-6" data-deck-id="{{deckId}}" data-deck-format="{{format}}">
     <div class="flex items-start justify-between mb-2 flex-wrap gap-3">
         <div>
-            <h1 class="page-title">
-                {{name}}
-                {{#if deckColors.length}}
-                    <span class="deck-colors ml-2 align-middle" title="Colors in this deck">
-                        {{#each deckColors}}<i class="ms ms-cost ms-shadow ms-{{this}}"></i>{{/each}}
-                    </span>
-                {{/if}}
-            </h1>
+            <h1 class="page-title">{{name}} {{>deckColors colors=deckColors class="ml-1 align-middle"}}</h1>
             <p class="page-subtitle">
                 <span class="text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
                 <span class="mx-1">&middot;</span>

--- a/src/http/views/decks.hbs
+++ b/src/http/views/decks.hbs
@@ -1,3 +1,4 @@
+<link href="/public/css/mana.css?v={{assetVersion}}" rel="stylesheet" type="text/css" />
 <div class="content-wrapper py-6">
     <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
         <div>
@@ -49,7 +50,10 @@
                             <i class="fas fa-trash" aria-hidden="true"></i>
                         </button>
                     </div>
-                    <div class="mt-1 text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</div>
+                    <div class="mt-1 flex items-center gap-2">
+                        <span class="text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
+                        {{>deckColors colors=colors}}
+                    </div>
                     <div class="mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
                         <span>{{cardCount}} card{{#unless (eq cardCount 1)}}s{{/unless}}</span>
                         <span class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>

--- a/src/http/views/partials/deckColors.hbs
+++ b/src/http/views/partials/deckColors.hbs
@@ -1,0 +1,12 @@
+{{~!--
+  Renders a deck's color identity as whole mana-font pips (WUBRG).
+
+  Parameters:
+    colors - array of color letters ('w','u','b','r','g'), in WUBRG order.
+    class  - optional extra classes for the wrapping span.
+
+  Renders nothing when colors is empty, so callers can drop it inline.
+--~}}
+{{~#if colors.length~}}
+<span class="deck-colors {{class}}" title="Colors in this deck">{{#each colors}}<i class="ms ms-cost ms-shadow ms-{{this}}"></i>{{/each}}</span>
+{{~/if~}}

--- a/src/http/views/publishedDeckDetail.hbs
+++ b/src/http/views/publishedDeckDetail.hbs
@@ -1,7 +1,8 @@
+<link href="/public/css/mana.css?v={{assetVersion}}" rel="stylesheet" type="text/css" />
 <div class="content-wrapper py-6" data-published-deck-id="{{deckId}}">
     <div class="flex items-start justify-between mb-2 flex-wrap gap-3">
         <div>
-            <h1 class="page-title">{{deckTitle}}</h1>
+            <h1 class="page-title">{{deckTitle}} {{>deckColors colors=deckColors class="ml-1 align-middle"}}</h1>
             <p class="page-subtitle">
                 <span class="text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
                 {{#if tournamentName}}<span class="mx-1">&middot;</span>{{tournamentName}}{{/if}}

--- a/src/http/views/publishedDeckDetail.hbs
+++ b/src/http/views/publishedDeckDetail.hbs
@@ -67,7 +67,8 @@
                 {{#each cards}}
                     <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800">
                         <span class="w-7 text-center text-sm font-mono text-gray-500">{{quantity}}</span>
-                        <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                        <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if oracleText}} data-card-text="{{oracleText}}"{{/if}}>{{name}}</a>
+                        <span class="deck-mana whitespace-nowrap text-sm">{{>manaCost card=this}}</span>
                         {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400">Basic</span>{{/if}}
                         <span class="text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
                     </div>
@@ -85,7 +86,8 @@
                 {{#each sideboard}}
                     <div class="flex items-center gap-3 py-1.5 border-b border-gray-100 dark:border-midnight-800">
                         <span class="w-7 text-center text-sm font-mono text-gray-500">{{quantity}}</span>
-                        <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if imgSrc}} data-card-img="{{imgSrc}}"{{/if}}>{{name}}</a>
+                        <a href="{{url}}" class="card-name-link flex-1 text-sm hover:text-teal-600 dark:hover:text-teal-400 truncate"{{#if oracleText}} data-card-text="{{oracleText}}"{{/if}}>{{name}}</a>
+                        <span class="deck-mana whitespace-nowrap text-sm">{{>manaCost card=this}}</span>
                         {{#if missing}}<span class="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300" title="You own {{owned}} of {{quantity}}">Need {{missing}}</span>{{else if isBasic}}<span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 dark:bg-midnight-700 dark:text-gray-400">Basic</span>{{/if}}
                         <span class="text-sm font-mono text-gray-600 dark:text-gray-400 w-16 text-right">{{lineValue}}</span>
                     </div>

--- a/src/http/views/publishedDecks.hbs
+++ b/src/http/views/publishedDecks.hbs
@@ -1,3 +1,4 @@
+<link href="/public/css/mana.css?v={{assetVersion}}" rel="stylesheet" type="text/css" />
 <div class="content-wrapper py-6">
     <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
         <div>
@@ -28,6 +29,7 @@
                         <span class="font-display font-semibold text-lg text-gray-900 dark:text-white">{{title}}</span>
                         <span class="text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold whitespace-nowrap">{{formatLabel}}</span>
                     </div>
+                    {{>deckColors colors=colors class="mt-2 inline-flex"}}
                     {{#if tournamentName}}<div class="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">{{tournamentName}}</div>{{/if}}
                     <div class="mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
                         <span>{{#if result}}{{result}}{{else}}{{cardCount}} cards{{/if}}</span>


### PR DESCRIPTION
## Summary
Make deck color identity and card rows consistent across every deck view.

## Changes
- New shared `partials/deckColors.hbs` - whole WUBRG color pips, renders nothing when colorless. The user deck detail header now uses it too (DRY).
- **`/decks`** (your decks): color pips next to each card's format label.
- **`/published-decks`** (tournament list): color pips under each deck's title.
- **Published deck detail header**: color pips next to the title (mirrors the user deck detail page).
- **Published deck detail rows**: now show card text on hover (not the broken image) and a mana cost column, matching the user deck detail page from #542.
- `deckColors()` / `parseManaTokens()` reused from the deck layer; both list queries already load cards so mana costs are available.
- Load `mana.css` on `decks.hbs`, `publishedDecks.hbs`, and `publishedDeckDetail.hbs` so the glyphs render.

Colors are derived from mana costs and always rendered as whole symbols (never half).

## Verification
- `tsc --noEmit`: clean
- Deck unit tests: 54 passed
- Rebuilt CSS + web container