### PR TITLE
feat: public deck building, published-deck format rows, mana pip ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Note that `docker-compose.prod.yml`'s `etl` service exists but is gated behind `
 
 ### Checking Scry ingest on the production server
 
-The nightly ingest runs from cron, not `docker compose`. `/etc/cron.d/i-want-my-mtg` (installed from `cron/i-want-my-mtg`) runs `/opt/scripts/scry.sh` at **02:00 UTC daily**, appending to `/var/log/i-want-my-mtg/ingestion.log`. Sibling jobs: retention (Sun 03:00 UTC -> `retention.log`), published-deck ingest (Mon 03:30 UTC, `ingest-decks --days 8` -> `decks.log`), price-alert processing (02:15 UTC -> `price-alerts.log`), portfolio-summary refresh (02:30 UTC -> `portfolio.log`), log cleanup (Sun 04:00 UTC -> `cleanup.log`). All times UTC; all jobs run as user `ubuntu`.
+The nightly ingest runs from cron, not `docker compose`. `/etc/cron.d/i-want-my-mtg` (installed from `cron/i-want-my-mtg`) runs `/opt/scripts/scry.sh` at **02:00 UTC daily**, appending to `/var/log/i-want-my-mtg/ingestion.log`. Sibling jobs: retention (Sun 03:00 UTC -> `retention.log`), published-deck ingest (daily 03:30 UTC, `ingest-decks --days 2` -> `decks.log`), price-alert processing (02:15 UTC -> `price-alerts.log`), portfolio-summary refresh (02:30 UTC -> `portfolio.log`), log cleanup (Sun 04:00 UTC -> `cleanup.log`). All times UTC; all jobs run as user `ubuntu`.
 
 `scry.sh` sources `/home/ubuntu/.env` (which sets `DATABASE_URL`) then runs `/opt/scripts/scry <args>` (default `ingest`). **Always go through the wrapper**, never the bare `/opt/scripts/scry`, or `DATABASE_URL` is unset and it fails.
 
@@ -220,6 +220,8 @@ TypeORM is configured with `synchronize: false` — all schema changes must go t
 ## Views
 
 Server-side rendered using Handlebars (`src/http/views/`). Layouts in `views/layouts/`, partials in `views/partials/`. Styled with Tailwind CSS (source in `src/http/styles/`, compiled to `src/http/public/css/`). Custom Handlebars helpers registered in `main.ts`: `toUpperCase`, `toLowerCase`, `capitalize`, `eq`, `gt`, `lt`.
+
+When adding a paginated list, use the established pagination component (`src/http/views/partials/pagination.hbs` plus the `initListPage` AJAX flow in `src/http/public/js/ajaxUtils.js`) for visual consistency across the app, unless there's a specific reason not to. The published-decks page is the one intentional exception: it uses horizontal per-format rows with AJAX side-scroll instead of standard pagination.
 
 ## CI/CD
 

--- a/cron/i-want-my-mtg
+++ b/cron/i-want-my-mtg
@@ -9,8 +9,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Price history retention cleanup (weekly, Sunday at 3 AM)
 0 3 * * 0 ubuntu /opt/scripts/scry.sh retention >> /var/log/i-want-my-mtg/retention.log 2>&1
 
-# Published tournament-deck ingest (weekly, Monday at 3:30 AM; fetches the prior 8 days)
-30 3 * * 1 ubuntu /opt/scripts/scry.sh ingest-decks --days 8 >> /var/log/i-want-my-mtg/decks.log 2>&1
+# Published tournament-deck ingest (daily at 3:30 AM; fetches the prior 2 days)
+30 3 * * * ubuntu /opt/scripts/scry.sh ingest-decks --days 2 >> /var/log/i-want-my-mtg/decks.log 2>&1
 
 # Price alert processing (daily at 2:15 AM, after ingestion completes)
 15 2 * * * ubuntu curl -Sf -X POST -H "x-api-key: $(grep '^INTERNAL_API_KEY=' /home/ubuntu/.env | cut -d= -f2- | sed 's/^"//;s/"$//')" http://localhost/api/v1/price-alerts/process >> /var/log/i-want-my-mtg/price-alerts.log 2>&1

--- a/src/core/published-deck/ports/published-deck.repository.port.ts
+++ b/src/core/published-deck/ports/published-deck.repository.port.ts
@@ -15,9 +15,6 @@ export interface PublishedDeckRepositoryPort {
     /** A page of published decks (with cards + latest price), newest tournament first. */
     findPage(filter: PublishedDeckListFilter): Promise<PublishedDeck[]>;
 
-    /** Total decks matching the filter (for pagination). */
-    count(filter: { format?: string }): Promise<number>;
-
     /** One published deck with its cards (+ set + legalities + latest price), or null. */
     findById(id: number): Promise<PublishedDeck | null>;
 

--- a/src/core/published-deck/published-deck.service.ts
+++ b/src/core/published-deck/published-deck.service.ts
@@ -12,17 +12,19 @@ export class PublishedDeckService {
         private readonly repository: PublishedDeckRepositoryPort
     ) {}
 
-    /** A page of published decks plus the total for pagination. */
-    async list(
+    /**
+     * A page of published decks for one format's row, plus whether more exist.
+     * Fetches limit+1 and derives `hasMore` from the slice, so no COUNT query is
+     * needed per row (or per lazy-load fetch).
+     */
+    async rowPage(
         format: string | undefined,
         limit: number,
         offset: number
-    ): Promise<{ decks: PublishedDeck[]; total: number }> {
-        const [decks, total] = await Promise.all([
-            this.repository.findPage({ format, limit, offset }),
-            this.repository.count({ format }),
-        ]);
-        return { decks, total };
+    ): Promise<{ decks: PublishedDeck[]; hasMore: boolean }> {
+        const rows = await this.repository.findPage({ format, limit: limit + 1, offset });
+        const hasMore = rows.length > limit;
+        return { decks: hasMore ? rows.slice(0, limit) : rows, hasMore };
     }
 
     async get(id: number): Promise<PublishedDeck | null> {

--- a/src/database/published-deck/published-deck.repository.ts
+++ b/src/database/published-deck/published-deck.repository.ts
@@ -50,14 +50,6 @@ export class PublishedDeckRepository implements PublishedDeckRepositoryPort {
         return decks.map((d) => PublishedDeckMapper.toCore(d));
     }
 
-    async count(filter: { format?: string }): Promise<number> {
-        const qb = this.repository.createQueryBuilder('deck');
-        if (filter.format) {
-            qb.where('deck.format = :format', { format: filter.format });
-        }
-        return qb.getCount();
-    }
-
     async findById(id: number): Promise<PublishedDeck | null> {
         const deck = await this.repository
             .createQueryBuilder('deck')

--- a/src/http/hbs/deck/deck-mana.ts
+++ b/src/http/hbs/deck/deck-mana.ts
@@ -33,16 +33,44 @@ export function parseManaTokens(manaCost?: string): ManaToken[] {
     return tokens;
 }
 
-/** Distinct WUBRG colors present across all the deck's mana costs, in WUBRG order. */
-export function deckColors(cards: DeckCard[]): string[] {
-    const present = new Set<string>();
+/** A deck color pip: the WUBRG symbol plus whether to render it small (minor color). */
+export interface DeckColorPip {
+    symbol: string;
+    small: boolean;
+}
+
+// Colors below this share of the deck's colored cards render as a smaller pip,
+// unless they're the most abundant color (or the deck's only color).
+const MINOR_COLOR_THRESHOLD = 0.08;
+
+/**
+ * A deck's color pips ordered by how many cards of that color it contains
+ * (most abundant first; WUBRG breaks ties). A color counts a card's `quantity`
+ * for each WUBRG symbol in its mana cost, so a multicolor card counts toward
+ * each of its colors. Minor colors (< 8% of the colored total) render small,
+ * except the most abundant color and a single-color deck, which never do.
+ */
+export function deckColorPips(cards: DeckCard[]): DeckColorPip[] {
+    const weights = new Map<string, number>();
     for (const dc of cards) {
         const cost = dc.card?.manaCost;
         if (!cost) continue;
         const lower = cost.toLowerCase();
         for (const color of COLOR_ORDER) {
-            if (lower.includes(color)) present.add(color);
+            if (lower.includes(color)) {
+                weights.set(color, (weights.get(color) ?? 0) + dc.quantity);
+            }
         }
     }
-    return COLOR_ORDER.filter((c) => present.has(c));
+    if (weights.size === 0) return [];
+
+    const total = Array.from(weights.values()).reduce((sum, w) => sum + w, 0);
+    const ordered = COLOR_ORDER.filter((c) => weights.has(c)).sort(
+        (a, b) => weights.get(b)! - weights.get(a)!
+    );
+    const single = ordered.length === 1;
+    return ordered.map((color, index) => ({
+        symbol: color,
+        small: !single && index !== 0 && weights.get(color)! / total < MINOR_COLOR_THRESHOLD,
+    }));
 }

--- a/src/http/hbs/deck/deck-mana.ts
+++ b/src/http/hbs/deck/deck-mana.ts
@@ -67,7 +67,8 @@ export function deckColorPips(cards: DeckCard[]): DeckColorPip[] {
 
     const total = Array.from(weights.values()).reduce((sum, w) => sum + w, 0);
     const ordered = COLOR_ORDER.filter((c) => weights.has(c)).sort(
-        (a, b) => weights.get(b)! - weights.get(a)!
+        // Heaviest color first; equal weights fall back to canonical WUBRG order.
+        (a, b) => weights.get(b)! - weights.get(a)! || COLOR_ORDER.indexOf(a) - COLOR_ORDER.indexOf(b)
     );
     const single = ordered.length === 1;
     return ordered.map((color, index) => ({

--- a/src/http/hbs/deck/deck-mana.ts
+++ b/src/http/hbs/deck/deck-mana.ts
@@ -45,9 +45,10 @@ const MINOR_COLOR_THRESHOLD = 0.08;
 
 /**
  * A deck's color pips ordered by how many cards of that color it contains
- * (most abundant first; WUBRG breaks ties). A color counts a card's `quantity`
- * for each WUBRG symbol in its mana cost, so a multicolor card counts toward
- * each of its colors. Minor colors (< 8% of the colored total) render small,
+ * (most abundant first; WUBRG breaks ties). A color's weight adds a card's
+ * `quantity` once per WUBRG color present in its mana cost - so a multicolor
+ * card counts toward each of its colors, but a repeated symbol like {R}{R}
+ * does not count twice. Minor colors (< 8% of the colored total) render small,
  * except the most abundant color and a single-color deck, which never do.
  */
 export function deckColorPips(cards: DeckCard[]): DeckColorPip[] {

--- a/src/http/hbs/deck/deck-page.controller.ts
+++ b/src/http/hbs/deck/deck-page.controller.ts
@@ -11,6 +11,7 @@ import {
     UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
+import { OptionalAuthGuard } from 'src/http/auth/optional-auth.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { DeckPageOrchestrator } from './deck-page.orchestrator';
 import {
@@ -33,7 +34,7 @@ export class DeckPageController {
         return this.orchestrator.buildListView(req);
     }
 
-    @UseGuards(JwtAuthGuard)
+    @UseGuards(OptionalAuthGuard)
     @Get('import')
     @Render('deckImport')
     importForm(@Req() req: AuthenticatedRequest): DeckImportViewDto {

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -13,7 +13,7 @@ import { buildCardUrl } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
 import { primaryType, TYPE_ORDER, TYPE_PLURAL } from './deck-grouping';
-import { deckColors, parseManaTokens } from './deck-mana';
+import { deckColorPips, parseManaTokens } from './deck-mana';
 import {
     DeckCardGroupView,
     DeckCardView,
@@ -41,14 +41,18 @@ export class DeckPageOrchestrator {
     ) {}
 
     buildImportView(req: AuthenticatedRequest): DeckImportViewDto {
-        HttpErrorHandler.validateAuthenticatedRequest(req);
+        // Public: anyone can load the build form. Saving (POST) still requires
+        // auth; an anonymous user is bounced to login and their work preserved.
+        const authenticated = !!req.user;
         return new DeckImportViewDto({
-            authenticated: true,
-            title: 'Import deck - I Want My MTG',
+            authenticated,
+            title: 'Build a deck - I Want My MTG',
             breadcrumbs: [
                 { label: 'Home', url: '/' },
-                { label: 'Decks', url: '/decks' },
-                { label: 'Import', url: '/decks/import' },
+                authenticated
+                    ? { label: 'Decks', url: '/decks' }
+                    : { label: 'Tournament decks', url: '/published-decks' },
+                { label: 'Build', url: '/decks/import' },
             ],
             formatOptions: this.buildFormatOptions(null),
         });
@@ -157,7 +161,7 @@ export class DeckPageOrchestrator {
                 formatOptions: this.buildFormatOptions(deck.format ?? null),
                 mainGroups: this.groupByType(main, deck.format ?? null, gapByRow),
                 sideboard: side.map((c) => this.toCardView(c, deck.format ?? null, gapByRow)),
-                deckColors: deckColors(cards),
+                deckColors: deckColorPips(cards),
                 mainCount: DeckSummaryPolicy.cardCount(main),
                 sideCount: DeckSummaryPolicy.cardCount(side),
                 estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
@@ -187,7 +191,7 @@ export class DeckPageOrchestrator {
                 ? deck.updatedAt.toLocaleDateString('en-US', { timeZone: 'UTC' })
                 : '',
             url: `/decks/${deck.id}`,
-            colors: deckColors(cards),
+            colors: deckColorPips(cards),
             completeness: gap?.completeness ?? 0,
             missingCount: gap?.missingCount ?? 0,
             buildable: (gap?.missingCount ?? 0) === 0 && cards.length > 0,

--- a/src/http/hbs/deck/dto/deck.view.dto.ts
+++ b/src/http/hbs/deck/dto/deck.view.dto.ts
@@ -1,5 +1,6 @@
 import { BaseViewDto } from 'src/http/base/base.view.dto';
 import { ManaToken } from 'src/http/hbs/card/dto/card.response.dto';
+import { DeckColorPip } from 'src/http/hbs/deck/deck-mana';
 
 export interface FormatOptionView {
     value: string;
@@ -15,7 +16,7 @@ export interface DeckListItemView {
     estimatedValue: string;
     updatedAt: string;
     url: string;
-    colors: string[];
+    colors: DeckColorPip[];
     completeness: number;
     missingCount: number;
     buildable: boolean;
@@ -103,7 +104,7 @@ export class DeckDetailViewDto extends BaseViewDto {
     readonly formatOptions: FormatOptionView[];
     readonly mainGroups: DeckCardGroupView[];
     readonly sideboard: DeckCardView[];
-    readonly deckColors: string[];
+    readonly deckColors: DeckColorPip[];
     readonly mainCount: number;
     readonly sideCount: number;
     readonly estimatedValue: string;

--- a/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
+++ b/src/http/hbs/published-deck/dto/published-deck.view.dto.ts
@@ -1,10 +1,10 @@
 import { BaseViewDto } from 'src/http/base/base.view.dto';
 import { ManaToken } from 'src/http/hbs/card/dto/card.response.dto';
+import { DeckColorPip } from 'src/http/hbs/deck/deck-mana';
 
 export interface PublishedFormatOptionView {
     value: string;
     label: string;
-    selected: boolean;
 }
 
 export interface PublishedDeckListItemView {
@@ -17,29 +17,40 @@ export interface PublishedDeckListItemView {
     cardCount: number;
     estimatedValue: string;
     url: string;
-    colors: string[];
+    colors: DeckColorPip[];
+}
+
+/** One format's horizontally-scrolling row of decks (newest first). */
+export interface PublishedDeckRowView {
+    format: string;
+    label: string;
+    decks: PublishedDeckListItemView[];
+    nextOffset: number;
+    hasMore: boolean;
+}
+
+/** Payload for the AJAX endpoint that lazy-loads older decks in a row. */
+export interface PublishedDeckRowPage {
+    items: PublishedDeckListItemView[];
+    nextOffset: number;
+    hasMore: boolean;
 }
 
 export class PublishedDeckListViewDto extends BaseViewDto {
-    readonly decks: PublishedDeckListItemView[];
+    // One row per primary format that has decks (standard, pioneer, modern,
+    // legacy, commander), each newest-first with AJAX side-scroll for older decks.
+    readonly rows: PublishedDeckRowView[];
     readonly hasDecks: boolean;
-    readonly formats: PublishedFormatOptionView[];
-    readonly page: number;
-    readonly hasPrev: boolean;
-    readonly hasNext: boolean;
-    readonly prevUrl: string;
-    readonly nextUrl: string;
+    // Remaining formats present in the catalog, revealed by "View all formats".
+    readonly otherFormats: PublishedFormatOptionView[];
+    readonly hasOtherFormats: boolean;
 
     constructor(init: Partial<PublishedDeckListViewDto>) {
         super(init);
-        this.decks = init.decks ?? [];
+        this.rows = init.rows ?? [];
         this.hasDecks = init.hasDecks ?? false;
-        this.formats = init.formats ?? [];
-        this.page = init.page ?? 1;
-        this.hasPrev = init.hasPrev ?? false;
-        this.hasNext = init.hasNext ?? false;
-        this.prevUrl = init.prevUrl ?? '';
-        this.nextUrl = init.nextUrl ?? '';
+        this.otherFormats = init.otherFormats ?? [];
+        this.hasOtherFormats = init.hasOtherFormats ?? false;
     }
 }
 
@@ -64,7 +75,7 @@ export interface PublishedDeckGroupView {
 export class PublishedDeckDetailViewDto extends BaseViewDto {
     readonly deckId: number;
     readonly deckTitle: string;
-    readonly deckColors: string[];
+    readonly deckColors: DeckColorPip[];
     readonly tournamentName: string;
     readonly date: string;
     readonly formatLabel: string;

--- a/src/http/hbs/published-deck/published-deck.controller.ts
+++ b/src/http/hbs/published-deck/published-deck.controller.ts
@@ -21,6 +21,7 @@ import { PublishedDeckOrchestrator } from './published-deck.orchestrator';
 import {
     PublishedDeckDetailViewDto,
     PublishedDeckListViewDto,
+    PublishedDeckRowPage,
 } from './dto/published-deck.view.dto';
 
 @Controller('published-decks')
@@ -33,12 +34,25 @@ export class PublishedDeckController {
     @UseGuards(OptionalAuthGuard)
     @Get()
     @Render('publishedDecks')
-    async list(
-        @Req() req: AuthenticatedRequest,
+    async list(@Req() req: AuthenticatedRequest): Promise<PublishedDeckListViewDto> {
+        return this.orchestrator.buildListView(req);
+    }
+
+    // AJAX: a batch of decks for one format's row (side-scroll + "view all").
+    // Declared before :id so "rows" isn't parsed as a deck id.
+    @UseGuards(OptionalAuthGuard)
+    @Get('rows')
+    async rows(
         @Query('format') format?: string,
-        @Query('page') page?: string
-    ): Promise<PublishedDeckListViewDto> {
-        return this.orchestrator.buildListView(req, format || undefined, parseInt(page ?? '1', 10));
+        @Query('offset') offset?: string,
+        @Query('limit') limit?: string
+    ): Promise<{ success: boolean; data: PublishedDeckRowPage }> {
+        const page = await this.orchestrator.buildRow(
+            format || undefined,
+            parseInt(offset ?? '0', 10),
+            parseInt(limit ?? '12', 10)
+        );
+        return { success: true, data: page };
     }
 
     @UseGuards(OptionalAuthGuard)

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -50,9 +50,13 @@ export class PublishedDeckOrchestrator {
             const present = await this.publishedDeckService.formats();
             const presentSet = new Set(present);
             const primary = PRIMARY_FORMATS.filter((f) => presentSet.has(f));
+            // If none of the primary formats are present (e.g. only Pauper),
+            // show every present format as a row so the page isn't blank behind
+            // a "View all formats" button.
+            const rowFormats = primary.length > 0 ? primary : present;
 
             const rows: PublishedDeckRowView[] = await Promise.all(
-                primary.map(async (format) => {
+                rowFormats.map(async (format) => {
                     const { decks, total } = await this.publishedDeckService.list(
                         format,
                         ROW_SIZE,
@@ -68,7 +72,9 @@ export class PublishedDeckOrchestrator {
                 })
             );
 
-            const others = present.filter((f) => !PRIMARY_FORMATS.includes(f));
+            // Only the formats not already shown as rows go behind "View all".
+            const others =
+                primary.length > 0 ? present.filter((f) => !PRIMARY_FORMATS.includes(f)) : [];
             return new PublishedDeckListViewDto({
                 authenticated: !!req.user,
                 indexable: true,

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -11,16 +11,23 @@ import { buildCardUrl } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
 import { primaryType, TYPE_ORDER, TYPE_PLURAL } from '../deck/deck-grouping';
-import { deckColors, parseManaTokens } from '../deck/deck-mana';
+import { deckColorPips, parseManaTokens } from '../deck/deck-mana';
 import {
     PublishedDeckCardView,
     PublishedDeckDetailViewDto,
     PublishedDeckGroupView,
+    PublishedDeckListItemView,
     PublishedDeckListViewDto,
-    PublishedFormatOptionView,
+    PublishedDeckRowPage,
+    PublishedDeckRowView,
 } from './dto/published-deck.view.dto';
 
-const PAGE_SIZE = 24;
+// Formats shown as their own row by default, in this order. Any other format
+// present in the catalog is revealed by the "View all formats" control.
+const PRIMARY_FORMATS = ['standard', 'pioneer', 'modern', 'legacy', 'commander'];
+// Decks loaded per row initially and per AJAX side-scroll batch.
+const ROW_SIZE = 12;
+const MAX_ROW_LIMIT = 48;
 
 @Injectable()
 export class PublishedDeckOrchestrator {
@@ -38,42 +45,67 @@ export class PublishedDeckOrchestrator {
         @Inject(DeckService) private readonly deckService: DeckService
     ) {}
 
-    async buildListView(
-        req: AuthenticatedRequest,
-        format: string | undefined,
-        page: number
-    ): Promise<PublishedDeckListViewDto> {
+    async buildListView(req: AuthenticatedRequest): Promise<PublishedDeckListViewDto> {
         try {
-            const safePage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
-            const offset = (safePage - 1) * PAGE_SIZE;
-            const [{ decks, total }, formats] = await Promise.all([
-                this.publishedDeckService.list(format, PAGE_SIZE, offset),
-                this.publishedDeckService.formats(),
-            ]);
-            const baseUrl = format ? `/published-decks?format=${encodeURIComponent(format)}&` : '/published-decks?';
+            const present = await this.publishedDeckService.formats();
+            const presentSet = new Set(present);
+            const primary = PRIMARY_FORMATS.filter((f) => presentSet.has(f));
+
+            const rows: PublishedDeckRowView[] = await Promise.all(
+                primary.map(async (format) => {
+                    const { decks, total } = await this.publishedDeckService.list(
+                        format,
+                        ROW_SIZE,
+                        0
+                    );
+                    return {
+                        format,
+                        label: this.capitalize(format),
+                        decks: decks.map((d) => this.toListItem(d)),
+                        nextOffset: decks.length,
+                        hasMore: decks.length < total,
+                    };
+                })
+            );
+
+            const others = present.filter((f) => !PRIMARY_FORMATS.includes(f));
             return new PublishedDeckListViewDto({
                 authenticated: !!req.user,
                 indexable: true,
                 title: 'Tournament decks - I Want My MTG',
                 metaDescription:
-                    'Browse published tournament decklists and see which ones you can build from your collection.',
+                    'Browse published tournament decklists by format and see which ones you can build from your collection.',
                 breadcrumbs: [
                     { label: 'Home', url: '/' },
                     { label: 'Tournament decks', url: '/published-decks' },
                 ],
-                decks: decks.map((d) => this.toListItem(d)),
-                hasDecks: decks.length > 0,
-                formats: this.buildFormatOptions(formats, format),
-                page: safePage,
-                hasPrev: safePage > 1,
-                hasNext: offset + decks.length < total,
-                prevUrl: `${baseUrl}page=${safePage - 1}`,
-                nextUrl: `${baseUrl}page=${safePage + 1}`,
+                rows,
+                hasDecks: present.length > 0,
+                otherFormats: others.map((f) => ({ value: f, label: this.capitalize(f) })),
+                hasOtherFormats: others.length > 0,
             });
         } catch (error) {
             this.LOGGER.debug(`Error building published deck list: ${error?.message}`);
             return HttpErrorHandler.toHttpException(error, 'buildListView');
         }
+    }
+
+    /** A batch of decks for one format's row (AJAX side-scroll / "view all"). */
+    async buildRow(
+        format: string | undefined,
+        offset: number,
+        limit: number
+    ): Promise<PublishedDeckRowPage> {
+        if (!format) {
+            return { items: [], nextOffset: 0, hasMore: false };
+        }
+        const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 0;
+        const safeLimit =
+            Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), MAX_ROW_LIMIT) : ROW_SIZE;
+        const { decks, total } = await this.publishedDeckService.list(format, safeLimit, safeOffset);
+        const items: PublishedDeckListItemView[] = decks.map((d) => this.toListItem(d));
+        const nextOffset = safeOffset + decks.length;
+        return { items, nextOffset, hasMore: nextOffset < total };
     }
 
     async buildDetailView(
@@ -110,7 +142,7 @@ export class PublishedDeckOrchestrator {
                 ],
                 deckId: deck.id!,
                 deckTitle: title,
-                deckColors: deckColors(cards),
+                deckColors: deckColorPips(cards),
                 tournamentName: deck.tournamentName ?? '',
                 date: this.formatDate(deck.tournamentDate),
                 formatLabel: deck.format ? this.capitalize(deck.format) : 'Unknown format',
@@ -175,7 +207,7 @@ export class PublishedDeckOrchestrator {
             cardCount: DeckSummaryPolicy.cardCount(cards),
             estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),
             url: `/published-decks/${deck.id}`,
-            colors: deckColors(cards),
+            colors: deckColorPips(cards),
         };
     }
 
@@ -237,19 +269,6 @@ export class PublishedDeckOrchestrator {
         } catch {
             return '';
         }
-    }
-
-    private buildFormatOptions(
-        formats: string[],
-        selected: string | undefined
-    ): PublishedFormatOptionView[] {
-        const options: PublishedFormatOptionView[] = [
-            { value: '', label: 'All formats', selected: !selected },
-        ];
-        for (const f of formats) {
-            options.push({ value: f, label: this.capitalize(f), selected: f === selected });
-        }
-        return options;
     }
 
     private formatDate(date?: Date | null): string {

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -57,7 +57,7 @@ export class PublishedDeckOrchestrator {
 
             const rows: PublishedDeckRowView[] = await Promise.all(
                 rowFormats.map(async (format) => {
-                    const { decks, total } = await this.publishedDeckService.list(
+                    const { decks, hasMore } = await this.publishedDeckService.rowPage(
                         format,
                         ROW_SIZE,
                         0
@@ -67,7 +67,7 @@ export class PublishedDeckOrchestrator {
                         label: this.capitalize(format),
                         decks: decks.map((d) => this.toListItem(d)),
                         nextOffset: decks.length,
-                        hasMore: decks.length < total,
+                        hasMore,
                     };
                 })
             );
@@ -108,10 +108,13 @@ export class PublishedDeckOrchestrator {
         const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.floor(offset) : 0;
         const safeLimit =
             Number.isFinite(limit) && limit > 0 ? Math.min(Math.floor(limit), MAX_ROW_LIMIT) : ROW_SIZE;
-        const { decks, total } = await this.publishedDeckService.list(format, safeLimit, safeOffset);
+        const { decks, hasMore } = await this.publishedDeckService.rowPage(
+            format,
+            safeLimit,
+            safeOffset
+        );
         const items: PublishedDeckListItemView[] = decks.map((d) => this.toListItem(d));
-        const nextOffset = safeOffset + decks.length;
-        return { items, nextOffset, hasMore: nextOffset < total };
+        return { items, nextOffset: safeOffset + items.length, hasMore };
     }
 
     async buildDetailView(

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -946,6 +946,11 @@ img,
   margin: 1.5rem;
 }
 
+.-mx-1 {
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+}
+
 .mx-1 {
   margin-left: 0.25rem;
   margin-right: 0.25rem;
@@ -1254,6 +1259,10 @@ img,
   width: 100%;
 }
 
+.w-px {
+  width: 1px;
+}
+
 .min-w-0 {
   min-width: 0px;
 }
@@ -1310,6 +1319,10 @@ img,
   flex-shrink: 0;
 }
 
+.shrink-0 {
+  flex-shrink: 0;
+}
+
 .border-collapse {
   border-collapse: collapse;
 }
@@ -1345,6 +1358,14 @@ img,
 
 .resize {
   resize: both;
+}
+
+.snap-x {
+  scroll-snap-type: x var(--tw-scroll-snap-strictness);
+}
+
+.snap-start {
+  scroll-snap-align: start;
 }
 
 .list-inside {
@@ -1951,6 +1972,10 @@ img,
 
 .pb-2 {
   padding-bottom: 0.5rem;
+}
+
+.pb-3 {
+  padding-bottom: 0.75rem;
 }
 
 .pb-4 {
@@ -8173,6 +8198,14 @@ img,
   .tile-quick-add {
     transition: none;
   }
+}
+
+/* Minor-color deck pips render smaller than the dominant colors. Scoped to
+   .deck-colors so it outranks mana.css's .ms-cost size regardless of load order. */
+
+.deck-colors .deck-pip-sm {
+  font-size: 0.62em;
+  vertical-align: 0.12em;
 }
 
 .after\:absolute::after {

--- a/src/http/public/js/deckImportAuth.js
+++ b/src/http/public/js/deckImportAuth.js
@@ -1,0 +1,75 @@
+/**
+ * Public deck building: the build/import form is reachable without auth, but
+ * saving needs an account. When an anonymous user submits, stash their list in
+ * localStorage and send them to login/signup (returnUrl brings them back). On
+ * return - now authenticated - repopulate the fields and auto-save. The stash
+ * survives a login or signup round-trip, so their work is never lost.
+ */
+(function () {
+    var STORAGE_KEY = 'pendingDeckImport';
+    var RETURN_URL = '/decks/import';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var form = document.getElementById('deck-import-form');
+        if (!form) return;
+
+        var authenticated = form.getAttribute('data-authenticated') === 'true';
+        var nameInput = document.getElementById('deck-name');
+        var formatInput = document.getElementById('deck-format');
+        var textInput = document.getElementById('deck-text');
+
+        var stored = readStored();
+
+        if (stored) {
+            // Bring back whatever they typed before being sent to login.
+            if (nameInput && stored.name) nameInput.value = stored.name;
+            if (formatInput && stored.format) formatInput.value = stored.format;
+            if (textInput && stored.text) textInput.value = stored.text;
+
+            // If they came back logged in, finish the save automatically.
+            if (authenticated) {
+                clearStored();
+                form.submit();
+                return;
+            }
+        }
+
+        if (!authenticated) {
+            form.addEventListener('submit', function (e) {
+                e.preventDefault();
+                writeStored({
+                    name: nameInput ? nameInput.value : '',
+                    format: formatInput ? formatInput.value : '',
+                    text: textInput ? textInput.value : '',
+                });
+                window.location.href =
+                    '/auth/login?returnUrl=' + encodeURIComponent(RETURN_URL);
+            });
+        }
+    });
+
+    function readStored() {
+        try {
+            var raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? JSON.parse(raw) : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function writeStored(payload) {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+        } catch (e) {
+            /* storage unavailable - fall through, the POST will just 401 */
+        }
+    }
+
+    function clearStored() {
+        try {
+            localStorage.removeItem(STORAGE_KEY);
+        } catch (e) {
+            /* ignore */
+        }
+    }
+})();

--- a/src/http/public/js/deckImportAuth.js
+++ b/src/http/public/js/deckImportAuth.js
@@ -61,7 +61,8 @@
         try {
             localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
         } catch (e) {
-            /* storage unavailable - fall through, the POST will just 401 */
+            /* storage unavailable - we still redirect to login below, but the
+               typed decklist can't be preserved across the round-trip */
         }
     }
 

--- a/src/http/public/js/publishedDecks.js
+++ b/src/http/public/js/publishedDecks.js
@@ -37,7 +37,7 @@
         if (!state.hasMore) return;
 
         if (typeof IntersectionObserver === 'undefined') {
-            // No observer support: load the rest in one go on first scroll.
+            // No observer support: load the next batch whenever the track scrolls.
             track.addEventListener(
                 'scroll',
                 function () {

--- a/src/http/public/js/publishedDecks.js
+++ b/src/http/public/js/publishedDecks.js
@@ -1,0 +1,235 @@
+/**
+ * Published tournament decks: one horizontally-scrolling row per format. Each
+ * row lazy-loads older decks (newest-first) as it's scrolled toward the end,
+ * and "View all formats" pulls in the rows for non-primary formats on demand.
+ *
+ * The card/row markup here mirrors the publishedDeckCard.hbs / publishedDeckRow.hbs
+ * partials - keep them in sync.
+ */
+(function () {
+    var ROWS_ENDPOINT = '/published-decks/rows';
+    var BATCH = 12;
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.deck-row').forEach(setupRow);
+
+        var viewAllBtn = document.getElementById('view-all-formats');
+        if (viewAllBtn) {
+            viewAllBtn.addEventListener('click', function () {
+                viewAllBtn.disabled = true;
+                loadOtherFormats(viewAllBtn);
+            });
+        }
+    });
+
+    /** Wire up a row's lazy side-scroll loading. */
+    function setupRow(section) {
+        var track = section.querySelector('.deck-row-track');
+        var sentinel = section.querySelector('.deck-row-sentinel');
+        if (!track || !sentinel) return;
+
+        var state = {
+            format: section.getAttribute('data-format'),
+            nextOffset: parseInt(section.getAttribute('data-next-offset'), 10) || 0,
+            hasMore: section.getAttribute('data-has-more') === 'true',
+            loading: false,
+        };
+        if (!state.hasMore) return;
+
+        if (typeof IntersectionObserver === 'undefined') {
+            // No observer support: load the rest in one go on first scroll.
+            track.addEventListener(
+                'scroll',
+                function () {
+                    loadMore(track, sentinel, state);
+                },
+                { passive: true }
+            );
+            return;
+        }
+
+        var observer = new IntersectionObserver(
+            function (entries) {
+                if (entries[0].isIntersecting) loadMore(track, sentinel, state, observer);
+            },
+            // root is the scroll container; prefetch a bit before the end is reached.
+            { root: track, rootMargin: '0px 300px 0px 0px' }
+        );
+        observer.observe(sentinel);
+    }
+
+    function loadMore(track, sentinel, state, observer) {
+        if (state.loading || !state.hasMore) return;
+        state.loading = true;
+
+        var url =
+            ROWS_ENDPOINT +
+            '?format=' +
+            encodeURIComponent(state.format) +
+            '&offset=' +
+            state.nextOffset +
+            '&limit=' +
+            BATCH;
+
+        fetch(url, { credentials: 'same-origin' })
+            .then(function (res) {
+                return res.json();
+            })
+            .then(function (json) {
+                state.loading = false;
+                if (!json || !json.success || !json.data) {
+                    state.hasMore = false;
+                    if (observer) observer.disconnect();
+                    return;
+                }
+                var data = json.data;
+                (data.items || []).forEach(function (item) {
+                    track.insertBefore(buildCard(item), sentinel);
+                });
+                state.nextOffset = data.nextOffset;
+                state.hasMore = !!data.hasMore;
+                if (!state.hasMore && observer) observer.disconnect();
+            })
+            .catch(function () {
+                state.loading = false;
+                state.hasMore = false;
+                if (observer) observer.disconnect();
+            });
+    }
+
+    /** Fetch and render the first batch for each non-primary format. */
+    function loadOtherFormats(btn) {
+        var formats = (btn.getAttribute('data-formats') || '')
+            .split(',')
+            .map(function (f) {
+                return f.trim();
+            })
+            .filter(Boolean);
+        var container = document.getElementById('other-format-rows');
+        if (!container || formats.length === 0) {
+            btn.remove();
+            return;
+        }
+
+        Promise.all(
+            formats.map(function (format) {
+                return fetch(
+                    ROWS_ENDPOINT + '?format=' + encodeURIComponent(format) + '&offset=0&limit=' + BATCH,
+                    { credentials: 'same-origin' }
+                )
+                    .then(function (res) {
+                        return res.json();
+                    })
+                    .then(function (json) {
+                        return { format: format, data: json && json.success ? json.data : null };
+                    })
+                    .catch(function () {
+                        return { format: format, data: null };
+                    });
+            })
+        ).then(function (results) {
+            results.forEach(function (r) {
+                if (!r.data || !r.data.items || r.data.items.length === 0) return;
+                var section = buildRow(r.format, r.data);
+                container.appendChild(section);
+                setupRow(section);
+            });
+            btn.remove();
+        });
+    }
+
+    /** Build a row <section> matching publishedDeckRow.hbs, then fill its cards. */
+    function buildRow(format, data) {
+        var section = document.createElement('section');
+        section.className = 'deck-row';
+        section.setAttribute('data-format', format);
+        section.setAttribute('data-next-offset', String(data.nextOffset));
+        section.setAttribute('data-has-more', data.hasMore ? 'true' : 'false');
+
+        var heading = document.createElement('h2');
+        heading.className =
+            'font-display font-semibold text-lg text-gray-900 dark:text-white mb-3';
+        heading.textContent = capitalize(format);
+        section.appendChild(heading);
+
+        var track = document.createElement('div');
+        track.className = 'deck-row-track flex gap-4 overflow-x-auto pb-3 -mx-1 px-1 snap-x';
+
+        var sentinel = document.createElement('div');
+        sentinel.className = 'deck-row-sentinel shrink-0 w-px';
+        sentinel.setAttribute('aria-hidden', 'true');
+
+        (data.items || []).forEach(function (item) {
+            track.appendChild(buildCard(item));
+        });
+        track.appendChild(sentinel);
+        section.appendChild(track);
+        return section;
+    }
+
+    /** Build one deck card, mirroring publishedDeckCard.hbs. */
+    function buildCard(item) {
+        var wrap = document.createElement('div');
+        wrap.className = 'deck-row-item snap-start shrink-0 w-64';
+
+        var a = document.createElement('a');
+        a.href = item.url;
+        a.className =
+            'published-deck-card section-container block h-full hover:border-teal-400 dark:hover:border-teal-500 transition-colors';
+
+        var title = document.createElement('span');
+        title.className = 'block font-display font-semibold text-base text-gray-900 dark:text-white';
+        title.textContent = item.title;
+        a.appendChild(title);
+
+        var pips = buildPips(item.colors);
+        if (pips) a.appendChild(pips);
+
+        if (item.tournamentName) {
+            var tourney = document.createElement('div');
+            tourney.className = 'mt-1 text-sm text-gray-600 dark:text-gray-400 truncate';
+            tourney.textContent = item.tournamentName;
+            a.appendChild(tourney);
+        }
+
+        var meta = document.createElement('div');
+        meta.className =
+            'mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400';
+        var left = document.createElement('span');
+        left.textContent = item.result ? item.result : item.cardCount + ' cards';
+        var right = document.createElement('span');
+        right.className = 'font-mono text-gray-900 dark:text-gray-100';
+        right.textContent = item.estimatedValue;
+        meta.appendChild(left);
+        meta.appendChild(right);
+        a.appendChild(meta);
+
+        if (item.date) {
+            var date = document.createElement('div');
+            date.className = 'mt-1 text-xs text-gray-400';
+            date.textContent = item.date;
+            a.appendChild(date);
+        }
+
+        wrap.appendChild(a);
+        return wrap;
+    }
+
+    /** Build the deck-colors pip span, mirroring deckColors.hbs. */
+    function buildPips(colors) {
+        if (!colors || colors.length === 0) return null;
+        var span = document.createElement('span');
+        span.className = 'deck-colors mt-2 inline-flex';
+        span.title = 'Colors in this deck';
+        colors.forEach(function (pip) {
+            var i = document.createElement('i');
+            i.className = 'ms ms-cost ms-shadow ms-' + pip.symbol + (pip.small ? ' deck-pip-sm' : '');
+            span.appendChild(i);
+        });
+        return span;
+    }
+
+    function capitalize(value) {
+        return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+    }
+})();

--- a/src/http/public/js/setCardListAjax.js
+++ b/src/http/public/js/setCardListAjax.js
@@ -252,7 +252,16 @@ document.addEventListener('DOMContentLoaded', function () {
             headers.push({ key: 'prices.foil', label: 'Foil', subtitle: '7d', classes: 'xs-hide' });
         }
         if (hasAnyNormalPrice || hasAnyFoilPrice) {
-            headers.push({ key: '', label: 'Price', classes: 'xs-show' });
+            // Mobile-only combined price column. Must stay sortable (by normal
+            // price, matching the server-rendered header) - otherwise the first
+            // sort works off the SSR header but the AJAX re-render replaces it
+            // with a static th, so price can't be re-sorted until a hard refresh.
+            headers.push({
+                key: 'prices.normal',
+                label: 'Price',
+                subtitle: '7d',
+                classes: 'xs-show',
+            });
         }
 
         var html = '<div class="table-wrapper"><table class="table-container">';

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -1959,3 +1959,10 @@
         transition: none;
     }
 }
+
+/* Minor-color deck pips render smaller than the dominant colors. Scoped to
+   .deck-colors so it outranks mana.css's .ms-cost size regardless of load order. */
+.deck-colors .deck-pip-sm {
+    font-size: 0.62em;
+    vertical-align: 0.12em;
+}

--- a/src/http/views/deckImport.hbs
+++ b/src/http/views/deckImport.hbs
@@ -1,11 +1,11 @@
 <div class="content-wrapper py-6">
     <div class="mb-4">
-        <h1 class="page-title">Import a decklist</h1>
-        <p class="page-subtitle">Paste a decklist (one card per line, e.g. <code>4 Lightning Bolt</code>). Set codes like <code>(2X2)</code> are optional. A <code>Sideboard</code> line routes the rest to the sideboard.</p>
+        <h1 class="page-title">Build a deck</h1>
+        <p class="page-subtitle">Paste a decklist (one card per line, e.g. <code>4 Lightning Bolt</code>). Set codes like <code>(2X2)</code> are optional. A <code>Sideboard</code> line routes the rest to the sideboard.{{#unless authenticated}} Sign in when you save - your list is kept.{{/unless}}</p>
     </div>
 
     <div class="section-container">
-        <form method="post" action="/decks/import" class="space-y-4">
+        <form id="deck-import-form" method="post" action="/decks/import" class="space-y-4" data-authenticated="{{authenticated}}">
             <div class="flex flex-wrap items-end gap-3">
                 <div class="flex-1 min-w-[12rem]">
                     <label for="deck-name" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Deck name</label>
@@ -31,10 +31,12 @@
             </div>
             <div class="flex gap-3">
                 <button type="submit" class="btn btn-primary">
-                    <i class="fas fa-file-import mr-1" aria-hidden="true"></i> Import deck
+                    <i class="fas fa-file-import mr-1" aria-hidden="true"></i> {{#if authenticated}}Import deck{{else}}Save deck{{/if}}
                 </button>
-                <a href="/decks" class="btn btn-secondary">Cancel</a>
+                <a href="{{#if authenticated}}/decks{{else}}/published-decks{{/if}}" class="btn btn-secondary">Cancel</a>
             </div>
         </form>
     </div>
 </div>
+
+<script src="/public/js/deckImportAuth.js?v={{assetVersion}}" defer></script>

--- a/src/http/views/partials/deckColors.hbs
+++ b/src/http/views/partials/deckColors.hbs
@@ -1,12 +1,13 @@
 {{~!--
-  Renders a deck's color identity as whole mana-font pips (WUBRG).
+  Renders a deck's color identity as mana-font pips, ordered most-abundant first.
 
   Parameters:
-    colors - array of color letters ('w','u','b','r','g'), in WUBRG order.
+    colors - array of pip objects { symbol: 'w'|'u'|'b'|'r'|'g', small: boolean },
+             ordered by how many cards of that color the deck contains.
     class  - optional extra classes for the wrapping span.
 
   Renders nothing when colors is empty, so callers can drop it inline.
 --~}}
 {{~#if colors.length~}}
-<span class="deck-colors {{class}}" title="Colors in this deck">{{#each colors}}<i class="ms ms-cost ms-shadow ms-{{this}}"></i>{{/each}}</span>
+<span class="deck-colors {{class}}" title="Colors in this deck">{{#each colors}}<i class="ms ms-cost ms-shadow ms-{{this.symbol}}{{#if this.small}} deck-pip-sm{{/if}}"></i>{{/each}}</span>
 {{~/if~}}

--- a/src/http/views/partials/publishedDeckCard.hbs
+++ b/src/http/views/partials/publishedDeckCard.hbs
@@ -1,0 +1,18 @@
+{{~!--
+  One published-deck card used inside a format row. The format is implied by the
+  row heading, so (unlike the old grid) no format chip is shown here.
+
+  Parameters: a PublishedDeckListItemView (id, title, url, colors, tournamentName,
+  result, cardCount, estimatedValue, date). publishedDecks.js mirrors this markup
+  when rendering AJAX-loaded cards - keep the two in sync.
+--~}}
+<a href="{{url}}" class="published-deck-card section-container block h-full hover:border-teal-400 dark:hover:border-teal-500 transition-colors">
+    <span class="block font-display font-semibold text-base text-gray-900 dark:text-white">{{title}}</span>
+    {{>deckColors colors=colors class="mt-2 inline-flex"}}
+    {{#if tournamentName}}<div class="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">{{tournamentName}}</div>{{/if}}
+    <div class="mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
+        <span>{{#if result}}{{result}}{{else}}{{cardCount}} cards{{/if}}</span>
+        <span class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
+    </div>
+    {{#if date}}<div class="mt-1 text-xs text-gray-400">{{date}}</div>{{/if}}
+</a>

--- a/src/http/views/partials/publishedDeckRow.hbs
+++ b/src/http/views/partials/publishedDeckRow.hbs
@@ -1,0 +1,16 @@
+{{~!--
+  One format's horizontally-scrolling row of published decks (newest first).
+
+  Context: a PublishedDeckRowView { format, label, decks, nextOffset, hasMore }.
+  publishedDecks.js reads the data-* attributes to lazy-load older decks when the
+  track is scrolled near its end, and mirrors this markup for AJAX-loaded rows.
+--~}}
+<section class="deck-row" data-format="{{format}}" data-next-offset="{{nextOffset}}" data-has-more="{{hasMore}}">
+    <h2 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-3">{{label}}</h2>
+    <div class="deck-row-track flex gap-4 overflow-x-auto pb-3 -mx-1 px-1 snap-x">
+        {{#each decks}}
+            <div class="deck-row-item snap-start shrink-0 w-64">{{>publishedDeckCard}}</div>
+        {{/each}}
+        <div class="deck-row-sentinel shrink-0 w-px" aria-hidden="true"></div>
+    </div>
+</section>

--- a/src/http/views/publishedDecks.hbs
+++ b/src/http/views/publishedDecks.hbs
@@ -1,50 +1,35 @@
 <link href="/public/css/mana.css?v={{assetVersion}}" rel="stylesheet" type="text/css" />
 <div class="content-wrapper py-6">
-    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+    <div class="flex items-start justify-between mb-6 flex-wrap gap-3">
         <div>
             <h1 class="page-title">Tournament decks</h1>
-            <p class="page-subtitle">Published tournament decklists. Sign in to see which ones you can build from your collection.</p>
+            <p class="page-subtitle">Published tournament decklists by format, newest first. {{#if authenticated}}Open one to see what you can build from your collection.{{else}}Sign in to see which ones you can build from your collection.{{/if}}</p>
         </div>
-        <a href="/decks" class="btn btn-ghost text-sm">&larr; My decks</a>
+        <div class="flex gap-2">
+            <a href="/decks/import" class="btn btn-secondary text-sm">
+                <i class="fas fa-plus mr-1" aria-hidden="true"></i> Build a deck
+            </a>
+            {{#if authenticated}}<a href="/decks" class="btn btn-ghost text-sm">My decks &rarr;</a>{{/if}}
+        </div>
     </div>
 
-    <form method="get" action="/published-decks" class="section-container mb-6 flex flex-wrap items-end gap-3">
-        <div>
-            <label for="format" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">Format</label>
-            <select id="format" name="format" onchange="this.form.submit()"
-                class="rounded-md border border-gray-300 dark:border-midnight-600 bg-white dark:bg-midnight-800 px-3 py-2 text-sm">
-                {{#each formats}}
-                    <option value="{{value}}" {{#if selected}}selected{{/if}}>{{label}}</option>
-                {{/each}}
-            </select>
-        </div>
-        <noscript><button type="submit" class="btn btn-secondary">Filter</button></noscript>
-    </form>
-
     {{#if hasDecks}}
-        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {{#each decks}}
-                <a href="{{url}}" class="section-container block hover:border-teal-400 dark:hover:border-teal-500 transition-colors">
-                    <div class="flex items-start justify-between gap-2">
-                        <span class="font-display font-semibold text-lg text-gray-900 dark:text-white">{{title}}</span>
-                        <span class="text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold whitespace-nowrap">{{formatLabel}}</span>
-                    </div>
-                    {{>deckColors colors=colors class="mt-2 inline-flex"}}
-                    {{#if tournamentName}}<div class="mt-1 text-sm text-gray-600 dark:text-gray-400 truncate">{{tournamentName}}</div>{{/if}}
-                    <div class="mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
-                        <span>{{#if result}}{{result}}{{else}}{{cardCount}} cards{{/if}}</span>
-                        <span class="font-mono text-gray-900 dark:text-gray-100">{{estimatedValue}}</span>
-                    </div>
-                    {{#if date}}<div class="mt-1 text-xs text-gray-400">{{date}}</div>{{/if}}
-                </a>
+        <div id="deck-rows" class="space-y-8">
+            {{#each rows}}
+                {{>publishedDeckRow}}
             {{/each}}
         </div>
 
-        <div class="flex items-center justify-between mt-6">
-            {{#if hasPrev}}<a href="{{prevUrl}}" class="btn btn-secondary">&larr; Newer</a>{{else}}<span></span>{{/if}}
-            <span class="text-sm text-gray-500">Page {{page}}</span>
-            {{#if hasNext}}<a href="{{nextUrl}}" class="btn btn-secondary">Older &rarr;</a>{{else}}<span></span>{{/if}}
-        </div>
+        {{#if hasOtherFormats}}
+            <div class="mt-8">
+                <button type="button" id="view-all-formats"
+                    data-formats="{{#each otherFormats}}{{value}}{{#unless @last}},{{/unless}}{{/each}}"
+                    class="btn btn-secondary">
+                    <i class="fas fa-layer-group mr-1" aria-hidden="true"></i> View all formats
+                </button>
+                <div id="other-format-rows" class="space-y-8 mt-8"></div>
+            </div>
+        {{/if}}
     {{else}}
         <div class="section-container text-center py-12">
             <div class="inline-flex items-center justify-center w-12 h-12 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-600 dark:text-purple-300 mb-3">
@@ -55,3 +40,5 @@
         </div>
     {{/if}}
 </div>
+
+<script src="/public/js/publishedDecks.js?v={{assetVersion}}" defer></script>

--- a/test/e2e/public.e2e.ts
+++ b/test/e2e/public.e2e.ts
@@ -54,6 +54,36 @@ test.describe('Set detail page', () => {
         await page.goto(href);
         await expect(page.locator('#set-card-list-ajax')).toBeVisible();
     });
+
+    test('mobile price column stays sortable after the first sort', async ({ page }) => {
+        // Regression: the AJAX re-render used to replace the sortable mobile
+        // "Price" header with a static one, so price could only be sorted once
+        // until a hard refresh.
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.goto('/sets');
+        const href = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        await page.goto(href);
+
+        const cardCalls: string[] = [];
+        page.on('request', (req) => {
+            const u = req.url();
+            if (u.includes('/api/v1/sets/') && u.includes('/cards')) cardCalls.push(u);
+        });
+
+        const priceSort = page.locator('thead a.sort-btn:visible', { hasText: 'Price' }).first();
+        await expect(priceSort).toBeVisible();
+
+        await priceSort.click();
+        await expect.poll(() => cardCalls.length).toBeGreaterThanOrEqual(1);
+
+        // The re-rendered header must still be a sortable price link.
+        const priceSortAgain = page
+            .locator('thead a.sort-btn:visible', { hasText: 'Price' })
+            .first();
+        await expect(priceSortAgain).toBeVisible();
+        await priceSortAgain.click();
+        await expect.poll(() => cardCalls.length).toBeGreaterThanOrEqual(2);
+    });
 });
 
 test.describe('Card detail page', () => {

--- a/test/http/hbs/deck/deck-mana.spec.ts
+++ b/test/http/hbs/deck/deck-mana.spec.ts
@@ -1,0 +1,62 @@
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { deckColorPips } from 'src/http/hbs/deck/deck-mana';
+
+function card(manaCost: string | undefined, quantity: number): DeckCard {
+    return new DeckCard({
+        cardId: manaCost ?? 'land',
+        quantity,
+        isSideboard: false,
+        card: { manaCost } as any,
+    });
+}
+
+describe('deckColorPips', () => {
+    it('returns no pips when nothing has a mana cost', () => {
+        expect(deckColorPips([card(undefined, 20)])).toEqual([]);
+    });
+
+    it('orders colors by quantity-weighted card count, most abundant first', () => {
+        // 12 red cards, 4 white cards -> red before white.
+        const pips = deckColorPips([
+            card('{R}', 4),
+            card('{1}{R}', 4),
+            card('{R}{R}', 4),
+            card('{W}', 4),
+        ]);
+        expect(pips.map((p) => p.symbol)).toEqual(['r', 'w']);
+    });
+
+    it('never marks a single-color deck small', () => {
+        const pips = deckColorPips([card('{W}', 1)]);
+        expect(pips).toEqual([{ symbol: 'w', small: false }]);
+    });
+
+    it('marks a minor color (< 8% of colored cards) small, but never the most abundant', () => {
+        // 30 red, 1 white -> white is ~3% so it renders small; red stays normal.
+        const cards = [card('{R}', 30), card('{W}', 1)];
+        const pips = deckColorPips(cards);
+        expect(pips).toEqual([
+            { symbol: 'r', small: false },
+            { symbol: 'w', small: true },
+        ]);
+    });
+
+    it('keeps a color normal when it is above the minor threshold', () => {
+        // 10 red, 3 white -> white is ~23%, stays normal.
+        const pips = deckColorPips([card('{R}', 10), card('{W}', 3)]);
+        expect(pips).toEqual([
+            { symbol: 'r', small: false },
+            { symbol: 'w', small: false },
+        ]);
+    });
+
+    it('counts a multicolor card toward each of its colors', () => {
+        const pips = deckColorPips([card('{W}{U}', 4)]);
+        expect(pips.map((p) => p.symbol).sort()).toEqual(['u', 'w']);
+    });
+
+    it('breaks ties by canonical WUBRG order', () => {
+        const pips = deckColorPips([card('{G}', 4), card('{W}', 4)]);
+        expect(pips.map((p) => p.symbol)).toEqual(['w', 'g']);
+    });
+});


### PR DESCRIPTION
## Summary
- **Public deck building** - `/decks/import` is reachable logged out. Saving while signed out stashes the pasted decklist (localStorage), sends the user to login/signup via `returnUrl`, then auto-saves on return. `/decks` (your decks) stays auth-gated.
- **Published decks redesign** - replaced the single paginated grid with one horizontal row per format (Standard → Pioneer → Modern → Legacy → Commander), newest-first, with AJAX side-scroll to reach older decks and a "View all formats" expander for the rest. New `GET /published-decks/rows` JSON endpoint.
- **Mana pip ordering + sizing** - deck color pips are ordered by how many cards of each color the deck holds (most abundant first); minor colors (< 8% of colored cards) render as smaller pips, except the most abundant or a single-color deck. Applied across all deck listings.
- **Daily published-deck ingest** - cron changed from weekly to daily (`--days 2`).
- **Mobile price sort fix** - the AJAX re-render used to replace the sortable mobile "Price" header with a static one, so price could only be sorted once until a hard refresh. The re-rendered column is now sortable (matching the server-rendered header).
- **Docs** - CLAUDE.md notes to use the established pagination component unless there's a reason not to (published-decks is the documented exception).

## Testing
- 1340 unit + 118 frontend tests pass; new `deckColorPips` unit tests.
- Playwright: full public + responsive-overflow suites pass (16 tests), including a new regression test for the mobile price sort.
- Browser-verified: format-row lazy-scroll, view-all expansion, anon import → login → preserved decklist, pip ordering/sizing.

## Notes
- "Preserve intent" keeps the pasted list through login/signup in the same browser (localStorage), not across devices.
- Regenerated `src/http/public/css/tailwind.css` (committed) for the new utilities + `.deck-pip-sm` rule.