### PR TITLE
feat: nav Decks entry (public landing, my decks nested) + row scroll buttons

### DIFF
--- a/src/http/public/css/app.css
+++ b/src/http/public/css/app.css
@@ -1032,6 +1032,9 @@ html:not(.dark) .iwm-overlay {
 }
 .iwm-drawer-link:hover svg { opacity: 0.85; }
 
+/* Sub-items nested under a section's primary link (e.g. My decks under Decks). */
+.iwm-drawer-link--nested { padding-left: 2rem; font-size: 0.92em; opacity: 0.9; }
+
 .iwm-drawer-link--danger { color: #f87171; }
 html:not(.dark) .iwm-drawer-link--danger { color: #dc2626; }
 .iwm-drawer-link--danger:hover {

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -8208,6 +8208,62 @@ img,
   vertical-align: 0.12em;
 }
 
+/* Published-deck format rows: side buttons to scroll the horizontal track.
+   JS toggles [hidden] based on scroll position / overflow. */
+
+.deck-row-scroller {
+  position: relative;
+}
+
+.deck-row-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #1a1533;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.deck-row-nav:hover {
+  background: #ffffff;
+}
+
+.deck-row-nav:active {
+  transform: translateY(-50%) scale(0.94);
+}
+
+.dark .deck-row-nav {
+  background: rgba(26, 21, 51, 0.92);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+.dark .deck-row-nav:hover {
+  background: #241e45;
+}
+
+.deck-row-nav[hidden] {
+  display: none;
+}
+
+.deck-row-nav-left {
+  left: -0.5rem;
+}
+
+.deck-row-nav-right {
+  right: -0.5rem;
+}
+
 .after\:absolute::after {
   content: var(--tw-content);
   position: absolute;

--- a/src/http/public/js/publishedDecks.js
+++ b/src/http/public/js/publishedDecks.js
@@ -28,6 +28,8 @@
         var sentinel = section.querySelector('.deck-row-sentinel');
         if (!track || !sentinel) return;
 
+        setupScrollButtons(section, track);
+
         var state = {
             format: section.getAttribute('data-format'),
             nextOffset: parseInt(section.getAttribute('data-next-offset'), 10) || 0,
@@ -56,6 +58,39 @@
             { root: track, rootMargin: '0px 300px 0px 0px' }
         );
         observer.observe(sentinel);
+    }
+
+    /** Wire a row's left/right buttons and toggle their visibility by scroll position. */
+    function setupScrollButtons(section, track) {
+        var left = section.querySelector('.deck-row-nav-left');
+        var right = section.querySelector('.deck-row-nav-right');
+        if (!left || !right) return;
+
+        function scrollByPage(dir) {
+            track.scrollBy({ left: dir * Math.round(track.clientWidth * 0.8), behavior: 'smooth' });
+        }
+        left.addEventListener('click', function () {
+            scrollByPage(-1);
+        });
+        right.addEventListener('click', function () {
+            scrollByPage(1);
+        });
+
+        function updateNav() {
+            // Slack absorbs the track's px-1 padding and sub-pixel rounding so a
+            // button isn't left stuck visible at either end.
+            var SLACK = 8;
+            var atStart = track.scrollLeft <= SLACK;
+            var atEnd = track.scrollLeft + track.clientWidth >= track.scrollWidth - SLACK;
+            var overflowing = track.scrollWidth > track.clientWidth + SLACK;
+            left.hidden = atStart || !overflowing;
+            right.hidden = atEnd || !overflowing;
+        }
+        track.addEventListener('scroll', updateNav, { passive: true });
+        window.addEventListener('resize', updateNav);
+        // Expose so loadMore can refresh button state after appending cards.
+        track._updateNav = updateNav;
+        updateNav();
     }
 
     function loadMore(track, sentinel, state, observer) {
@@ -88,6 +123,7 @@
                 });
                 state.nextOffset = data.nextOffset;
                 state.hasMore = !!data.hasMore;
+                if (track._updateNav) track._updateNav();
                 if (!state.hasMore && observer) observer.disconnect();
             })
             .catch(function () {
@@ -146,11 +182,15 @@
         section.setAttribute('data-next-offset', String(data.nextOffset));
         section.setAttribute('data-has-more', data.hasMore ? 'true' : 'false');
 
+        var label = capitalize(format);
         var heading = document.createElement('h2');
         heading.className =
             'font-display font-semibold text-lg text-gray-900 dark:text-white mb-3';
-        heading.textContent = capitalize(format);
+        heading.textContent = label;
         section.appendChild(heading);
+
+        var scroller = document.createElement('div');
+        scroller.className = 'deck-row-scroller';
 
         var track = document.createElement('div');
         track.className = 'deck-row-track flex gap-4 overflow-x-auto pb-3 -mx-1 px-1 snap-x';
@@ -163,8 +203,27 @@
             track.appendChild(buildCard(item));
         });
         track.appendChild(sentinel);
-        section.appendChild(track);
+
+        scroller.appendChild(navButton('left', label));
+        scroller.appendChild(track);
+        scroller.appendChild(navButton('right', label));
+        section.appendChild(scroller);
         return section;
+    }
+
+    /** A row scroll button mirroring the markup in publishedDeckRow.hbs. */
+    function navButton(dir, label) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'deck-row-nav deck-row-nav-' + dir;
+        btn.setAttribute('aria-label', 'Scroll ' + label + ' decks ' + dir);
+        btn.hidden = true;
+        var d = dir === 'left' ? 'M15 18l-6-6 6-6' : 'M9 18l6-6-6-6';
+        btn.innerHTML =
+            '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+            'stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+            '<path d="' + d + '"/></svg>';
+        return btn;
     }
 
     /** Build one deck card, mirroring publishedDeckCard.hbs. */

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -1966,3 +1966,50 @@
     font-size: 0.62em;
     vertical-align: 0.12em;
 }
+
+/* Published-deck format rows: side buttons to scroll the horizontal track.
+   JS toggles [hidden] based on scroll position / overflow. */
+.deck-row-scroller {
+    position: relative;
+}
+.deck-row-nav {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.92);
+    color: #1a1533;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+    cursor: pointer;
+    transition: background 0.15s ease, transform 0.15s ease;
+}
+.deck-row-nav:hover {
+    background: #ffffff;
+}
+.deck-row-nav:active {
+    transform: translateY(-50%) scale(0.94);
+}
+.dark .deck-row-nav {
+    background: rgba(26, 21, 51, 0.92);
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.12);
+}
+.dark .deck-row-nav:hover {
+    background: #241e45;
+}
+.deck-row-nav[hidden] {
+    display: none;
+}
+.deck-row-nav-left {
+    left: -0.5rem;
+}
+.deck-row-nav-right {
+    right: -0.5rem;
+}

--- a/src/http/views/partials/navbar.hbs
+++ b/src/http/views/partials/navbar.hbs
@@ -584,12 +584,14 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
 
-        // Close on outside click
+        // Close on outside click. Capture phase so it still runs when another
+        // dropdown's trigger calls stopPropagation() - otherwise clicking a
+        // second trigger could leave both menus open.
         document.addEventListener('click', function (e) {
             if (!dropdown.contains(e.target)) {
                 closeDD(false);
             }
-        });
+        }, true);
     }
     });
 });

--- a/src/http/views/partials/navbar.hbs
+++ b/src/http/views/partials/navbar.hbs
@@ -52,9 +52,30 @@
                             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 2h2l1.5 8.5h7L14 5H5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.5" cy="13.5" r="1"/><circle cx="12.5" cy="13.5" r="1"/></svg>
                             Buy List
                         </a>
+                    </div>
+                </div>
+                {{!-- Decks dropdown: public tournament decks is the landing, My decks nested under --}}
+                <div class="iwm-dropdown" id="decks-dropdown">
+                    <button class="iwm-nav-link iwm-dropdown-trigger"
+                            aria-haspopup="menu" aria-expanded="false"
+                            aria-controls="decks-menu"
+                            id="decks-btn">
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l6 3-6 3-6-3 6-3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8l6 3 6-3M2 11.5l6 3 6-3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                        Decks
+                        <svg class="iwm-dd-chevron" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M6 9l6 6 6-6"/></svg>
+                    </button>
+                    <div class="iwm-dropdown-menu" id="decks-menu" role="menu" aria-labelledby="decks-btn" hidden>
+                        <a href="/published-decks" class="iwm-dropdown-item" role="menuitem">
+                            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l1.8 3.7 4 .6-2.9 2.8.7 4L8 13l-3.6 1.9.7-4L2.2 8l4-.6L8 1.5z" stroke-linejoin="round"/></svg>
+                            Tournament decks
+                        </a>
                         <a href="/decks" class="iwm-dropdown-item" role="menuitem">
                             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l6 3-6 3-6-3 6-3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8l6 3 6-3M2 11.5l6 3 6-3" stroke-linecap="round" stroke-linejoin="round"/></svg>
-                            Decks
+                            My decks
+                        </a>
+                        <a href="/decks/import" class="iwm-dropdown-item" role="menuitem">
+                            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 3v10M3 8h10" stroke-linecap="round"/></svg>
+                            Build a deck
                         </a>
                     </div>
                 </div>
@@ -68,6 +89,10 @@
                 </a>
             {{else}}
                 {{!-- Unauthenticated: public links --}}
+                <a href="/published-decks" class="iwm-nav-link">
+                    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l6 3-6 3-6-3 6-3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8l6 3 6-3M2 11.5l6 3 6-3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    Decks
+                </a>
                 <a href="/sets" class="iwm-nav-link">
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><rect x="2" y="3" width="12" height="10" rx="1"/><path d="M5 3V2h6v1"/></svg>
                     Sets
@@ -202,9 +227,19 @@
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M2 2h2l1.5 8.5h7L14 5H5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="6.5" cy="13.5" r="1"/><circle cx="12.5" cy="13.5" r="1"/></svg>
             Buy List
         </a>
-        <a href="/decks" class="iwm-drawer-link">
+
+        <div class="iwm-drawer-section-label">Decks</div>
+        <a href="/published-decks" class="iwm-drawer-link">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l1.8 3.7 4 .6-2.9 2.8.7 4L8 13l-3.6 1.9.7-4L2.2 8l4-.6L8 1.5z" stroke-linejoin="round"/></svg>
+            Tournament decks
+        </a>
+        <a href="/decks" class="iwm-drawer-link iwm-drawer-link--nested">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l6 3-6 3-6-3 6-3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8l6 3 6-3M2 11.5l6 3 6-3" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            Decks
+            My decks
+        </a>
+        <a href="/decks/import" class="iwm-drawer-link iwm-drawer-link--nested">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 3v10M3 8h10" stroke-linecap="round"/></svg>
+            Build a deck
         </a>
 
         <div class="iwm-drawer-section-label">Explore</div>
@@ -272,6 +307,14 @@
         <a href="/spoilers" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="8" cy="8" r="6"/><path d="M8 5.5v3M8 10.5v.2" stroke-linecap="round"/></svg>
             Spoilers
+        </a>
+        <a href="/published-decks" class="iwm-drawer-link">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 1.5l6 3-6 3-6-3 6-3z" stroke-linecap="round" stroke-linejoin="round"/><path d="M2 8l6 3 6-3M2 11.5l6 3 6-3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            Decks
+        </a>
+        <a href="/decks/import" class="iwm-drawer-link iwm-drawer-link--nested">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M8 3v10M3 8h10" stroke-linecap="round"/></svg>
+            Build a deck
         </a>
         <a href="/pricing" class="iwm-drawer-link">
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="8" cy="8" r="6"/><path d="M8 4.5v1m0 5v1M5.5 8h4" stroke-linecap="round"/></svg>
@@ -471,9 +514,10 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     });
 
-    /* ── Collection dropdown (WAI-ARIA menu button) ── */
-    var ddBtn  = document.getElementById('collection-btn');
-    var ddMenu = document.getElementById('collection-menu');
+    /* ── Nav dropdowns (WAI-ARIA menu buttons): Collection, Decks ── */
+    document.querySelectorAll('.iwm-dropdown').forEach(function (dropdown) {
+    var ddBtn  = dropdown.querySelector('.iwm-dropdown-trigger');
+    var ddMenu = dropdown.querySelector('.iwm-dropdown-menu');
 
     if (ddBtn && ddMenu) {
         var ddItems = Array.prototype.slice.call(ddMenu.querySelectorAll('[role="menuitem"]'));
@@ -542,10 +586,11 @@ document.addEventListener('DOMContentLoaded', function () {
 
         // Close on outside click
         document.addEventListener('click', function (e) {
-            if (!document.getElementById('collection-dropdown').contains(e.target)) {
+            if (!dropdown.contains(e.target)) {
                 closeDD(false);
             }
         });
     }
+    });
 });
 </script>

--- a/src/http/views/partials/publishedDeckRow.hbs
+++ b/src/http/views/partials/publishedDeckRow.hbs
@@ -7,10 +7,18 @@
 --~}}
 <section class="deck-row" data-format="{{format}}" data-next-offset="{{nextOffset}}" data-has-more="{{hasMore}}">
     <h2 class="font-display font-semibold text-lg text-gray-900 dark:text-white mb-3">{{label}}</h2>
-    <div class="deck-row-track flex gap-4 overflow-x-auto pb-3 -mx-1 px-1 snap-x">
-        {{#each decks}}
-            <div class="deck-row-item snap-start shrink-0 w-64">{{>publishedDeckCard}}</div>
-        {{/each}}
-        <div class="deck-row-sentinel shrink-0 w-px" aria-hidden="true"></div>
+    <div class="deck-row-scroller">
+        <button type="button" class="deck-row-nav deck-row-nav-left" aria-label="Scroll {{label}} decks left" hidden>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 18l-6-6 6-6"/></svg>
+        </button>
+        <div class="deck-row-track flex gap-4 overflow-x-auto pb-3 -mx-1 px-1 snap-x">
+            {{#each decks}}
+                <div class="deck-row-item snap-start shrink-0 w-64">{{>publishedDeckCard}}</div>
+            {{/each}}
+            <div class="deck-row-sentinel shrink-0 w-px" aria-hidden="true"></div>
+        </div>
+        <button type="button" class="deck-row-nav deck-row-nav-right" aria-label="Scroll {{label}} decks right" hidden>
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18l6-6-6-6"/></svg>
+        </button>
     </div>
 </section>


### PR DESCRIPTION
Follow-up to #545.

## Summary
- **Nav** - public tournament decks (`/published-decks`) is now the "Decks" landing:
  - Authenticated: a new **Decks** dropdown (Tournament decks → `/published-decks`, My decks → `/decks`, Build a deck → `/decks/import`); removed the buried "Decks → /decks" item from the Collection dropdown.
  - Unauthenticated: a top-level **Decks** link → `/published-decks`.
  - Mobile drawer: a **Decks** section with "My decks" / "Build a deck" nested under "Tournament decks" (auth) and a public Decks entry (logged out).
  - Generalized the nav dropdown JS to drive any number of `.iwm-dropdown`s (Collection + Decks), instead of the hard-coded `collection-*` IDs.
- **Format rows** - added left/right scroll buttons on each horizontal row. They appear only when the row overflows, hide at the start/end, scroll ~80% of the visible width, and refresh after lazy-loaded cards are appended. Mirrored in both the server-rendered partial and the AJAX `buildRow`.

## Testing
- Public + responsive-overflow e2e suites pass (16 tests).
- Browser-verified: unauth Decks link, authed Decks + Collection dropdowns both open (no console errors), scroll buttons scroll and toggle visibility correctly, left hidden at the true start.