### PR TITLE
feat: declare OpenAPI response schemas via ApiOkEnvelope

### DIFF
--- a/src/http/api/auth/auth-api.controller.ts
+++ b/src/http/api/auth/auth-api.controller.ts
@@ -16,6 +16,7 @@ import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import { LoginRequestDto, LoginResponseDto } from './dto/auth-response.dto';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 
 @ApiTags('Auth')
 @Controller('api/v1/auth')
@@ -27,7 +28,7 @@ export class AuthApiController {
     @UseGuards(LocalAuthGuard)
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Login and obtain JWT token' })
-    @ApiResponse({ status: 200, description: 'Login successful' })
+    @ApiOkEnvelope(LoginResponseDto, { description: 'Login successful' })
     @ApiResponse({ status: 401, description: 'Invalid credentials' })
     async login(
         @Body() _dto: LoginRequestDto,

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -8,6 +8,7 @@ import {
     UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 import { CardService } from 'src/core/card/card.service';
 import { SearchQueryOptions } from 'src/core/query/search-query-options.dto';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
@@ -75,7 +76,10 @@ export class CardApiController {
     })
     @ApiQuery({ name: 'page', required: false })
     @ApiQuery({ name: 'limit', required: false })
-    @ApiResponse({ status: 200, description: 'Search results (ordered by card name)' })
+    @ApiOkEnvelope(CardApiResponseDto, {
+        isArray: true,
+        description: 'Search results (ordered by card name)',
+    })
     @ApiResponse({
         status: 400,
         description:
@@ -125,7 +129,7 @@ export class CardApiController {
 
     @Get(':cardId/prices')
     @ApiOperation({ operationId: 'getCardPrices', summary: 'Get current prices for a card by ID' })
-    @ApiResponse({ status: 200, description: 'Card prices' })
+    @ApiOkEnvelope(CardApiResponseDto, { description: 'Card prices' })
     async getPricesById(
         @Param('cardId') cardId: string
     ): Promise<ApiResponseDto<CardApiResponseDto>> {
@@ -141,7 +145,9 @@ export class CardApiController {
         operationId: 'getCardBuylist',
         summary: 'Get current buylist (sell-to-vendor) offers for a card by ID',
     })
-    @ApiResponse({ status: 200, description: 'Buylist offers grouped by finish (NM, best first)' })
+    @ApiOkEnvelope(CardBuylistApiResponseDto, {
+        description: 'Buylist offers grouped by finish (NM, best first)',
+    })
     async getBuylistById(
         @Param('cardId') cardId: string
     ): Promise<ApiResponseDto<CardBuylistApiResponseDto>> {
@@ -155,7 +161,7 @@ export class CardApiController {
         summary: 'Get price history for a card by ID',
     })
     @ApiQuery({ name: 'days', required: false, description: 'Number of days of history' })
-    @ApiResponse({ status: 200, description: 'Price history data' })
+    @ApiOkEnvelope(PriceHistoryPointDto, { isArray: true, description: 'Price history data' })
     async getPriceHistoryById(
         @Param('cardId') cardId: string,
         @Query('days') days?: string
@@ -168,7 +174,7 @@ export class CardApiController {
         operationId: 'getCardPricesBySetAndNumber',
         summary: 'Get current prices for a card by set code and number',
     })
-    @ApiResponse({ status: 200, description: 'Card prices' })
+    @ApiOkEnvelope(CardApiResponseDto, { description: 'Card prices' })
     @ApiResponse({ status: 404, description: 'Card not found' })
     async getPricesBySetCodeAndNumber(
         @Param('setCode') setCode: string,
@@ -190,7 +196,9 @@ export class CardApiController {
         operationId: 'getCardBuylistBySetAndNumber',
         summary: 'Get current buylist offers for a card by set code and number',
     })
-    @ApiResponse({ status: 200, description: 'Buylist offers grouped by finish (NM, best first)' })
+    @ApiOkEnvelope(CardBuylistApiResponseDto, {
+        description: 'Buylist offers grouped by finish (NM, best first)',
+    })
     @ApiResponse({ status: 404, description: 'Card not found' })
     async getBuylistBySetCodeAndNumber(
         @Param('setCode') setCode: string,
@@ -210,7 +218,7 @@ export class CardApiController {
         summary: 'Get price history for a card by set code and number',
     })
     @ApiQuery({ name: 'days', required: false, description: 'Number of days of history' })
-    @ApiResponse({ status: 200, description: 'Price history data' })
+    @ApiOkEnvelope(PriceHistoryPointDto, { isArray: true, description: 'Price history data' })
     @ApiResponse({ status: 404, description: 'Card not found' })
     async getPriceHistoryBySetCodeAndNumber(
         @Param('setCode') setCode: string,
@@ -229,7 +237,7 @@ export class CardApiController {
         operationId: 'getCardBySetAndNumber',
         summary: 'Get card by set code and collector number',
     })
-    @ApiResponse({ status: 200, description: 'Card detail' })
+    @ApiOkEnvelope(CardApiResponseDto, { description: 'Card detail' })
     @ApiResponse({ status: 404, description: 'Card not found' })
     async findBySetCodeAndNumber(
         @Param('setCode') setCode: string,

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -46,6 +46,7 @@ import { InventoryQuantityApiDto } from './dto/inventory-quantity.dto';
 import { InventorySellApiResponseDto } from './dto/inventory-sell-response.dto';
 import { InventoryApiPresenter } from './inventory-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
 import { validateApiQuery } from '../shared/query-validation';
 
@@ -67,7 +68,7 @@ export class InventoryApiController {
     @ApiQuery({ name: 'sort', required: false })
     @ApiQuery({ name: 'ascend', required: false })
     @ApiQuery({ name: 'filter', required: false })
-    @ApiResponse({ status: 200, description: 'Inventory list' })
+    @ApiOkEnvelope(InventoryItemApiDto, { isArray: true, description: 'Inventory list' })
     @ApiResponse({
         status: 400,
         description: 'Invalid sort value',
@@ -97,7 +98,7 @@ export class InventoryApiController {
             'Matches every owned card against current buylist offers, picks the best NM offer ' +
             'per item (qty-capped), groups by vendor, and totals it. Mirrors the /inventory/sell page.',
     })
-    @ApiResponse({ status: 200, description: 'Market sell value plan' })
+    @ApiOkEnvelope(InventorySellApiResponseDto, { description: 'Market sell value plan' })
     async sellPlan(
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<InventorySellApiResponseDto>> {
@@ -108,7 +109,10 @@ export class InventoryApiController {
     @Get('quantities')
     @ApiOperation({ summary: 'Get inventory quantities for a batch of card IDs' })
     @ApiQuery({ name: 'cardIds', required: true, description: 'Comma-separated card IDs' })
-    @ApiResponse({ status: 200, description: 'Inventory quantities by card ID' })
+    @ApiOkEnvelope(InventoryQuantityApiDto, {
+        isArray: true,
+        description: 'Inventory quantities by card ID',
+    })
     async getQuantities(
         @Query('cardIds') cardIds: string,
         @Req() req: AuthenticatedRequest
@@ -136,7 +140,11 @@ export class InventoryApiController {
     @Post()
     @HttpCode(HttpStatus.CREATED)
     @ApiOperation({ summary: 'Add inventory items' })
-    @ApiResponse({ status: 201, description: 'Items added' })
+    @ApiOkEnvelope(InventoryItemApiDto, {
+        isArray: true,
+        status: 201,
+        description: 'Items added',
+    })
     async create(
         @Body() dtos: InventoryRequestApiDto[],
         @Req() req: AuthenticatedRequest
@@ -157,7 +165,7 @@ export class InventoryApiController {
     @Patch()
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Update inventory items' })
-    @ApiResponse({ status: 200, description: 'Items updated' })
+    @ApiOkEnvelope(InventoryItemApiDto, { isArray: true, description: 'Items updated' })
     async update(
         @Body() dtos: InventoryRequestApiDto[],
         @Req() req: AuthenticatedRequest
@@ -196,7 +204,7 @@ export class InventoryApiController {
             required: ['file'],
         },
     })
-    @ApiResponse({ status: 200, description: 'Import result', type: InventoryImportResponseDto })
+    @ApiOkEnvelope(InventoryImportResponseDto, { description: 'Import result' })
     @ApiResponse({ status: 400, description: 'Missing or invalid CSV file' })
     async importCards(
         @UploadedFile() file: Express.Multer.File,

--- a/src/http/api/portfolio/portfolio-api.controller.ts
+++ b/src/http/api/portfolio/portfolio-api.controller.ts
@@ -37,6 +37,7 @@ import {
     PortfolioSummaryApiDto,
 } from './dto/portfolio-response.dto';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 
 @ApiTags('Portfolio')
 @ApiBearerAuth()
@@ -55,7 +56,7 @@ export class PortfolioApiController {
 
     @Get()
     @ApiOperation({ summary: 'Get portfolio summary' })
-    @ApiResponse({ status: 200, description: 'Portfolio summary' })
+    @ApiOkEnvelope(PortfolioSummaryApiDto, { description: 'Portfolio summary' })
     async getSummary(
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<PortfolioSummaryApiDto | null>> {
@@ -79,7 +80,7 @@ export class PortfolioApiController {
     @ApiOperation({ summary: 'Get portfolio value history (Premium)' })
     @ApiResponse({ status: 403, description: 'Premium subscription required' })
     @ApiQuery({ name: 'days', required: false, description: 'Number of days of history' })
-    @ApiResponse({ status: 200, description: 'Value history data' })
+    @ApiOkEnvelope(PortfolioHistoryPointDto, { isArray: true, description: 'Value history data' })
     async getHistory(
         @Req() req: AuthenticatedRequest,
         @Query('days') days?: string
@@ -96,7 +97,7 @@ export class PortfolioApiController {
     @ApiOperation({ summary: 'Get card performance data' })
     @ApiQuery({ name: 'type', required: false, description: 'best or worst' })
     @ApiQuery({ name: 'limit', required: false, description: 'Number of results' })
-    @ApiResponse({ status: 200, description: 'Card performance data' })
+    @ApiOkEnvelope(CardPerformanceApiDto, { isArray: true, description: 'Card performance data' })
     async getPerformance(
         @Req() req: AuthenticatedRequest,
         @Query('type') type?: string,
@@ -156,7 +157,7 @@ export class PortfolioApiController {
     @UseGuards(SubscriptionGuard)
     @RequiresSubscription()
     @ApiOperation({ summary: 'Get cash flow periods (Premium)' })
-    @ApiResponse({ status: 200, description: 'Cash flow data' })
+    @ApiOkEnvelope(CashFlowPeriodApiDto, { isArray: true, description: 'Cash flow data' })
     @ApiResponse({ status: 403, description: 'Premium subscription required' })
     async getCashFlow(
         @Req() req: AuthenticatedRequest
@@ -233,7 +234,7 @@ export class PortfolioApiController {
         description:
             'For by=color: the active superset filter (W,U,B,R,G,C) so drill-down matches the aggregate row. Ignored for other dimensions.',
     })
-    @ApiResponse({ status: 200, description: 'Cards in the slice' })
+    @ApiOkEnvelope(BreakdownCardApiDto, { isArray: true, description: 'Cards in the slice' })
     @ApiResponse({ status: 403, description: 'Premium subscription required' })
     async getBreakdownCards(
         @Req() req: AuthenticatedRequest,

--- a/src/http/api/portfolio/portfolio-api.controller.ts
+++ b/src/http/api/portfolio/portfolio-api.controller.ts
@@ -56,7 +56,10 @@ export class PortfolioApiController {
 
     @Get()
     @ApiOperation({ summary: 'Get portfolio summary' })
-    @ApiOkEnvelope(PortfolioSummaryApiDto, { description: 'Portfolio summary' })
+    @ApiOkEnvelope(PortfolioSummaryApiDto, {
+        description: 'Portfolio summary',
+        nullableData: true,
+    })
     async getSummary(
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<PortfolioSummaryApiDto | null>> {

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -9,6 +9,7 @@ import {
     UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { CardService } from 'src/core/card/card.service';
 import { InventoryService } from 'src/core/inventory/inventory.service';
@@ -64,7 +65,7 @@ export class SetApiController {
         required: false,
         description: 'Grouping mode: "block" for block-level pagination',
     })
-    @ApiResponse({ status: 200, description: 'List of sets' })
+    @ApiOkEnvelope(SetApiResponseDto, { isArray: true, description: 'List of sets' })
     @ApiResponse({
         status: 400,
         description: 'Invalid sort value',
@@ -147,7 +148,7 @@ export class SetApiController {
 
     @Get(':code')
     @ApiOperation({ operationId: 'getSet', summary: 'Get set detail by code' })
-    @ApiResponse({ status: 200, description: 'Set detail' })
+    @ApiOkEnvelope(SetApiResponseDto, { description: 'Set detail' })
     @ApiResponse({ status: 404, description: 'Set not found' })
     async findByCode(@Param('code') code: string): Promise<ApiResponseDto<SetApiResponseDto>> {
         const set = await this.setService.findByCode(code);
@@ -187,7 +188,7 @@ export class SetApiController {
         description: 'Legality status; only meaningful with format. Defaults to "legal".',
         enum: [...LEGALITY_VALUES],
     })
-    @ApiResponse({ status: 200, description: 'Cards in set' })
+    @ApiOkEnvelope(CardApiResponseDto, { isArray: true, description: 'Cards in set' })
     @ApiResponse({
         status: 400,
         description: 'Invalid filter value (unknown rarity/format/legality/sort)',
@@ -222,7 +223,10 @@ export class SetApiController {
     @Get(':code/price-history')
     @ApiOperation({ operationId: 'getSetPriceHistory', summary: 'Get set price history' })
     @ApiQuery({ name: 'days', required: false, description: 'Number of days of history' })
-    @ApiResponse({ status: 200, description: 'Set price history data' })
+    @ApiOkEnvelope(SetPriceHistoryPointDto, {
+        isArray: true,
+        description: 'Set price history data',
+    })
     async getPriceHistory(
         @Param('code') code: string,
         @Query('days') days?: string

--- a/src/http/api/shared/api-ok-envelope.decorator.ts
+++ b/src/http/api/shared/api-ok-envelope.decorator.ts
@@ -1,6 +1,6 @@
 import { applyDecorators, Type } from '@nestjs/common';
 import { ApiExtraModels, ApiResponse, getSchemaPath } from '@nestjs/swagger';
-import { PaginationMeta } from 'src/http/base/api-response.dto';
+import { BlockPaginationMeta, PaginationMeta } from 'src/http/base/api-response.dto';
 
 /**
  * Documents a response whose body is the standard API envelope
@@ -11,17 +11,32 @@ import { PaginationMeta } from 'src/http/base/api-response.dto';
  * in the OpenAPI spec so generated clients (mobile, MCP) and RapidAPI get typed
  * responses instead of an untyped body. The envelope is inlined (rather than an
  * allOf against `ApiResponseDto`) so `data` carries the model type cleanly.
+ *
+ * `meta` mirrors `ApiResponseDto.meta`: either `PaginationMeta` or
+ * `BlockPaginationMeta` (the block-grouped set listing returns the latter,
+ * which carries `multiSetBlockKeys`).
+ *
+ * Set `nullableData` for endpoints that return `success: true` with `data: null`
+ * (e.g. portfolio summary before it's computed).
  */
 export function ApiOkEnvelope<TModel extends Type<unknown>>(
     model: TModel,
-    options?: { isArray?: boolean; description?: string; status?: number },
+    options?: {
+        isArray?: boolean;
+        description?: string;
+        status?: number;
+        nullableData?: boolean;
+    },
 ) {
+    const modelRef = options?.nullableData
+        ? { allOf: [{ $ref: getSchemaPath(model) }], nullable: true }
+        : { $ref: getSchemaPath(model) };
     const dataSchema = options?.isArray
         ? { type: 'array' as const, items: { $ref: getSchemaPath(model) } }
-        : { $ref: getSchemaPath(model) };
+        : modelRef;
 
     return applyDecorators(
-        ApiExtraModels(PaginationMeta, model),
+        ApiExtraModels(PaginationMeta, BlockPaginationMeta, model),
         ApiResponse({
             status: options?.status ?? 200,
             description: options?.description,
@@ -32,7 +47,12 @@ export function ApiOkEnvelope<TModel extends Type<unknown>>(
                     data: dataSchema,
                     error: { type: 'string' },
                     message: { type: 'string' },
-                    meta: { $ref: getSchemaPath(PaginationMeta) },
+                    meta: {
+                        oneOf: [
+                            { $ref: getSchemaPath(PaginationMeta) },
+                            { $ref: getSchemaPath(BlockPaginationMeta) },
+                        ],
+                    },
                 },
                 required: ['success'],
             },

--- a/src/http/api/shared/api-ok-envelope.decorator.ts
+++ b/src/http/api/shared/api-ok-envelope.decorator.ts
@@ -1,0 +1,41 @@
+import { applyDecorators, Type } from '@nestjs/common';
+import { ApiExtraModels, ApiResponse, getSchemaPath } from '@nestjs/swagger';
+import { PaginationMeta } from 'src/http/base/api-response.dto';
+
+/**
+ * Documents a response whose body is the standard API envelope
+ * (`{ success, data, error, message, meta }`) with `data` set to `model`
+ * (or an array of `model` when `isArray`).
+ *
+ * The controllers already return `ApiResponseDto<Dto>`; this exposes that shape
+ * in the OpenAPI spec so generated clients (mobile, MCP) and RapidAPI get typed
+ * responses instead of an untyped body. The envelope is inlined (rather than an
+ * allOf against `ApiResponseDto`) so `data` carries the model type cleanly.
+ */
+export function ApiOkEnvelope<TModel extends Type<unknown>>(
+    model: TModel,
+    options?: { isArray?: boolean; description?: string; status?: number },
+) {
+    const dataSchema = options?.isArray
+        ? { type: 'array' as const, items: { $ref: getSchemaPath(model) } }
+        : { $ref: getSchemaPath(model) };
+
+    return applyDecorators(
+        ApiExtraModels(PaginationMeta, model),
+        ApiResponse({
+            status: options?.status ?? 200,
+            description: options?.description,
+            schema: {
+                type: 'object',
+                properties: {
+                    success: { type: 'boolean' },
+                    data: dataSchema,
+                    error: { type: 'string' },
+                    message: { type: 'string' },
+                    meta: { $ref: getSchemaPath(PaginationMeta) },
+                },
+                required: ['success'],
+            },
+        }),
+    );
+}

--- a/src/http/api/transaction/transaction-api.controller.ts
+++ b/src/http/api/transaction/transaction-api.controller.ts
@@ -33,6 +33,7 @@ import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { QueryValidationErrorDto } from '../shared/dto/query-validation-error.dto';
 import { validateApiQuery } from '../shared/query-validation';
 import { CostBasisApiDto, TransactionApiItemDto } from './dto/transaction-response.dto';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 import { TransactionApiPresenter } from './transaction-api.presenter';
 
 @ApiTags('Transactions')
@@ -54,7 +55,7 @@ export class TransactionApiController {
     @ApiQuery({ name: 'ascend', required: false })
     @ApiQuery({ name: 'filter', required: false })
     @ApiQuery({ name: 'type', required: false, enum: ['BUY', 'SELL'] })
-    @ApiResponse({ status: 200, description: 'Transaction list' })
+    @ApiOkEnvelope(TransactionApiItemDto, { isArray: true, description: 'Transaction list' })
     @ApiResponse({
         status: 400,
         description: 'Invalid sort value or transaction type',
@@ -83,7 +84,7 @@ export class TransactionApiController {
     @Post()
     @HttpCode(HttpStatus.CREATED)
     @ApiOperation({ summary: 'Create transaction' })
-    @ApiResponse({ status: 201, description: 'Transaction created' })
+    @ApiOkEnvelope(TransactionApiItemDto, { status: 201, description: 'Transaction created' })
     async create(
         @Body() dto: TransactionRequestDto,
         @Req() req: AuthenticatedRequest
@@ -98,7 +99,7 @@ export class TransactionApiController {
     @Put(':id')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Update transaction' })
-    @ApiResponse({ status: 200, description: 'Transaction updated' })
+    @ApiOkEnvelope(TransactionApiItemDto, { description: 'Transaction updated' })
     async update(
         @Param('id', ParseIntPipe) id: number,
         @Body() dto: TransactionUpdateRequestDto,
@@ -131,7 +132,7 @@ export class TransactionApiController {
     @Get('cost-basis/:cardId')
     @ApiOperation({ summary: 'Get cost basis for a card by ID' })
     @ApiQuery({ name: 'isFoil', required: false, description: 'Whether to check foil version' })
-    @ApiResponse({ status: 200, description: 'Cost basis data' })
+    @ApiOkEnvelope(CostBasisApiDto, { description: 'Cost basis data' })
     async getCostBasisById(
         @Param('cardId') cardId: string,
         @Query('isFoil') isFoilStr: string,
@@ -143,7 +144,7 @@ export class TransactionApiController {
     @Get('cost-basis/:setCode/:setNumber')
     @ApiOperation({ summary: 'Get cost basis for a card by set code and number' })
     @ApiQuery({ name: 'isFoil', required: false, description: 'Whether to check foil version' })
-    @ApiResponse({ status: 200, description: 'Cost basis data' })
+    @ApiOkEnvelope(CostBasisApiDto, { description: 'Cost basis data' })
     @ApiResponse({ status: 404, description: 'Card not found' })
     async getCostBasisBySetCodeAndNumber(
         @Param('setCode') setCode: string,

--- a/src/http/api/user/user-api.controller.ts
+++ b/src/http/api/user/user-api.controller.ts
@@ -42,6 +42,7 @@ import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import { UserApiResponseDto } from './dto/user-response.dto';
 import { UserExportDto } from './dto/user-export.dto';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 
 @ApiTags('User')
 @ApiBearerAuth()
@@ -63,7 +64,7 @@ export class UserApiController {
 
     @Get()
     @ApiOperation({ summary: 'Get current user profile' })
-    @ApiResponse({ status: 200, description: 'User profile' })
+    @ApiOkEnvelope(UserApiResponseDto, { description: 'User profile' })
     async getProfile(
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<UserApiResponseDto>> {
@@ -166,7 +167,7 @@ export class UserApiController {
     @UseGuards(JwtAuthGuard)
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Update user profile (session only, not API keys)' })
-    @ApiResponse({ status: 200, description: 'Profile updated' })
+    @ApiOkEnvelope(UserApiResponseDto, { description: 'Profile updated' })
     async updateProfile(
         @Body() dto: UpdateUserRequestDto,
         @Req() req: AuthenticatedRequest
@@ -209,7 +210,7 @@ export class UserApiController {
     @Get('preferences/set-types')
     @UseGuards(JwtAuthGuard)
     @ApiOperation({ summary: 'Get the current set-type filter preference' })
-    @ApiResponse({ status: 200, description: 'Current preference', type: SetTypePreferenceResponseDto })
+    @ApiOkEnvelope(SetTypePreferenceResponseDto, { description: 'Current preference' })
     async getSetTypePreference(
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<SetTypePreferenceResponseDto>> {
@@ -223,7 +224,7 @@ export class UserApiController {
     @UseGuards(JwtAuthGuard)
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Update the set-type filter preference' })
-    @ApiResponse({ status: 200, description: 'Preference updated', type: SetTypePreferenceResponseDto })
+    @ApiOkEnvelope(SetTypePreferenceResponseDto, { description: 'Preference updated' })
     async updateSetTypePreference(
         @Body() dto: UpdateSetTypePreferenceRequestDto,
         @Req() req: AuthenticatedRequest


### PR DESCRIPTION
API responses are typed in code (`ApiResponseDto<Dto>`) but the Swagger annotations only set status + description, so the generated OpenAPI spec carried **no response bodies**. Generated clients (the new mobile app, the MCP server) and RapidAPI all see untyped responses.

## What this does
- Adds a reusable **`@ApiOkEnvelope(Dto, { isArray?, status?, description? })`** decorator (`src/http/api/shared/api-ok-envelope.decorator.ts`) that documents the standard `{ success, data, error, message, meta }` envelope with `data` typed to the DTO (or an array of it). The envelope is inlined (not an `allOf` against `ApiResponseDto`) so `data` carries the model type cleanly.
- Applies it across the v1-relevant controllers: **card, set, inventory, transaction, portfolio, user, auth**.

## Scope / deliberately left alone
- Endpoints whose body has no DTO class (`{ deleted: boolean }`, `{ refreshed: boolean }`, `{ updated: boolean }`, `{ totalRealizedGain }`, portfolio `breakdown` which returns a core type), the CSV export, and the bare-JSON `user/export` (sends `UserExportDto` which is an interface, not a decorated class) keep their existing annotations.
- Other controllers (deck, buy-list, optimizer, price-alert, sealed-product, api-keys) are not touched here - the decorator is ready to apply to them in a follow-up; this PR is scoped to what the mobile v1 + MCP consume.

## Why it matters
Once deployed, the mobile client (`i-want-my-mtg-mobile`) can regenerate from the live spec and drop its hand-written `lib/api/types.ts` response shapes in favor of generated types. Same benefit for MCP and RapidAPI consumers.

## Validation
- `tsc --noEmit` clean.
- Generated the Swagger document for the decorator in isolation and confirmed each endpoint's 200 schema is the envelope with `data` → `$ref` of the DTO (or array), and that the DTO + `PaginationMeta` land in `components.schemas`.

No runtime behavior change - annotations only.