### PR TITLE
fix: type inventory write request bodies in OpenAPI spec

### DIFF
--- a/src/http/api/inventory/dto/inventory-delete-api.dto.ts
+++ b/src/http/api/inventory/dto/inventory-delete-api.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsUUID } from 'class-validator';
+
+/**
+ * API-specific inventory delete request DTO.
+ * Identifies the inventory row by card and finish; userId comes from the JWT.
+ */
+export class InventoryDeleteApiDto {
+    @ApiProperty()
+    @IsUUID()
+    readonly cardId: string;
+
+    @ApiProperty()
+    @IsBoolean()
+    readonly isFoil: boolean;
+}

--- a/src/http/api/inventory/dto/inventory-request-api.dto.ts
+++ b/src/http/api/inventory/dto/inventory-request-api.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsInt, IsUUID } from 'class-validator';
 
 /**
@@ -5,12 +6,15 @@ import { IsBoolean, IsInt, IsUUID } from 'class-validator';
  * Excludes userId - the API sets it from the JWT token.
  */
 export class InventoryRequestApiDto {
+    @ApiProperty()
     @IsUUID()
     readonly cardId: string;
 
+    @ApiProperty({ description: 'Absolute quantity to set; 0 removes the row' })
     @IsInt()
     readonly quantity: number;
 
+    @ApiProperty()
     @IsBoolean()
     readonly isFoil: boolean;
 }

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -39,6 +39,7 @@ import { JwtOrApiKeyGuard } from 'src/http/api/shared/jwt-or-api-key.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { csvUploadInterceptor } from 'src/http/base/csv-upload.interceptor';
 import { InventoryRequestApiDto } from './dto/inventory-request-api.dto';
+import { InventoryDeleteApiDto } from './dto/inventory-delete-api.dto';
 import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
 import { InventoryItemApiDto } from './dto/inventory-response.dto';
 import { InventoryImportResponseDto } from './dto/inventory-import-response.dto';
@@ -140,6 +141,7 @@ export class InventoryApiController {
     @Post()
     @HttpCode(HttpStatus.CREATED)
     @ApiOperation({ summary: 'Add inventory items' })
+    @ApiBody({ type: InventoryRequestApiDto, isArray: true })
     @ApiOkEnvelope(InventoryItemApiDto, {
         isArray: true,
         status: 201,
@@ -165,6 +167,7 @@ export class InventoryApiController {
     @Patch()
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Update inventory items' })
+    @ApiBody({ type: InventoryRequestApiDto, isArray: true })
     @ApiOkEnvelope(InventoryItemApiDto, { isArray: true, description: 'Items updated' })
     async update(
         @Body() dtos: InventoryRequestApiDto[],
@@ -253,9 +256,10 @@ export class InventoryApiController {
     @Delete()
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Delete inventory item' })
+    @ApiBody({ type: InventoryDeleteApiDto })
     @ApiResponse({ status: 200, description: 'Item deleted' })
     async delete(
-        @Body() body: { cardId: string; isFoil: boolean },
+        @Body() body: InventoryDeleteApiDto,
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<{ deleted: boolean }>> {
         const success = await this.inventoryService.delete(req.user.id, body.cardId, body.isFoil);


### PR DESCRIPTION
## Why

The inventory write endpoints (`POST` / `PATCH` / `DELETE /api/v1/inventory`) were missing their `@ApiBody` annotations, so the generated OpenAPI spec described their request bodies incorrectly. Because the spec is the single source of truth that the **MCP server, web app, mobile app, and REST consumers** all read, every consumer would otherwise have to independently work around the same defect.

Concretely, in the generated spec:
- `POST` / `PATCH` bodies showed as `string[]` instead of `InventoryRequestApiDto[]`. NestJS erases the array element type at runtime, so without an explicit `@ApiBody({ type, isArray: true })` Swagger can't infer it (the classic Nest array-body gotcha).
- `DELETE` showed **no** request body, even though the handler reads `{ cardId, isFoil }`.

This blocked the mobile inventory feature (issue mobile#5) from building on honest types.

## What

- `InventoryRequestApiDto`: add `@ApiProperty()` to each field (the DTO had only class-validator decorators, so it wasn't emitted into the spec at all).
- `create` / `update`: add `@ApiBody({ type: InventoryRequestApiDto, isArray: true })`.
- `delete`: introduce `InventoryDeleteApiDto` (`{ cardId, isFoil }`, validated) to replace the inline body type, plus `@ApiBody({ type: InventoryDeleteApiDto })`.

No runtime behavior change to create/update. Delete now validates its body (UUID `cardId`, boolean `isFoil`) via the global `ValidationPipe`, matching the create DTO. The untyped `{ deleted: boolean }` response is left as-is to match the existing convention (e.g. transaction delete).

## Verify

- `tsc --noEmit` clean, eslint clean
- Inventory API tests pass (18/18)

After merge + deploy, the mobile and MCP clients regenerate from the corrected live spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)