### PR TITLE
docs: mark iOS TestFlight done in roadmap 7.1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -102,7 +102,7 @@ Extend the product's surface area so newcomers can use it where they expect to �
 
 **Framework — React Native + Expo, not Flutter or bare RN.** One language across web/API/MCP/mobile, so the generated OpenAPI client and the sort/filter/legality enums are shared, not re-implemented. This is an API-driven CRUD + camera app (Expo's sweet spot), not a graphics showcase where Flutter's perf edge would pay off. EAS Build + OTA updates keep the toolchain manageable for a solo maintainer (no Mac/Xcode babysitting, JS fixes shippable without a store-review cycle). Escape hatch if a needed native module isn't in Expo: a dev-client + config plugins.
 
-**Repo: [`i-want-my-mtg-mobile`](https://github.com/matthewdtowles/i-want-my-mtg-mobile)** (scaffolded 2026-06-22; browse + inventory + transactions + portfolio shipped — see its `HANDOFF.md`) — Expo app. Reuses the running `/api/v1` backend with **no behavioral server changes.** The one server-side caveat: write endpoints' request DTOs needed `@ApiProperty` annotations so the generated client could type their bodies — without them the inventory POST/PATCH bodies generated as `string[]` (and DELETE had no body) per #549, and the transaction bodies generated as empty objects per #550; both are spec/annotation-only fixes. Auth is confirmed (below); CORS is a non-issue for native builds.
+**Repo: [`i-want-my-mtg-mobile`](https://github.com/matthewdtowles/i-want-my-mtg-mobile)** (scaffolded 2026-06-22; browse + inventory + transactions + portfolio shipped, iOS live on TestFlight — see its `HANDOFF.md`) — Expo app. Reuses the running `/api/v1` backend with **no behavioral server changes.** The one server-side caveat: write endpoints' request DTOs needed `@ApiProperty` annotations so the generated client could type their bodies — without them the inventory POST/PATCH bodies generated as `string[]` (and DELETE had no body) per #549, and the transaction bodies generated as empty objects per #550; both are spec/annotation-only fixes. Auth is confirmed (below); CORS is a non-issue for native builds.
 
 **Auth confirmed (2026-06-22) — no backend change needed.** `POST /api/v1/auth/login` already returns the JWT in the response body (`{ accessToken }`, `auth-api.controller.ts`), and the JWT strategy reads `Authorization: Bearer` first, cookie only as fallback (`jwt.strategy.ts`). So mobile captures the token at login, stores it in `expo-secure-store`, and sends it as a bearer header — the exact path the API/MCP clients already use.
 
@@ -120,7 +120,8 @@ Stack:
 - [x] Inventory: view, add/edit quantities, finish toggle
 - [x] Transactions: log buy/sell, view recent history
 - [x] Portfolio overview (current value)
-- [ ] TestFlight (iOS) + Play internal-testing (Android) distribution — **next**
+- [x] TestFlight (iOS) distribution - **done (2026-06-24)**: app builds on EAS and ships to TestFlight (mobile PR #18); see the mobile repo's README "Distribution"
+- [ ] Play internal-testing (Android) distribution - **next**
 
 **Fast-follow (after v1 validates):**
 - [ ] Camera-based card scanning (7.3) — the "scan on phone, manage on web" differentiator; premium-gated per the Appendix
@@ -132,16 +133,16 @@ Stack:
 
 There is no general-audience sideloading on iOS, so reaching real users means going through Apple (TestFlight or App Store) and Google Play. The lead time here is calendar-bound, not code-bound — account enrollment, Google's new-individual closed-test gate, and first review can run 2–3 weeks of *waiting* — so the account/test items must start before the app is "done."
 
-- [ ] **Apple Developer Program** — $99/year, required even for TestFlight; enrollment can take days and may need ID verification (D-U-N-S if enrolling as an org rather than individual)
+- [x] **Apple Developer Program** - enrolled (individual, 2026-06-24); App ID + App Store Connect app registered, TestFlight live
 - [ ] **Google Play Developer** — $25 one-time; new individual accounts must run a **closed test with ~12 testers for 14 continuous days** before production is unlocked — start this clock early
 - [ ] **Payments / store-cut decision (biggest policy risk):** premium is Stripe today, but Apple/Google require digital subscriptions sold *in-app* to use their IAP (15–30%). v1 has no billing UI, so launch posture is **read/track only — no upgrade button or web-purchase steering inside the app** (Apple polices external-purchase links). Decide and document this explicitly; native IAP + entitlement reconciliation is the alternative and is much larger.
 - [ ] **Privacy disclosures:** Apple App Privacy questionnaire + Google Data Safety form (declare account email + JWT); reuse the existing `/privacy` URL (§3.2)
 - [ ] **Account deletion** reachable in-app or clearly linked (both stores require it for apps with accounts) — confirm the §3.2 FK-cascade scrub is user-triggerable
 - [ ] **Listing assets:** name, description, keywords, app icon, multi-size screenshots, Play feature graphic; content/age-rating questionnaires
 - [ ] **If social login is ever added:** offering Google/any social sign-in forces **Sign in with Apple** alongside it — plain email/password (current) avoids this
-- [ ] **Release pipeline:** EAS Build produces the signed `.ipa`/`.aab`; EAS Submit uploads to App Store Connect + Play Console (no local Xcode/Transporter). First submission and native changes go through full review (Apple ~1–3 days, Play hours–days); EAS Update ships JS-only fixes without re-review.
+- [ ] **Release pipeline:** EAS Build produces the signed `.ipa`/`.aab`; EAS Submit uploads to App Store Connect + Play Console (no local Xcode/Transporter). First submission and native changes go through full review (Apple ~1–3 days, Play hours–days); EAS Update ships JS-only fixes without re-review. **These are manual commands, run by hand** - merging to `main` only tags a version, it does **not** build or submit anything (no `eas` step in CI). And `eas submit` reaches **TestFlight / Play internal testing only**; a public store release is a separate, deliberate Submit-for-Review in App Store Connect / Play Console.
 
-**Cross-repo tracking:** the mobile work lives in the `i-want-my-mtg-mobile` repo, but we want **one view of progress**. The v1 issues (#1–#8) live there and roll up on the **"I Want My MTG" GitHub project** (`PVT_kwHOAP2Yos4A4tP0`) alongside web, scry, and MCP — same pattern used for the cross-repo scry / MCP items. #1–#7 are done; **#8 distribution is next**. Its calendar-bound part — **store enrollment** — should be in flight while the app is still being built, not discovered at submission time: Apple's $99 enrollment and Google's 14-day closed-test gate both have multi-day-to-week lead times.
+**Cross-repo tracking:** the mobile work lives in the `i-want-my-mtg-mobile` repo, but we want **one view of progress**. The v1 issues (#1–#8) live there and roll up on the **"I Want My MTG" GitHub project** (`PVT_kwHOAP2Yos4A4tP0`) alongside web, scry, and MCP — same pattern used for the cross-repo scry / MCP items. #1–#7 are done; **#8 distribution is in progress - iOS TestFlight shipped (2026-06-24), Android / Play internal is the remaining piece**. Its calendar-bound part — **store enrollment** — should be in flight while the app is still being built, not discovered at submission time: Apple's $99 enrollment (done) and Google's 14-day closed-test gate both have multi-day-to-week lead times.
 
 ### 7.2 Desktop App (Optional)
 


### PR DESCRIPTION
Updates ROADMAP §7.1 now that the mobile iOS app ships to TestFlight (mobile PR #18/#19):

- v1 scope: TestFlight (iOS) checked done; Play (Android) split out as next.
- Store readiness: Apple Developer Program checked done (enrolled, App ID + App Store Connect app registered).
- Release pipeline + cross-repo tracking lines: note #8 is in progress (iOS done, Android next), and make explicit that EAS build/submit are **manual** - merging to main only tags a version, and `eas submit` reaches TestFlight only, not the public store.

Docs only.