### PR TITLE
feat: type deck + buy-list response bodies in OpenAPI spec

### DIFF
--- a/src/http/api/buy-list/buy-list-api.controller.ts
+++ b/src/http/api/buy-list/buy-list-api.controller.ts
@@ -17,6 +17,7 @@ import { BuyListService } from 'src/core/buy-list/buy-list.service';
 import { parseCardImport } from 'src/core/import/parsers/card-import-dispatch';
 import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { JwtOrApiKeyGuard } from '../shared/jwt-or-api-key.guard';
 import { BuyListApiPresenter } from './buy-list-api.presenter';
@@ -37,7 +38,7 @@ export class BuyListApiController {
 
     @Get()
     @ApiOperation({ summary: "List the authenticated user's buy-list" })
-    @ApiResponse({ status: 200, description: 'Buy-list items' })
+    @ApiOkEnvelope(BuyListItemApiDto, { isArray: true, description: 'Buy-list items' })
     async list(@Req() req: AuthenticatedRequest): Promise<ApiResponseDto<BuyListItemApiDto[]>> {
         const items = await this.buyListService.list(req.user.id);
         return ApiResponseDto.ok(items.map((i) => BuyListApiPresenter.toItem(i)));
@@ -93,7 +94,7 @@ export class BuyListApiController {
             'native format as inventory import; external exports (Moxfield, Archidekt, Deckbox, ' +
             'TCGPlayer) are auto-detected. Returns counts and per-row errors.',
     })
-    @ApiResponse({ status: 200, description: 'Import result', type: BuyListImportResponseDto })
+    @ApiOkEnvelope(BuyListImportResponseDto, { description: 'Import result' })
     @ApiResponse({ status: 400, description: 'Invalid CSV text' })
     async import(
         @Body() dto: BuyListImportApiDto,

--- a/src/http/api/deck/deck-api.controller.ts
+++ b/src/http/api/deck/deck-api.controller.ts
@@ -20,6 +20,7 @@ import { DeckImportService } from 'src/core/deck/deck-import.service';
 import { DeckService } from 'src/core/deck/deck.service';
 import { ApiResponseDto } from 'src/http/base/api-response.dto';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { JwtOrApiKeyGuard } from '../shared/jwt-or-api-key.guard';
 import { DeckApiPresenter } from './deck-api.presenter';
@@ -34,6 +35,7 @@ import {
 import {
     DeckDetailApiDto,
     DeckImportApiResultDto,
+    DeckMissingToBuyListResultDto,
     DeckSummaryApiDto,
 } from './dto/deck-response.dto';
 
@@ -51,7 +53,7 @@ export class DeckApiController {
 
     @Get()
     @ApiOperation({ summary: "List the authenticated user's decks" })
-    @ApiResponse({ status: 200, description: 'Deck summaries' })
+    @ApiOkEnvelope(DeckSummaryApiDto, { isArray: true, description: 'Deck summaries' })
     async list(@Req() req: AuthenticatedRequest): Promise<ApiResponseDto<DeckSummaryApiDto[]>> {
         const decks = await this.deckService.listDecks(req.user.id);
         return ApiResponseDto.ok(decks.map((d) => DeckApiPresenter.toSummary(d)));
@@ -59,7 +61,7 @@ export class DeckApiController {
 
     @Post()
     @ApiOperation({ summary: 'Create a deck' })
-    @ApiResponse({ status: 201, description: 'Created deck' })
+    @ApiOkEnvelope(DeckDetailApiDto, { status: 201, description: 'Created deck' })
     async create(
         @Body() dto: DeckCreateApiDto,
         @Req() req: AuthenticatedRequest
@@ -71,7 +73,9 @@ export class DeckApiController {
     @Post('import')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'Create a deck from pasted decklist text' })
-    @ApiResponse({ status: 200, description: 'Import result with the new deck id + unresolved lines' })
+    @ApiOkEnvelope(DeckImportApiResultDto, {
+        description: 'Import result with the new deck id + unresolved lines',
+    })
     async import(
         @Body() dto: DeckImportApiDto,
         @Req() req: AuthenticatedRequest
@@ -87,7 +91,7 @@ export class DeckApiController {
 
     @Get(':id')
     @ApiOperation({ summary: 'Get a deck with its cards' })
-    @ApiResponse({ status: 200, description: 'Deck detail' })
+    @ApiOkEnvelope(DeckDetailApiDto, { description: 'Deck detail' })
     @ApiResponse({ status: 404, description: 'Deck not found' })
     async get(
         @Param('id', ParseIntPipe) id: number,
@@ -103,12 +107,12 @@ export class DeckApiController {
     @Post(':id/missing-to-buy-list')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: "Add the deck's missing cards (vs. inventory) to the buy-list" })
-    @ApiResponse({ status: 200, description: 'Count of distinct cards added' })
+    @ApiOkEnvelope(DeckMissingToBuyListResultDto, { description: 'Count of distinct cards added' })
     @ApiResponse({ status: 404, description: 'Deck not found' })
     async missingToBuyList(
         @Param('id', ParseIntPipe) id: number,
         @Req() req: AuthenticatedRequest
-    ): Promise<ApiResponseDto<{ added: number }>> {
+    ): Promise<ApiResponseDto<DeckMissingToBuyListResultDto>> {
         const deck = await this.deckService.getDeck(id, req.user.id);
         if (!deck) {
             throw new NotFoundException(`Deck ${id} not found.`);
@@ -122,7 +126,7 @@ export class DeckApiController {
 
     @Patch(':id')
     @ApiOperation({ summary: 'Rename / re-format a deck' })
-    @ApiResponse({ status: 200, description: 'Updated deck' })
+    @ApiOkEnvelope(DeckSummaryApiDto, { description: 'Updated deck' })
     @ApiResponse({ status: 404, description: 'Deck not found' })
     async update(
         @Param('id', ParseIntPipe) id: number,

--- a/src/http/api/deck/dto/deck-response.dto.ts
+++ b/src/http/api/deck/dto/deck-response.dto.ts
@@ -91,6 +91,12 @@ export class DeckImportApiResultDto {
     readonly errors: { row: number; name?: string; error: string }[];
 }
 
+/** Result of adding a deck's missing cards to the buy-list. */
+export class DeckMissingToBuyListResultDto {
+    @ApiProperty({ description: 'Count of distinct cards added to the buy-list.' })
+    readonly added: number;
+}
+
 /** Full deck with its cards. */
 export class DeckDetailApiDto extends DeckSummaryApiDto {
     @ApiProperty({ description: 'Count of cards not legal in the deck format (0 when no format).' })


### PR DESCRIPTION
Closes #555.

## What
Adds `ApiOkEnvelope` + response DTOs to the data-bearing **deck** and **buy-list** endpoints so the generated client (mobile `lib/api/schema.ts`, MCP) gets concrete return types instead of `content?: never`.

| Endpoint | Now typed as |
|---|---|
| `GET /api/v1/decks` | `DeckSummaryApiDto[]` |
| `POST /api/v1/decks` (201) | `DeckDetailApiDto` |
| `POST /api/v1/decks/import` | `DeckImportApiResultDto` |
| `GET /api/v1/decks/{id}` | `DeckDetailApiDto` |
| `PATCH /api/v1/decks/{id}` | `DeckSummaryApiDto` |
| `POST /api/v1/decks/{id}/missing-to-buy-list` | `DeckMissingToBuyListResultDto` (new) |
| `GET /api/v1/buy-list` | `BuyListItemApiDto[]` |
| `POST /api/v1/buy-list/import` | `BuyListImportResponseDto` |

Trivial `{ added/updated/deleted: boolean }` toggle confirmations stay plain, matching the existing inventory/transaction precedent.

## Verification
Booted the app and inspected the live `/api/openapi.json`: each 200/201 above now carries the envelope with a `$ref`'d `data` schema, and all referenced DTOs are registered under `components.schemas`. Lint + deck/buy-list unit tests pass.

After merge, re-run `npm run gen:api` in the mobile repo (unblocks mobile #23, #31).