### PR TITLE
feat: refresh-token / long-lived session for persistent login

### DIFF
--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -978,6 +978,27 @@ CREATE INDEX idx_api_usage_day ON public.api_usage (day);
 
 
 --
+-- Name: refresh_token; Type: TABLE; Schema: public
+--
+
+CREATE TABLE public.refresh_token (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    user_id integer NOT NULL,
+    token_hash varchar NOT NULL UNIQUE,
+    device_label varchar,
+    expires_at timestamptz NOT NULL,
+    last_used_at timestamptz,
+    revoked_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT refresh_token_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_refresh_token_user FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_refresh_token_user_active ON public.refresh_token (user_id) WHERE revoked_at IS NULL;
+
+
+--
 -- Name: deck; Type: TABLE; Schema: public
 --
 

--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -987,7 +987,6 @@ CREATE TABLE public.refresh_token (
     token_hash varchar NOT NULL UNIQUE,
     device_label varchar,
     expires_at timestamptz NOT NULL,
-    last_used_at timestamptz,
     revoked_at timestamptz,
     created_at timestamptz NOT NULL DEFAULT NOW(),
     CONSTRAINT refresh_token_pkey PRIMARY KEY (id),

--- a/migrations/044_refresh_token.sql
+++ b/migrations/044_refresh_token.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+-- Refresh tokens for long-lived mobile/API sessions (#554).
+--
+-- The API login endpoint issues a short-lived access JWT plus an opaque refresh
+-- token; the client exchanges the refresh token at POST /api/v1/auth/refresh for
+-- a new access token. Only the SHA-256 hash of the refresh token is stored (like
+-- api_key.key_hash) so a DB leak can't be replayed. Tokens are rotated on use
+-- (the old row is revoked and a new one issued) and revoked on sign-out /
+-- password change. `device_label` is optional client-supplied metadata so a user
+-- can tell their sessions apart.
+--
+-- IF NOT EXISTS guards keep this replayable (the migration set re-runs every deploy).
+
+CREATE TABLE IF NOT EXISTS public.refresh_token (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    user_id integer NOT NULL,
+    token_hash varchar NOT NULL UNIQUE,
+    device_label varchar,
+    expires_at timestamptz NOT NULL,
+    last_used_at timestamptz,
+    revoked_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT refresh_token_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_refresh_token_user FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE
+);
+
+-- Active-token lookups by user (revoke-all on password change) skip revoked rows.
+CREATE INDEX IF NOT EXISTS idx_refresh_token_user_active
+    ON public.refresh_token (user_id) WHERE revoked_at IS NULL;
+
+COMMIT;

--- a/migrations/044_refresh_token.sql
+++ b/migrations/044_refresh_token.sql
@@ -18,7 +18,6 @@ CREATE TABLE IF NOT EXISTS public.refresh_token (
     token_hash varchar NOT NULL UNIQUE,
     device_label varchar,
     expires_at timestamptz NOT NULL,
-    last_used_at timestamptz,
     revoked_at timestamptz,
     created_at timestamptz NOT NULL DEFAULT NOW(),
     CONSTRAINT refresh_token_pkey PRIMARY KEY (id),

--- a/src/core/auth/auth.module.ts
+++ b/src/core/auth/auth.module.ts
@@ -7,11 +7,13 @@ import { getLogger } from 'src/logger/global-app-logger';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
 import { LocalStrategy } from './local.strategy';
+import { RefreshTokenModule } from './refresh-token.module';
 
 @Module({
     imports: [
         ConfigModule,
         UserModule,
+        RefreshTokenModule,
         PassportModule,
         JwtModule.registerAsync({
             imports: [ConfigModule],

--- a/src/core/auth/auth.service.ts
+++ b/src/core/auth/auth.service.ts
@@ -4,7 +4,8 @@ import * as bcrypt from 'bcrypt';
 import { User } from 'src/core/user/user.entity';
 import { UserService } from 'src/core/user/user.service';
 import { getLogger } from 'src/logger/global-app-logger';
-import { AuthToken, JwtPayload } from './auth.types';
+import { AuthToken, AuthTokenPair, JwtPayload } from './auth.types';
+import { RefreshTokenService } from './refresh-token.service';
 
 @Injectable()
 export class AuthService {
@@ -12,7 +13,8 @@ export class AuthService {
 
     constructor(
         @Inject(UserService) private readonly userService: UserService,
-        @Inject(JwtService) private readonly jwtService: JwtService
+        @Inject(JwtService) private readonly jwtService: JwtService,
+        @Inject(RefreshTokenService) private readonly refreshTokenService: RefreshTokenService
     ) {}
 
     async validateUser(email: string, password: string): Promise<User | null> {
@@ -46,5 +48,40 @@ export class AuthService {
         };
         this.LOGGER.debug(`Login successful for user ${user.id}.`);
         return authToken;
+    }
+
+    /**
+     * Log in and also mint a refresh token. Used by the API/mobile login flow
+     * (the cookie-based web flow keeps using {@link login}).
+     */
+    async loginWithRefresh(user: User, deviceLabel?: string | null): Promise<AuthTokenPair> {
+        const { access_token } = await this.login(user);
+        const refreshToken = await this.refreshTokenService.issue(user.id, deviceLabel);
+        return { accessToken: access_token, refreshToken };
+    }
+
+    /**
+     * Exchange a refresh token for a new access token, rotating the refresh
+     * token. Returns null when the refresh token is unknown, revoked, expired,
+     * or its owning user no longer exists.
+     */
+    async refresh(rawRefreshToken: string): Promise<AuthTokenPair | null> {
+        const rotated = await this.refreshTokenService.rotate(rawRefreshToken);
+        if (!rotated) {
+            return null;
+        }
+        const user = await this.userService.findById(rotated.userId);
+        if (!user) {
+            // Owner vanished between rotation and lookup; revoke the fresh token.
+            await this.refreshTokenService.revoke(rotated.rawToken);
+            return null;
+        }
+        const { access_token } = await this.login(user);
+        return { accessToken: access_token, refreshToken: rotated.rawToken };
+    }
+
+    /** Revoke a refresh token on sign-out. */
+    async logout(rawRefreshToken: string): Promise<void> {
+        await this.refreshTokenService.revoke(rawRefreshToken);
     }
 }

--- a/src/core/auth/auth.types.ts
+++ b/src/core/auth/auth.types.ts
@@ -5,6 +5,13 @@ export interface AuthToken {
     access_token: string;
 }
 
+export interface AuthTokenPair {
+    /** Short-lived JWT used in Authorization headers. */
+    accessToken: string;
+    /** Long-lived opaque token exchanged at /auth/refresh for a new access token. */
+    refreshToken: string;
+}
+
 export interface JwtPayload {
     /**
      * User's unique ID

--- a/src/core/auth/ports/refresh-token.repository.port.ts
+++ b/src/core/auth/ports/refresh-token.repository.port.ts
@@ -5,7 +5,7 @@ export const RefreshTokenRepositoryPort = 'RefreshTokenRepositoryPort';
 export interface RefreshTokenRepositoryPort {
     create(token: RefreshToken): Promise<RefreshToken>;
     findByHash(tokenHash: string): Promise<RefreshToken | null>;
-    revoke(id: number, when: Date): Promise<void>;
+    /** Revoke the token only if still active; returns true when this call performed the revoke. */
+    revoke(id: number, when: Date): Promise<boolean>;
     revokeAllForUser(userId: number, when: Date): Promise<void>;
-    touchLastUsed(id: number, when: Date): Promise<void>;
 }

--- a/src/core/auth/ports/refresh-token.repository.port.ts
+++ b/src/core/auth/ports/refresh-token.repository.port.ts
@@ -1,0 +1,11 @@
+import { RefreshToken } from '../refresh-token.entity';
+
+export const RefreshTokenRepositoryPort = 'RefreshTokenRepositoryPort';
+
+export interface RefreshTokenRepositoryPort {
+    create(token: RefreshToken): Promise<RefreshToken>;
+    findByHash(tokenHash: string): Promise<RefreshToken | null>;
+    revoke(id: number, when: Date): Promise<void>;
+    revokeAllForUser(userId: number, when: Date): Promise<void>;
+    touchLastUsed(id: number, when: Date): Promise<void>;
+}

--- a/src/core/auth/refresh-token.entity.ts
+++ b/src/core/auth/refresh-token.entity.ts
@@ -6,7 +6,6 @@ export class RefreshToken {
     readonly tokenHash: string;
     readonly deviceLabel: string | null;
     readonly expiresAt: Date;
-    readonly lastUsedAt: Date | null;
     readonly revokedAt: Date | null;
     readonly createdAt: Date;
 
@@ -17,7 +16,6 @@ export class RefreshToken {
         this.tokenHash = init.tokenHash;
         this.deviceLabel = init.deviceLabel ?? null;
         this.expiresAt = init.expiresAt;
-        this.lastUsedAt = init.lastUsedAt ?? null;
         this.revokedAt = init.revokedAt ?? null;
         this.createdAt = init.createdAt ?? new Date();
     }

--- a/src/core/auth/refresh-token.entity.ts
+++ b/src/core/auth/refresh-token.entity.ts
@@ -1,0 +1,37 @@
+import { validateInit } from 'src/core/validation.util';
+
+export class RefreshToken {
+    readonly id: number | null;
+    readonly userId: number;
+    readonly tokenHash: string;
+    readonly deviceLabel: string | null;
+    readonly expiresAt: Date;
+    readonly lastUsedAt: Date | null;
+    readonly revokedAt: Date | null;
+    readonly createdAt: Date;
+
+    constructor(init: Partial<RefreshToken>) {
+        validateInit(init, ['userId', 'tokenHash', 'expiresAt']);
+        this.id = init.id ?? null;
+        this.userId = init.userId;
+        this.tokenHash = init.tokenHash;
+        this.deviceLabel = init.deviceLabel ?? null;
+        this.expiresAt = init.expiresAt;
+        this.lastUsedAt = init.lastUsedAt ?? null;
+        this.revokedAt = init.revokedAt ?? null;
+        this.createdAt = init.createdAt ?? new Date();
+    }
+
+    isRevoked(): boolean {
+        return this.revokedAt !== null;
+    }
+
+    isExpired(now: Date = new Date()): boolean {
+        return this.expiresAt.getTime() <= now.getTime();
+    }
+
+    /** Usable for exchange: neither revoked nor expired. */
+    isActive(now: Date = new Date()): boolean {
+        return !this.isRevoked() && !this.isExpired(now);
+    }
+}

--- a/src/core/auth/refresh-token.module.ts
+++ b/src/core/auth/refresh-token.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/database/database.module';
+import { getLogger } from 'src/logger/global-app-logger';
+import { RefreshTokenService } from './refresh-token.service';
+
+/**
+ * Leaf module for refresh-token issuance/rotation/revocation. Depends only on
+ * the database layer, so both AuthModule (login/refresh/logout) and UserModule
+ * (revoke-on-password-change) can import it without a dependency cycle.
+ */
+@Module({
+    imports: [DatabaseModule],
+    providers: [RefreshTokenService],
+    exports: [RefreshTokenService],
+})
+export class RefreshTokenModule {
+    private readonly LOGGER = getLogger(RefreshTokenModule.name);
+
+    constructor() {
+        this.LOGGER.log(`Initialized`);
+    }
+}

--- a/src/core/auth/refresh-token.service.ts
+++ b/src/core/auth/refresh-token.service.ts
@@ -1,0 +1,86 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { createHash, randomBytes } from 'crypto';
+import { getLogger } from 'src/logger/global-app-logger';
+import { RefreshToken } from './refresh-token.entity';
+import { RefreshTokenRepositoryPort } from './ports/refresh-token.repository.port';
+
+const REFRESH_TOKEN_TTL_DAYS = 30;
+const TOKEN_RANDOM_BYTES = 32; // -> 43 url-safe base64 chars
+
+export interface RotatedRefreshToken {
+    userId: number;
+    rawToken: string;
+}
+
+/**
+ * Issues, validates, rotates and revokes opaque refresh tokens. Only the
+ * SHA-256 hash of each token is persisted, so the raw value exists exactly once
+ * (returned to the client at issue time) and a DB leak can't be replayed.
+ */
+@Injectable()
+export class RefreshTokenService {
+    private readonly LOGGER = getLogger(RefreshTokenService.name);
+
+    constructor(
+        @Inject(RefreshTokenRepositoryPort)
+        private readonly repository: RefreshTokenRepositoryPort
+    ) {}
+
+    /** Mint a new refresh token for a user and return its raw value. */
+    async issue(userId: number, deviceLabel?: string | null): Promise<string> {
+        const rawToken = randomBytes(TOKEN_RANDOM_BYTES).toString('base64url');
+        await this.repository.create(
+            new RefreshToken({
+                userId,
+                tokenHash: this.hash(rawToken),
+                deviceLabel: deviceLabel?.trim() || null,
+                expiresAt: this.expiry(),
+            })
+        );
+        this.LOGGER.debug(`Issued refresh token for user ${userId}.`);
+        return rawToken;
+    }
+
+    /**
+     * Validate a raw refresh token and rotate it: the presented token is revoked
+     * and a fresh one issued. Returns the owning user id + new raw token, or null
+     * when the token is unknown, revoked or expired.
+     */
+    async rotate(rawToken: string): Promise<RotatedRefreshToken | null> {
+        if (!rawToken) return null;
+        const found = await this.repository.findByHash(this.hash(rawToken));
+        if (!found || !found.isActive()) {
+            return null;
+        }
+        const newRawToken = await this.issue(found.userId, found.deviceLabel);
+        await this.repository.revoke(found.id, new Date());
+        this.LOGGER.debug(`Rotated refresh token ${found.id} for user ${found.userId}.`);
+        return { userId: found.userId, rawToken: newRawToken };
+    }
+
+    /** Revoke a single refresh token by its raw value (sign-out). No-op if unknown. */
+    async revoke(rawToken: string): Promise<void> {
+        if (!rawToken) return;
+        const found = await this.repository.findByHash(this.hash(rawToken));
+        if (found && !found.isRevoked()) {
+            await this.repository.revoke(found.id, new Date());
+            this.LOGGER.debug(`Revoked refresh token ${found.id} for user ${found.userId}.`);
+        }
+    }
+
+    /** Revoke every active refresh token for a user (password change). */
+    async revokeAllForUser(userId: number): Promise<void> {
+        await this.repository.revokeAllForUser(userId, new Date());
+        this.LOGGER.debug(`Revoked all refresh tokens for user ${userId}.`);
+    }
+
+    private expiry(): Date {
+        const expiresAt = new Date();
+        expiresAt.setDate(expiresAt.getDate() + REFRESH_TOKEN_TTL_DAYS);
+        return expiresAt;
+    }
+
+    private hash(rawToken: string): string {
+        return createHash('sha256').update(rawToken).digest('hex');
+    }
+}

--- a/src/core/auth/refresh-token.service.ts
+++ b/src/core/auth/refresh-token.service.ts
@@ -52,8 +52,15 @@ export class RefreshTokenService {
         if (!found || !found.isActive()) {
             return null;
         }
+        // Single-use rotation: atomically revoke the presented token first and
+        // only mint a replacement if this call won the revoke. Two concurrent
+        // requests with the same token race on the conditional UPDATE; the loser
+        // gets `false` and bails, so one presented token yields one new token.
+        const won = await this.repository.revoke(found.id, new Date());
+        if (!won) {
+            return null;
+        }
         const newRawToken = await this.issue(found.userId, found.deviceLabel);
-        await this.repository.revoke(found.id, new Date());
         this.LOGGER.debug(`Rotated refresh token ${found.id} for user ${found.userId}.`);
         return { userId: found.userId, rawToken: newRawToken };
     }

--- a/src/core/user/user.module.ts
+++ b/src/core/user/user.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { RefreshTokenModule } from 'src/core/auth/refresh-token.module';
 import { DatabaseModule } from 'src/database/database.module';
 import { getLogger } from 'src/logger/global-app-logger';
 import { PendingUserService } from './pending-user.service';
 import { UserService } from './user.service';
 
 @Module({
-    imports: [DatabaseModule],
+    imports: [DatabaseModule, RefreshTokenModule],
     providers: [UserService, PendingUserService],
     exports: [UserService, PendingUserService],
 })

--- a/src/core/user/user.service.ts
+++ b/src/core/user/user.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
+import { RefreshTokenService } from 'src/core/auth/refresh-token.service';
 import { getLogger } from 'src/logger/global-app-logger';
 import { User } from './user.entity';
 import { UserRepositoryPort } from './ports/user.repository.port';
@@ -8,7 +9,10 @@ import { UserRepositoryPort } from './ports/user.repository.port';
 export class UserService {
     private readonly LOGGER = getLogger(UserService.name);
 
-    constructor(@Inject(UserRepositoryPort) private readonly repository: UserRepositoryPort) {}
+    constructor(
+        @Inject(UserRepositoryPort) private readonly repository: UserRepositoryPort,
+        @Inject(RefreshTokenService) private readonly refreshTokenService: RefreshTokenService
+    ) {}
 
     async create(userIn: User): Promise<User | null> {
         this.LOGGER.debug(`Create user ${userIn?.email}.`);
@@ -71,7 +75,12 @@ export class UserService {
             ...userIn,
             password: await this.encrypt(newPassword),
         });
-        return !!(await this.repository.update(user));
+        const updated = !!(await this.repository.update(user));
+        if (updated && userIn.id) {
+            // Sign out every long-lived mobile/API session on a password change.
+            await this.refreshTokenService.revokeAllForUser(userIn.id);
+        }
+        return updated;
     }
 
     async remove(id: number): Promise<void> {

--- a/src/core/user/user.service.ts
+++ b/src/core/user/user.service.ts
@@ -75,12 +75,13 @@ export class UserService {
             ...userIn,
             password: await this.encrypt(newPassword),
         });
-        const updated = !!(await this.repository.update(user));
-        if (updated && userIn.id) {
-            // Sign out every long-lived mobile/API session on a password change.
+        // Sign out every long-lived mobile/API session *before* writing the new
+        // password: if revocation fails we abort, so we never leave a changed
+        // password with old refresh tokens still live.
+        if (userIn.id) {
             await this.refreshTokenService.revokeAllForUser(userIn.id);
         }
-        return updated;
+        return !!(await this.repository.update(user));
     }
 
     async remove(id: number): Promise<void> {

--- a/src/database/auth/refresh-token.mapper.ts
+++ b/src/database/auth/refresh-token.mapper.ts
@@ -1,0 +1,30 @@
+import { RefreshToken } from 'src/core/auth/refresh-token.entity';
+import { RefreshTokenOrmEntity } from './refresh-token.orm-entity';
+
+export class RefreshTokenMapper {
+    static toCore(orm: RefreshTokenOrmEntity): RefreshToken {
+        return new RefreshToken({
+            id: orm.id,
+            userId: orm.userId,
+            tokenHash: orm.tokenHash,
+            deviceLabel: orm.deviceLabel,
+            expiresAt: orm.expiresAt,
+            lastUsedAt: orm.lastUsedAt,
+            revokedAt: orm.revokedAt,
+            createdAt: orm.createdAt,
+        });
+    }
+
+    static toOrmEntity(core: RefreshToken): RefreshTokenOrmEntity {
+        const orm = new RefreshTokenOrmEntity();
+        if (core.id !== null) orm.id = core.id;
+        orm.userId = core.userId;
+        orm.tokenHash = core.tokenHash;
+        orm.deviceLabel = core.deviceLabel;
+        orm.expiresAt = core.expiresAt;
+        orm.lastUsedAt = core.lastUsedAt;
+        orm.revokedAt = core.revokedAt;
+        orm.createdAt = core.createdAt;
+        return orm;
+    }
+}

--- a/src/database/auth/refresh-token.mapper.ts
+++ b/src/database/auth/refresh-token.mapper.ts
@@ -9,7 +9,6 @@ export class RefreshTokenMapper {
             tokenHash: orm.tokenHash,
             deviceLabel: orm.deviceLabel,
             expiresAt: orm.expiresAt,
-            lastUsedAt: orm.lastUsedAt,
             revokedAt: orm.revokedAt,
             createdAt: orm.createdAt,
         });
@@ -22,7 +21,6 @@ export class RefreshTokenMapper {
         orm.tokenHash = core.tokenHash;
         orm.deviceLabel = core.deviceLabel;
         orm.expiresAt = core.expiresAt;
-        orm.lastUsedAt = core.lastUsedAt;
         orm.revokedAt = core.revokedAt;
         orm.createdAt = core.createdAt;
         return orm;

--- a/src/database/auth/refresh-token.orm-entity.ts
+++ b/src/database/auth/refresh-token.orm-entity.ts
@@ -18,9 +18,6 @@ export class RefreshTokenOrmEntity {
     @Column({ name: 'expires_at', type: 'timestamptz' })
     expiresAt: Date;
 
-    @Column({ name: 'last_used_at', type: 'timestamptz', nullable: true })
-    lastUsedAt: Date | null;
-
     @Column({ name: 'revoked_at', type: 'timestamptz', nullable: true })
     revokedAt: Date | null;
 

--- a/src/database/auth/refresh-token.orm-entity.ts
+++ b/src/database/auth/refresh-token.orm-entity.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('refresh_token')
+@Index('idx_refresh_token_user_active', ['userId'], { where: 'revoked_at IS NULL' })
+export class RefreshTokenOrmEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ name: 'user_id' })
+    userId: number;
+
+    @Column({ name: 'token_hash', unique: true })
+    tokenHash: string;
+
+    @Column({ name: 'device_label', nullable: true })
+    deviceLabel: string | null;
+
+    @Column({ name: 'expires_at', type: 'timestamptz' })
+    expiresAt: Date;
+
+    @Column({ name: 'last_used_at', type: 'timestamptz', nullable: true })
+    lastUsedAt: Date | null;
+
+    @Column({ name: 'revoked_at', type: 'timestamptz', nullable: true })
+    revokedAt: Date | null;
+
+    @Column({ name: 'created_at', type: 'timestamptz', default: () => 'NOW()' })
+    createdAt: Date;
+}

--- a/src/database/auth/refresh-token.repository.ts
+++ b/src/database/auth/refresh-token.repository.ts
@@ -24,15 +24,14 @@ export class RefreshTokenRepository implements RefreshTokenRepositoryPort {
         return found ? RefreshTokenMapper.toCore(found) : null;
     }
 
-    async revoke(id: number, when: Date): Promise<void> {
-        await this.repository.update({ id }, { revokedAt: when });
+    async revoke(id: number, when: Date): Promise<boolean> {
+        // Conditional on revoked_at IS NULL so concurrent rotations of the same
+        // token serialize on the row: only the first UPDATE matches and affects a row.
+        const result = await this.repository.update({ id, revokedAt: IsNull() }, { revokedAt: when });
+        return (result.affected ?? 0) > 0;
     }
 
     async revokeAllForUser(userId: number, when: Date): Promise<void> {
         await this.repository.update({ userId, revokedAt: IsNull() }, { revokedAt: when });
-    }
-
-    async touchLastUsed(id: number, when: Date): Promise<void> {
-        await this.repository.update({ id }, { lastUsedAt: when });
     }
 }

--- a/src/database/auth/refresh-token.repository.ts
+++ b/src/database/auth/refresh-token.repository.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { RefreshToken } from 'src/core/auth/refresh-token.entity';
+import { RefreshTokenRepositoryPort } from 'src/core/auth/ports/refresh-token.repository.port';
+import { IsNull, Repository } from 'typeorm';
+import { RefreshTokenMapper } from './refresh-token.mapper';
+import { RefreshTokenOrmEntity } from './refresh-token.orm-entity';
+
+@Injectable()
+export class RefreshTokenRepository implements RefreshTokenRepositoryPort {
+    constructor(
+        @InjectRepository(RefreshTokenOrmEntity)
+        private readonly repository: Repository<RefreshTokenOrmEntity>
+    ) {}
+
+    async create(token: RefreshToken): Promise<RefreshToken> {
+        const orm = RefreshTokenMapper.toOrmEntity(token);
+        const saved = await this.repository.save(orm);
+        return RefreshTokenMapper.toCore(saved);
+    }
+
+    async findByHash(tokenHash: string): Promise<RefreshToken | null> {
+        const found = await this.repository.findOneBy({ tokenHash });
+        return found ? RefreshTokenMapper.toCore(found) : null;
+    }
+
+    async revoke(id: number, when: Date): Promise<void> {
+        await this.repository.update({ id }, { revokedAt: when });
+    }
+
+    async revokeAllForUser(userId: number, when: Date): Promise<void> {
+        await this.repository.update({ userId, revokedAt: IsNull() }, { revokedAt: when });
+    }
+
+    async touchLastUsed(id: number, when: Date): Promise<void> {
+        await this.repository.update({ id }, { lastUsedAt: when });
+    }
+}

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -80,6 +80,9 @@ import { ApiSubscriptionOrmEntity } from './api-tier/api-subscription.orm-entity
 import { ApiSubscriptionRepository } from './api-tier/api-subscription.repository';
 import { ApiUsageOrmEntity } from './api-tier/api-usage.orm-entity';
 import { ApiUsageRepository } from './api-tier/api-usage.repository';
+import { RefreshTokenRepositoryPort } from 'src/core/auth/ports/refresh-token.repository.port';
+import { RefreshTokenOrmEntity } from './auth/refresh-token.orm-entity';
+import { RefreshTokenRepository } from './auth/refresh-token.repository';
 
 @Module({
     imports: [
@@ -115,6 +118,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
             ApiKeyOrmEntity,
             ApiSubscriptionOrmEntity,
             ApiUsageOrmEntity,
+            RefreshTokenOrmEntity,
         ]),
     ],
     providers: [
@@ -145,6 +149,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         { provide: ApiKeyRepositoryPort, useClass: ApiKeyRepository },
         { provide: ApiSubscriptionRepositoryPort, useClass: ApiSubscriptionRepository },
         { provide: ApiUsageRepositoryPort, useClass: ApiUsageRepository },
+        { provide: RefreshTokenRepositoryPort, useClass: RefreshTokenRepository },
     ],
     exports: [
         CardRepositoryPort,
@@ -171,6 +176,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         ApiKeyRepositoryPort,
         ApiSubscriptionRepositoryPort,
         ApiUsageRepositoryPort,
+        RefreshTokenRepositoryPort,
     ],
 })
 export class DatabaseModule {

--- a/src/http/api/auth/auth-api.controller.ts
+++ b/src/http/api/auth/auth-api.controller.ts
@@ -6,6 +6,7 @@ import {
     Inject,
     Post,
     Req,
+    UnauthorizedException,
     UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -14,7 +15,7 @@ import { User } from 'src/core/user/user.entity';
 import { LocalAuthGuard } from 'src/http/auth/local.auth.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { ApiResponseDto } from 'src/http/base/api-response.dto';
-import { LoginRequestDto, LoginResponseDto } from './dto/auth-response.dto';
+import { LoginRequestDto, LoginResponseDto, RefreshRequestDto } from './dto/auth-response.dto';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
 import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 
@@ -27,14 +28,41 @@ export class AuthApiController {
     @Post('login')
     @UseGuards(LocalAuthGuard)
     @HttpCode(HttpStatus.OK)
-    @ApiOperation({ summary: 'Login and obtain JWT token' })
+    @ApiOperation({ summary: 'Login and obtain access + refresh tokens' })
     @ApiOkEnvelope(LoginResponseDto, { description: 'Login successful' })
     @ApiResponse({ status: 401, description: 'Invalid credentials' })
     async login(
-        @Body() _dto: LoginRequestDto,
+        @Body() dto: LoginRequestDto,
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<LoginResponseDto>> {
-        const authToken = await this.authService.login(req.user as unknown as User);
-        return ApiResponseDto.ok({ accessToken: authToken.access_token });
+        const tokens = await this.authService.loginWithRefresh(
+            req.user as unknown as User,
+            dto.deviceLabel
+        );
+        return ApiResponseDto.ok(tokens);
+    }
+
+    @Post('refresh')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Exchange a refresh token for a new access token (rotates the refresh token)',
+    })
+    @ApiOkEnvelope(LoginResponseDto, { description: 'New access + refresh tokens' })
+    @ApiResponse({ status: 401, description: 'Invalid, revoked, or expired refresh token' })
+    async refresh(@Body() dto: RefreshRequestDto): Promise<ApiResponseDto<LoginResponseDto>> {
+        const tokens = await this.authService.refresh(dto.refreshToken);
+        if (!tokens) {
+            throw new UnauthorizedException('Invalid or expired refresh token.');
+        }
+        return ApiResponseDto.ok(tokens);
+    }
+
+    @Post('logout')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'Revoke a refresh token (sign-out)' })
+    @ApiResponse({ status: 200, description: 'Refresh token revoked' })
+    async logout(@Body() dto: RefreshRequestDto): Promise<ApiResponseDto<{ revoked: boolean }>> {
+        await this.authService.logout(dto.refreshToken);
+        return ApiResponseDto.ok({ revoked: true });
     }
 }

--- a/src/http/api/auth/dto/auth-response.dto.ts
+++ b/src/http/api/auth/dto/auth-response.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEmail, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class LoginRequestDto {
     @ApiProperty({ example: 'user@example.com' })
@@ -11,9 +11,31 @@ export class LoginRequestDto {
     @IsString()
     @IsNotEmpty()
     readonly password: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Optional client/device label stored with the refresh token so a user can tell their sessions apart.',
+        example: 'iPhone 15',
+    })
+    @IsOptional()
+    @IsString()
+    readonly deviceLabel?: string;
 }
 
 export class LoginResponseDto {
-    @ApiProperty()
+    @ApiProperty({ description: 'Short-lived JWT for the Authorization header.' })
     readonly accessToken: string;
+
+    @ApiProperty({
+        description:
+            'Long-lived opaque token. Exchange it at POST /api/v1/auth/refresh for a new access token; rotated on each use.',
+    })
+    readonly refreshToken: string;
+}
+
+export class RefreshRequestDto {
+    @ApiProperty({ description: 'The refresh token issued at login (or the previous refresh call).' })
+    @IsString()
+    @IsNotEmpty()
+    readonly refreshToken: string;
 }

--- a/test/core/auth/auth.service.spec.ts
+++ b/test/core/auth/auth.service.spec.ts
@@ -3,6 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import * as bcrypt from 'bcrypt';
 import { AuthService } from 'src/core/auth/auth.service';
 import { AuthToken } from 'src/core/auth/auth.types';
+import { RefreshTokenService } from 'src/core/auth/refresh-token.service';
 import { User } from 'src/core/user/user.entity';
 import { UserRepositoryPort } from 'src/core/user/ports/user.repository.port';
 import { UserService } from 'src/core/user/user.service';
@@ -20,8 +21,14 @@ describe('AuthService', () => {
     let authService: AuthService;
     let userService: UserService;
     let jwtService: JwtService;
+    let refreshTokenService: jest.Mocked<Pick<RefreshTokenService, 'issue' | 'rotate' | 'revoke'>>;
 
     beforeAll(async () => {
+        refreshTokenService = {
+            issue: jest.fn().mockResolvedValue('refresh-raw'),
+            rotate: jest.fn(),
+            revoke: jest.fn().mockResolvedValue(undefined),
+        };
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 AuthService,
@@ -29,6 +36,7 @@ describe('AuthService', () => {
                     provide: UserService,
                     useValue: {
                         findByEmail: jest.fn().mockResolvedValue(mockUser),
+                        findById: jest.fn().mockResolvedValue(mockUser),
                         findSavedPassword: jest.fn().mockResolvedValue(mockUser.email),
                     },
                 },
@@ -43,6 +51,10 @@ describe('AuthService', () => {
                     useValue: {
                         signAsync: jest.fn().mockResolvedValue('jwtToken'),
                     },
+                },
+                {
+                    provide: RefreshTokenService,
+                    useValue: refreshTokenService,
                 },
             ],
         }).compile();
@@ -84,6 +96,51 @@ describe('AuthService', () => {
                 role: mockUser.role,
             });
             expect(result).toEqual(expectedToken);
+        });
+    });
+
+    describe('loginWithRefresh', () => {
+        it('returns an access token plus a freshly issued refresh token', async () => {
+            const result = await authService.loginWithRefresh(mockUser, 'iPhone');
+            expect(refreshTokenService.issue).toHaveBeenCalledWith(mockUser.id, 'iPhone');
+            expect(result).toEqual({ accessToken: 'jwtToken', refreshToken: 'refresh-raw' });
+        });
+    });
+
+    describe('refresh', () => {
+        it('rotates a valid refresh token into a new token pair', async () => {
+            refreshTokenService.rotate.mockResolvedValueOnce({
+                userId: mockUser.id,
+                rawToken: 'rotated-raw',
+            });
+            const result = await authService.refresh('old-raw');
+            expect(refreshTokenService.rotate).toHaveBeenCalledWith('old-raw');
+            expect(userService.findById).toHaveBeenCalledWith(mockUser.id);
+            expect(result).toEqual({ accessToken: 'jwtToken', refreshToken: 'rotated-raw' });
+        });
+
+        it('returns null when the refresh token is invalid', async () => {
+            refreshTokenService.rotate.mockResolvedValueOnce(null);
+            const result = await authService.refresh('bad-raw');
+            expect(result).toBeNull();
+        });
+
+        it('revokes the new token and returns null when the owner is gone', async () => {
+            refreshTokenService.rotate.mockResolvedValueOnce({
+                userId: 999,
+                rawToken: 'orphan-raw',
+            });
+            (userService.findById as jest.Mock).mockResolvedValueOnce(null);
+            const result = await authService.refresh('old-raw');
+            expect(refreshTokenService.revoke).toHaveBeenCalledWith('orphan-raw');
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('logout', () => {
+        it('revokes the supplied refresh token', async () => {
+            await authService.logout('some-raw');
+            expect(refreshTokenService.revoke).toHaveBeenCalledWith('some-raw');
         });
     });
 });

--- a/test/core/auth/refresh-token.service.spec.ts
+++ b/test/core/auth/refresh-token.service.spec.ts
@@ -11,9 +11,8 @@ describe('RefreshTokenService', () => {
         repository = {
             create: jest.fn().mockImplementation(async (t: RefreshToken) => t),
             findByHash: jest.fn(),
-            revoke: jest.fn().mockResolvedValue(undefined),
+            revoke: jest.fn().mockResolvedValue(true),
             revokeAllForUser: jest.fn().mockResolvedValue(undefined),
-            touchLastUsed: jest.fn().mockResolvedValue(undefined),
         };
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -58,6 +57,24 @@ describe('RefreshTokenService', () => {
             expect(result?.userId).toBe(7);
             expect(repository.create).toHaveBeenCalledTimes(1); // the new token
             expect(repository.revoke).toHaveBeenCalledWith(42, expect.any(Date));
+        });
+
+        it('returns null without minting a token when it loses the rotation race', async () => {
+            repository.findByHash.mockResolvedValue(
+                new RefreshToken({
+                    id: 42,
+                    userId: 7,
+                    tokenHash: 'irrelevant',
+                    expiresAt: new Date(Date.now() + 60_000),
+                })
+            );
+            // Concurrent rotation already revoked the row: the conditional revoke affects nothing.
+            repository.revoke.mockResolvedValueOnce(false);
+
+            const result = await service.rotate('presented-raw');
+
+            expect(result).toBeNull();
+            expect(repository.create).not.toHaveBeenCalled();
         });
 
         it('returns null for an unknown token', async () => {

--- a/test/core/auth/refresh-token.service.spec.ts
+++ b/test/core/auth/refresh-token.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RefreshToken } from 'src/core/auth/refresh-token.entity';
+import { RefreshTokenRepositoryPort } from 'src/core/auth/ports/refresh-token.repository.port';
+import { RefreshTokenService } from 'src/core/auth/refresh-token.service';
+
+describe('RefreshTokenService', () => {
+    let service: RefreshTokenService;
+    let repository: jest.Mocked<RefreshTokenRepositoryPort>;
+
+    beforeEach(async () => {
+        repository = {
+            create: jest.fn().mockImplementation(async (t: RefreshToken) => t),
+            findByHash: jest.fn(),
+            revoke: jest.fn().mockResolvedValue(undefined),
+            revokeAllForUser: jest.fn().mockResolvedValue(undefined),
+            touchLastUsed: jest.fn().mockResolvedValue(undefined),
+        };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                RefreshTokenService,
+                { provide: RefreshTokenRepositoryPort, useValue: repository },
+            ],
+        }).compile();
+        service = module.get(RefreshTokenService);
+    });
+
+    describe('issue', () => {
+        it('persists only the hash and returns the raw token', async () => {
+            const raw = await service.issue(7, 'Pixel 8');
+            expect(typeof raw).toBe('string');
+            expect(raw.length).toBeGreaterThan(0);
+            const stored = repository.create.mock.calls[0][0];
+            expect(stored.userId).toBe(7);
+            expect(stored.deviceLabel).toBe('Pixel 8');
+            expect(stored.tokenHash).not.toEqual(raw);
+            expect(stored.expiresAt.getTime()).toBeGreaterThan(Date.now());
+        });
+
+        it('normalizes a blank device label to null', async () => {
+            await service.issue(7, '   ');
+            expect(repository.create.mock.calls[0][0].deviceLabel).toBeNull();
+        });
+    });
+
+    describe('rotate', () => {
+        it('issues a new token and revokes the presented one when active', async () => {
+            const existing = new RefreshToken({
+                id: 42,
+                userId: 7,
+                tokenHash: 'irrelevant',
+                expiresAt: new Date(Date.now() + 60_000),
+            });
+            repository.findByHash.mockResolvedValue(existing);
+
+            const result = await service.rotate('presented-raw');
+
+            expect(result).not.toBeNull();
+            expect(result?.userId).toBe(7);
+            expect(repository.create).toHaveBeenCalledTimes(1); // the new token
+            expect(repository.revoke).toHaveBeenCalledWith(42, expect.any(Date));
+        });
+
+        it('returns null for an unknown token', async () => {
+            repository.findByHash.mockResolvedValue(null);
+            expect(await service.rotate('nope')).toBeNull();
+            expect(repository.revoke).not.toHaveBeenCalled();
+        });
+
+        it('returns null for an expired token', async () => {
+            repository.findByHash.mockResolvedValue(
+                new RefreshToken({
+                    id: 1,
+                    userId: 7,
+                    tokenHash: 'h',
+                    expiresAt: new Date(Date.now() - 1000),
+                })
+            );
+            expect(await service.rotate('expired')).toBeNull();
+            expect(repository.create).not.toHaveBeenCalled();
+        });
+
+        it('returns null for a revoked token', async () => {
+            repository.findByHash.mockResolvedValue(
+                new RefreshToken({
+                    id: 1,
+                    userId: 7,
+                    tokenHash: 'h',
+                    expiresAt: new Date(Date.now() + 60_000),
+                    revokedAt: new Date(),
+                })
+            );
+            expect(await service.rotate('revoked')).toBeNull();
+        });
+
+        it('returns null for an empty token without hitting the repository', async () => {
+            expect(await service.rotate('')).toBeNull();
+            expect(repository.findByHash).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('revoke', () => {
+        it('revokes a known active token', async () => {
+            repository.findByHash.mockResolvedValue(
+                new RefreshToken({
+                    id: 5,
+                    userId: 7,
+                    tokenHash: 'h',
+                    expiresAt: new Date(Date.now() + 60_000),
+                })
+            );
+            await service.revoke('raw');
+            expect(repository.revoke).toHaveBeenCalledWith(5, expect.any(Date));
+        });
+
+        it('is a no-op for an unknown token', async () => {
+            repository.findByHash.mockResolvedValue(null);
+            await service.revoke('raw');
+            expect(repository.revoke).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('revokeAllForUser', () => {
+        it('delegates to the repository', async () => {
+            await service.revokeAllForUser(7);
+            expect(repository.revokeAllForUser).toHaveBeenCalledWith(7, expect.any(Date));
+        });
+    });
+});

--- a/test/core/user/user.service.spec.ts
+++ b/test/core/user/user.service.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { RefreshTokenService } from 'src/core/auth/refresh-token.service';
 import { User } from 'src/core/user/user.entity';
 import { UserRepositoryPort } from 'src/core/user/ports/user.repository.port';
 import { UserService } from 'src/core/user/user.service';
@@ -7,6 +8,7 @@ import { UserRole } from 'src/shared/constants/user.role.enum';
 describe('UserService', () => {
     let service: UserService;
     let repository: UserRepositoryPort;
+    const mockRefreshTokenService = { revokeAllForUser: jest.fn().mockResolvedValue(undefined) };
 
     const createUser: User = new User({
         name: 'test-username1',
@@ -45,6 +47,10 @@ describe('UserService', () => {
                 {
                     provide: UserRepositoryPort,
                     useValue: mockUserRepository,
+                },
+                {
+                    provide: RefreshTokenService,
+                    useValue: mockRefreshTokenService,
                 },
             ],
         }).compile();
@@ -90,10 +96,11 @@ describe('UserService', () => {
         expect(repoSpy).toHaveBeenCalledWith(updateUser);
     });
 
-    it('updatePassword should update password for given user', async () => {
+    it('updatePassword should update password and revoke refresh tokens for given user', async () => {
         const repoSpy = jest.spyOn(repository, 'update');
         await expect(service.updatePassword(mockUser, 'newPassword')).resolves.toBe(true);
         expect(repoSpy).toHaveBeenCalled();
+        expect(mockRefreshTokenService.revokeAllForUser).toHaveBeenCalledWith(mockUser.id);
     });
 
     it('remove should delete given user, check if user exists and return false', async () => {


### PR DESCRIPTION
Closes #554. Unblocks persistent login in the mobile app (mobile #25).

## What
Adds revocable, rotated refresh tokens so mobile/API clients stay signed in past the short access-token TTL.

- **`refresh_token` table** (migration `044` + init schema): stores only the **SHA-256 hash** of each token, plus per-token `expires_at` (30d), `revoked_at`, optional `device_label`, and a partial index on active rows.
- **`RefreshTokenService`** (`issue` / `rotate` / `revoke` / `revokeAllForUser`) behind a repository port, in a leaf `RefreshTokenModule` so both `AuthModule` and `UserModule` use it without a DI cycle.
- **Endpoints** (`AuthApiController`):
  - `POST /api/v1/auth/login` → now returns `{ accessToken, refreshToken }` (optional `deviceLabel` in the body)
  - `POST /api/v1/auth/refresh` → exchanges + **rotates** the refresh token (old one revoked); 401 on invalid/expired/revoked
  - `POST /api/v1/auth/logout` → revokes the supplied refresh token
- **Password change revokes all** of a user's refresh tokens (single chokepoint in `UserService.updatePassword`, covering API + web + reset flows).
- OpenAPI-annotated request/response DTOs.
- The cookie-based **web login flow is unchanged** (still calls `AuthService.login`); access-token TTL stays 60m so web sessions don't regress.

## Verification
Unit tests for `RefreshTokenService`, `AuthService.{loginWithRefresh,refresh,logout}`, and password-change revocation. Booted the app + ran migration `044`, then end-to-end against a throwaway user:
1. login → returns access + 43-char refresh token ✅
2. refresh → new pair issued, old token row revoked ✅
3. reuse of rotated token → **401** ✅
4. logout → token revoked; subsequent refresh → **401** ✅
5. password change → user's refresh token revoked (refresh → **401**) ✅
6. DB stores 64-char sha256 hashes only, never the raw token ✅

After merge, mobile #25's 401→refresh→replay interceptor activates.