### PR TITLE
feat: push-notification device registration endpoint

### DIFF
--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -978,6 +978,26 @@ CREATE INDEX idx_api_usage_day ON public.api_usage (day);
 
 
 --
+-- Name: notification_device; Type: TABLE; Schema: public
+--
+
+CREATE TABLE public.notification_device (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    user_id integer NOT NULL,
+    token varchar NOT NULL UNIQUE,
+    platform varchar NOT NULL,
+    device_id varchar,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    updated_at timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT notification_device_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_notification_device_user FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_notification_device_user_id ON public.notification_device (user_id);
+
+
+--
 -- Name: deck; Type: TABLE; Schema: public
 --
 

--- a/migrations/045_notification_device.sql
+++ b/migrations/045_notification_device.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+-- Push-notification device registration (#556).
+--
+-- Stores each mobile/web device's push token so notifications and price alerts
+-- can later be fanned out to it (Expo/APNs/FCM). One row per push token; the
+-- token is unique, so re-registering the same device (e.g. after a fresh login)
+-- upserts onto it and can re-point it at the current user. `device_id` is
+-- optional client-supplied metadata. Fan-out delivery itself is a follow-up.
+--
+-- IF NOT EXISTS guards keep this replayable (the migration set re-runs every deploy).
+
+CREATE TABLE IF NOT EXISTS public.notification_device (
+    id integer NOT NULL GENERATED ALWAYS AS IDENTITY,
+    user_id integer NOT NULL,
+    token varchar NOT NULL UNIQUE,
+    platform varchar NOT NULL,
+    device_id varchar,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    updated_at timestamptz NOT NULL DEFAULT NOW(),
+    CONSTRAINT notification_device_pkey PRIMARY KEY (id),
+    CONSTRAINT fk_notification_device_user FOREIGN KEY (user_id)
+        REFERENCES public.users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_device_user_id
+    ON public.notification_device (user_id);
+
+COMMIT;

--- a/src/core/core.module.ts
+++ b/src/core/core.module.ts
@@ -10,6 +10,7 @@ import { DeckModule } from './deck/deck.module';
 import { EmailModule } from './email/email.module';
 import { ImportModule } from './import/import.module';
 import { InventoryModule } from './inventory/inventory.module';
+import { NotificationDeviceModule } from './notification-device/notification-device.module';
 import { OptimizerModule } from './optimizer/optimizer.module';
 import { PasswordResetModule } from './password-reset/password-reset.module';
 import { PriceAlertModule } from './price-alert/price-alert.module';
@@ -33,6 +34,7 @@ import { UserModule } from './user/user.module';
         EmailModule,
         ImportModule,
         InventoryModule,
+        NotificationDeviceModule,
         OptimizerModule,
         PasswordResetModule,
         PriceAlertModule,
@@ -55,6 +57,7 @@ import { UserModule } from './user/user.module';
         EmailModule,
         ImportModule,
         InventoryModule,
+        NotificationDeviceModule,
         OptimizerModule,
         PasswordResetModule,
         PriceAlertModule,

--- a/src/core/notification-device/notification-device.entity.ts
+++ b/src/core/notification-device/notification-device.entity.ts
@@ -1,0 +1,25 @@
+import { validateInit } from 'src/core/validation.util';
+
+export type DevicePlatform = 'ios' | 'android' | 'web';
+
+/** A registered push-notification target (one per push token). */
+export class NotificationDevice {
+    readonly id: number | null;
+    readonly userId: number;
+    readonly token: string;
+    readonly platform: DevicePlatform;
+    readonly deviceId: string | null;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+
+    constructor(init: Partial<NotificationDevice>) {
+        validateInit(init, ['userId', 'token', 'platform']);
+        this.id = init.id ?? null;
+        this.userId = init.userId;
+        this.token = init.token;
+        this.platform = init.platform;
+        this.deviceId = init.deviceId ?? null;
+        this.createdAt = init.createdAt ?? new Date();
+        this.updatedAt = init.updatedAt ?? new Date();
+    }
+}

--- a/src/core/notification-device/notification-device.module.ts
+++ b/src/core/notification-device/notification-device.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/database/database.module';
+import { getLogger } from 'src/logger/global-app-logger';
+import { NotificationDeviceService } from './notification-device.service';
+
+@Module({
+    imports: [DatabaseModule],
+    providers: [NotificationDeviceService],
+    exports: [NotificationDeviceService],
+})
+export class NotificationDeviceModule {
+    private readonly LOGGER = getLogger(NotificationDeviceModule.name);
+
+    constructor() {
+        this.LOGGER.log('Initialized');
+    }
+}

--- a/src/core/notification-device/notification-device.service.ts
+++ b/src/core/notification-device/notification-device.service.ts
@@ -1,0 +1,46 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { getLogger } from 'src/logger/global-app-logger';
+import { DevicePlatform, NotificationDevice } from './notification-device.entity';
+import { NotificationDeviceRepositoryPort } from './ports/notification-device.repository.port';
+
+@Injectable()
+export class NotificationDeviceService {
+    private readonly LOGGER = getLogger(NotificationDeviceService.name);
+
+    constructor(
+        @Inject(NotificationDeviceRepositoryPort)
+        private readonly repository: NotificationDeviceRepositoryPort
+    ) {}
+
+    /**
+     * Register (or re-register) a device's push token for the user. Keyed on the
+     * token, so the same device logging in again updates the existing row rather
+     * than creating duplicates.
+     */
+    async register(
+        userId: number,
+        token: string,
+        platform: DevicePlatform,
+        deviceId?: string | null
+    ): Promise<NotificationDevice> {
+        const device = await this.repository.upsertByToken(
+            new NotificationDevice({
+                userId,
+                token: token.trim(),
+                platform,
+                deviceId: deviceId?.trim() || null,
+            })
+        );
+        this.LOGGER.debug(`Registered ${platform} device for user ${userId}.`);
+        return device;
+    }
+
+    /** Unregister a device's push token (sign-out). Only removes the user's own token. */
+    async unregister(userId: number, token: string): Promise<boolean> {
+        const deleted = await this.repository.deleteByToken(token.trim(), userId);
+        if (deleted) {
+            this.LOGGER.debug(`Unregistered device for user ${userId}.`);
+        }
+        return deleted;
+    }
+}

--- a/src/core/notification-device/ports/notification-device.repository.port.ts
+++ b/src/core/notification-device/ports/notification-device.repository.port.ts
@@ -1,0 +1,10 @@
+import { NotificationDevice } from '../notification-device.entity';
+
+export const NotificationDeviceRepositoryPort = 'NotificationDeviceRepositoryPort';
+
+export interface NotificationDeviceRepositoryPort {
+    /** Insert the device, or update user/platform/device_id when the token already exists. */
+    upsertByToken(device: NotificationDevice): Promise<NotificationDevice>;
+    /** Remove the token if it belongs to the user. Returns true when a row was deleted. */
+    deleteByToken(token: string, userId: number): Promise<boolean>;
+}

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -80,6 +80,9 @@ import { ApiSubscriptionOrmEntity } from './api-tier/api-subscription.orm-entity
 import { ApiSubscriptionRepository } from './api-tier/api-subscription.repository';
 import { ApiUsageOrmEntity } from './api-tier/api-usage.orm-entity';
 import { ApiUsageRepository } from './api-tier/api-usage.repository';
+import { NotificationDeviceRepositoryPort } from 'src/core/notification-device/ports/notification-device.repository.port';
+import { NotificationDeviceOrmEntity } from './notification-device/notification-device.orm-entity';
+import { NotificationDeviceRepository } from './notification-device/notification-device.repository';
 
 @Module({
     imports: [
@@ -115,6 +118,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
             ApiKeyOrmEntity,
             ApiSubscriptionOrmEntity,
             ApiUsageOrmEntity,
+            NotificationDeviceOrmEntity,
         ]),
     ],
     providers: [
@@ -145,6 +149,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         { provide: ApiKeyRepositoryPort, useClass: ApiKeyRepository },
         { provide: ApiSubscriptionRepositoryPort, useClass: ApiSubscriptionRepository },
         { provide: ApiUsageRepositoryPort, useClass: ApiUsageRepository },
+        { provide: NotificationDeviceRepositoryPort, useClass: NotificationDeviceRepository },
     ],
     exports: [
         CardRepositoryPort,
@@ -171,6 +176,7 @@ import { ApiUsageRepository } from './api-tier/api-usage.repository';
         ApiKeyRepositoryPort,
         ApiSubscriptionRepositoryPort,
         ApiUsageRepositoryPort,
+        NotificationDeviceRepositoryPort,
     ],
 })
 export class DatabaseModule {

--- a/src/database/notification-device/notification-device.mapper.ts
+++ b/src/database/notification-device/notification-device.mapper.ts
@@ -1,0 +1,26 @@
+import { DevicePlatform, NotificationDevice } from 'src/core/notification-device/notification-device.entity';
+import { NotificationDeviceOrmEntity } from './notification-device.orm-entity';
+
+export class NotificationDeviceMapper {
+    static toCore(orm: NotificationDeviceOrmEntity): NotificationDevice {
+        return new NotificationDevice({
+            id: orm.id,
+            userId: orm.userId,
+            token: orm.token,
+            platform: orm.platform as DevicePlatform,
+            deviceId: orm.deviceId,
+            createdAt: orm.createdAt,
+            updatedAt: orm.updatedAt,
+        });
+    }
+
+    static toOrmEntity(core: NotificationDevice): NotificationDeviceOrmEntity {
+        const orm = new NotificationDeviceOrmEntity();
+        if (core.id !== null) orm.id = core.id;
+        orm.userId = core.userId;
+        orm.token = core.token;
+        orm.platform = core.platform;
+        orm.deviceId = core.deviceId;
+        return orm;
+    }
+}

--- a/src/database/notification-device/notification-device.orm-entity.ts
+++ b/src/database/notification-device/notification-device.orm-entity.ts
@@ -1,0 +1,33 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('notification_device')
+@Index('idx_notification_device_user_id', ['userId'])
+export class NotificationDeviceOrmEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ name: 'user_id' })
+    userId: number;
+
+    @Column({ unique: true })
+    token: string;
+
+    @Column()
+    platform: string;
+
+    @Column({ name: 'device_id', nullable: true })
+    deviceId: string | null;
+
+    @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+    createdAt: Date;
+
+    @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+    updatedAt: Date;
+}

--- a/src/database/notification-device/notification-device.repository.ts
+++ b/src/database/notification-device/notification-device.repository.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { NotificationDevice } from 'src/core/notification-device/notification-device.entity';
+import { NotificationDeviceRepositoryPort } from 'src/core/notification-device/ports/notification-device.repository.port';
+import { Repository } from 'typeorm';
+import { NotificationDeviceMapper } from './notification-device.mapper';
+import { NotificationDeviceOrmEntity } from './notification-device.orm-entity';
+
+@Injectable()
+export class NotificationDeviceRepository implements NotificationDeviceRepositoryPort {
+    constructor(
+        @InjectRepository(NotificationDeviceOrmEntity)
+        private readonly repository: Repository<NotificationDeviceOrmEntity>
+    ) {}
+
+    async upsertByToken(device: NotificationDevice): Promise<NotificationDevice> {
+        const orm = NotificationDeviceMapper.toOrmEntity(device);
+        // Re-registering the same push token updates the existing row (re-points
+        // it at the current user, refreshes platform) instead of duplicating it.
+        const existing = await this.repository.findOneBy({ token: device.token });
+        if (existing) {
+            orm.id = existing.id;
+        }
+        try {
+            const saved = await this.repository.save(orm);
+            return NotificationDeviceMapper.toCore(saved);
+        } catch (err) {
+            // A concurrent insert raced past the pre-check; the unique token
+            // constraint rejects the loser (23505) — fall back to an update.
+            if ((err as { code?: string })?.code === '23505') {
+                const current = await this.repository.findOneBy({ token: device.token });
+                if (current) {
+                    orm.id = current.id;
+                    const saved = await this.repository.save(orm);
+                    return NotificationDeviceMapper.toCore(saved);
+                }
+            }
+            throw err;
+        }
+    }
+
+    async deleteByToken(token: string, userId: number): Promise<boolean> {
+        const result = await this.repository.delete({ token, userId });
+        return (result.affected ?? 0) > 0;
+    }
+}

--- a/src/http/api/api.module.ts
+++ b/src/http/api/api.module.ts
@@ -10,6 +10,7 @@ import { BuyListApiController } from './buy-list/buy-list-api.controller';
 import { CardApiController } from './card/card-api.controller';
 import { DeckApiController } from './deck/deck-api.controller';
 import { InventoryApiController } from './inventory/inventory-api.controller';
+import { NotificationDeviceApiController } from './notification-device/notification-device-api.controller';
 import { SellOptimizerApiController } from './optimizer/sell-optimizer-api.controller';
 import { PortfolioApiController } from './portfolio/portfolio-api.controller';
 import { SetApiController } from './set/set-api.controller';
@@ -36,6 +37,7 @@ import { RapidApiProxyGuard } from './shared/rapidapi-proxy.guard';
         CardApiController,
         DeckApiController,
         InventoryApiController,
+        NotificationDeviceApiController,
         SellOptimizerApiController,
         PortfolioApiController,
         PriceAlertApiController,

--- a/src/http/api/notification-device/dto/notification-device-request.dto.ts
+++ b/src/http/api/notification-device/dto/notification-device-request.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+const DEVICE_PLATFORMS = ['ios', 'android', 'web'] as const;
+
+export class RegisterDeviceApiDto {
+    @ApiProperty({
+        description: 'The Expo/APNs/FCM push token for this device.',
+    })
+    @IsString()
+    @IsNotEmpty()
+    readonly token: string;
+
+    @ApiProperty({ enum: DEVICE_PLATFORMS, description: 'Device platform.' })
+    @IsIn(DEVICE_PLATFORMS)
+    readonly platform: (typeof DEVICE_PLATFORMS)[number];
+
+    @ApiPropertyOptional({
+        description: 'Optional client-supplied device identifier (metadata only).',
+    })
+    @IsOptional()
+    @IsString()
+    readonly deviceId?: string;
+}
+
+export class UnregisterDeviceApiDto {
+    @ApiProperty({ description: 'The push token to remove (e.g. on sign-out).' })
+    @IsString()
+    @IsNotEmpty()
+    readonly token: string;
+}

--- a/src/http/api/notification-device/dto/notification-device-request.dto.ts
+++ b/src/http/api/notification-device/dto/notification-device-request.dto.ts
@@ -1,14 +1,17 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsIn, IsOptional, IsString, Matches } from 'class-validator';
 
 const DEVICE_PLATFORMS = ['ios', 'android', 'web'] as const;
+// Rejects empty and whitespace-only tokens (`@IsNotEmpty` accepts "   ", which
+// would then trim to "" in the service and persist a blank token row).
+const NON_BLANK = /\S/;
 
 export class RegisterDeviceApiDto {
     @ApiProperty({
         description: 'The Expo/APNs/FCM push token for this device.',
     })
     @IsString()
-    @IsNotEmpty()
+    @Matches(NON_BLANK, { message: 'token must not be blank' })
     readonly token: string;
 
     @ApiProperty({ enum: DEVICE_PLATFORMS, description: 'Device platform.' })
@@ -26,6 +29,6 @@ export class RegisterDeviceApiDto {
 export class UnregisterDeviceApiDto {
     @ApiProperty({ description: 'The push token to remove (e.g. on sign-out).' })
     @IsString()
-    @IsNotEmpty()
+    @Matches(NON_BLANK, { message: 'token must not be blank' })
     readonly token: string;
 }

--- a/src/http/api/notification-device/dto/notification-device-response.dto.ts
+++ b/src/http/api/notification-device/dto/notification-device-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class NotificationDeviceApiDto {
+    @ApiProperty()
+    readonly id: number;
+
+    @ApiProperty({ enum: ['ios', 'android', 'web'] })
+    readonly platform: string;
+
+    @ApiPropertyOptional({ nullable: true })
+    readonly deviceId?: string | null;
+
+    @ApiProperty({ description: 'When the device was first registered.' })
+    readonly createdAt: string;
+}

--- a/src/http/api/notification-device/notification-device-api.controller.ts
+++ b/src/http/api/notification-device/notification-device-api.controller.ts
@@ -1,0 +1,75 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    HttpCode,
+    HttpStatus,
+    Inject,
+    Post,
+    Req,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { NotificationDevice } from 'src/core/notification-device/notification-device.entity';
+import { NotificationDeviceService } from 'src/core/notification-device/notification-device.service';
+import { ApiResponseDto } from 'src/http/base/api-response.dto';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
+import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { JwtOrApiKeyGuard } from '../shared/jwt-or-api-key.guard';
+import {
+    RegisterDeviceApiDto,
+    UnregisterDeviceApiDto,
+} from './dto/notification-device-request.dto';
+import { NotificationDeviceApiDto } from './dto/notification-device-response.dto';
+
+@ApiTags('Notifications')
+@ApiBearerAuth()
+@Controller('api/v1/notifications/devices')
+@UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
+export class NotificationDeviceApiController {
+    constructor(
+        @Inject(NotificationDeviceService)
+        private readonly deviceService: NotificationDeviceService
+    ) {}
+
+    @Post()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: "Register (or refresh) this device's push token for the authenticated user",
+    })
+    @ApiOkEnvelope(NotificationDeviceApiDto, { description: 'Device registered' })
+    async register(
+        @Body() dto: RegisterDeviceApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<NotificationDeviceApiDto>> {
+        const device = await this.deviceService.register(
+            req.user.id,
+            dto.token,
+            dto.platform,
+            dto.deviceId
+        );
+        return ApiResponseDto.ok(this.toDto(device));
+    }
+
+    @Delete()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: "Unregister a device's push token (e.g. on sign-out)" })
+    @ApiResponse({ status: 200, description: 'Device unregistered' })
+    async unregister(
+        @Body() dto: UnregisterDeviceApiDto,
+        @Req() req: AuthenticatedRequest
+    ): Promise<ApiResponseDto<{ unregistered: boolean }>> {
+        const unregistered = await this.deviceService.unregister(req.user.id, dto.token);
+        return ApiResponseDto.ok({ unregistered });
+    }
+
+    private toDto(device: NotificationDevice): NotificationDeviceApiDto {
+        return {
+            id: device.id,
+            platform: device.platform,
+            deviceId: device.deviceId,
+            createdAt: device.createdAt.toISOString(),
+        };
+    }
+}

--- a/test/core/notification-device/notification-device.service.spec.ts
+++ b/test/core/notification-device/notification-device.service.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationDevice } from 'src/core/notification-device/notification-device.entity';
+import { NotificationDeviceRepositoryPort } from 'src/core/notification-device/ports/notification-device.repository.port';
+import { NotificationDeviceService } from 'src/core/notification-device/notification-device.service';
+
+describe('NotificationDeviceService', () => {
+    let service: NotificationDeviceService;
+    let repository: jest.Mocked<NotificationDeviceRepositoryPort>;
+
+    beforeEach(async () => {
+        repository = {
+            upsertByToken: jest
+                .fn()
+                .mockImplementation(async (d: NotificationDevice) => new NotificationDevice({ ...d, id: 1 })),
+            deleteByToken: jest.fn().mockResolvedValue(true),
+        };
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                NotificationDeviceService,
+                { provide: NotificationDeviceRepositoryPort, useValue: repository },
+            ],
+        }).compile();
+        service = module.get(NotificationDeviceService);
+    });
+
+    describe('register', () => {
+        it('upserts the trimmed token for the user', async () => {
+            const result = await service.register(7, '  expo-token  ', 'ios', '  dev-1  ');
+            const stored = repository.upsertByToken.mock.calls[0][0];
+            expect(stored.userId).toBe(7);
+            expect(stored.token).toBe('expo-token');
+            expect(stored.platform).toBe('ios');
+            expect(stored.deviceId).toBe('dev-1');
+            expect(result.id).toBe(1);
+        });
+
+        it('normalizes a blank device id to null', async () => {
+            await service.register(7, 'tok', 'android', '   ');
+            expect(repository.upsertByToken.mock.calls[0][0].deviceId).toBeNull();
+        });
+    });
+
+    describe('unregister', () => {
+        it('deletes the trimmed token scoped to the user', async () => {
+            const result = await service.unregister(7, '  tok  ');
+            expect(repository.deleteByToken).toHaveBeenCalledWith('tok', 7);
+            expect(result).toBe(true);
+        });
+
+        it('returns false when nothing was deleted', async () => {
+            repository.deleteByToken.mockResolvedValueOnce(false);
+            expect(await service.unregister(7, 'tok')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Closes #556. Push half of mobile price alerts + notifications (mobile #32).

## What
Lets the mobile app register its push token so notifications can later be delivered to the device.

- **`notification_device` table** (migration `045` + init schema): one row per push token (`token` unique), with `platform`, optional `device_id`, and a `user_id` FK (`ON DELETE CASCADE`).
- **`NotificationDeviceService`** (`register` / `unregister`) behind a repository port, in a leaf `NotificationDeviceModule`. `register` **upserts on the token**, so a device re-registering (e.g. after a fresh login) updates the existing row and can re-point it at the current user instead of duplicating.
- **Endpoints** (`NotificationDeviceApiController`, `JwtOrApiKeyGuard`):
  - `POST /api/v1/notifications/devices` → register/refresh `{ token, platform, deviceId? }`, returns the device
  - `DELETE /api/v1/notifications/devices` → unregister `{ token }` (sign-out), returns `{ unregistered }`
- OpenAPI-annotated (`platform` is an `ios|android|web` enum).

## Scope
Per the issue, this is the **registration endpoint only**. Fan-out push delivery (Expo Push API on alert/notification firing, token pruning via delivery receipts) is a documented follow-up — I'll open a tracking issue.

## Verification
Service unit tests + end-to-end against a throwaway user on the running app:
1. register → returns device DTO ✅
2. re-register same token with a new platform → **upserts** (one row, platform updated, id stable) ✅
3. invalid platform → **400** ✅
4. unregister → `unregistered: true`; repeat → `false` ✅
5. unauthenticated → **401** ✅
6. `/api/openapi.json` types both request bodies + the response under the envelope ✅