### PR TITLE
refactor: share DEVICE_PLATFORMS enum between device DTOs

### DIFF
--- a/src/http/api/notification-device/dto/notification-device-request.dto.ts
+++ b/src/http/api/notification-device/dto/notification-device-request.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsIn, IsOptional, IsString, Matches } from 'class-validator';
 
-const DEVICE_PLATFORMS = ['ios', 'android', 'web'] as const;
+export const DEVICE_PLATFORMS = ['ios', 'android', 'web'] as const;
 // Rejects empty and whitespace-only tokens (`@IsNotEmpty` accepts "   ", which
 // would then trim to "" in the service and persist a blank token row).
 const NON_BLANK = /\S/;

--- a/src/http/api/notification-device/dto/notification-device-response.dto.ts
+++ b/src/http/api/notification-device/dto/notification-device-response.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DEVICE_PLATFORMS } from './notification-device-request.dto';
 
 export class NotificationDeviceApiDto {
     @ApiProperty()
     readonly id: number;
 
-    @ApiProperty({ enum: ['ios', 'android', 'web'] })
-    readonly platform: string;
+    @ApiProperty({ enum: DEVICE_PLATFORMS })
+    readonly platform: (typeof DEVICE_PLATFORMS)[number];
 
     @ApiPropertyOptional({ nullable: true })
     readonly deviceId?: string | null;


### PR DESCRIPTION
## What

Export `DEVICE_PLATFORMS` from the notification-device request DTO and reuse it in the response DTO, replacing the duplicated `['ios', 'android', 'web']` literal.

- Request DTO: `const DEVICE_PLATFORMS` → `export const DEVICE_PLATFORMS`
- Response DTO: `@ApiProperty({ enum: ['ios', 'android', 'web'] })` / `platform: string` → reuse `DEVICE_PLATFORMS` for the OpenAPI enum and a typed `platform: (typeof DEVICE_PLATFORMS)[number]`

## Why

Single source of truth for the device platform values so the request and response stay in sync. Follow-up to the device-registration feature (#559).