### PR TITLE
feat: type price-alert + notification response bodies in OpenAPI spec

### DIFF
--- a/src/http/api/price-alert/price-alert-api.controller.ts
+++ b/src/http/api/price-alert/price-alert-api.controller.ts
@@ -36,6 +36,7 @@ import { CreatePriceAlertDto, UpdatePriceAlertDto } from './dto/price-alert-requ
 import { PriceAlertApiDto } from './dto/price-alert-response.dto';
 import { PriceAlertApiPresenter } from './price-alert-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 
 @ApiTags('Price Alerts')
 @Controller('api/v1/price-alerts')
@@ -53,7 +54,7 @@ export class PriceAlertApiController {
     @ApiOperation({ summary: 'List price alerts' })
     @ApiQuery({ name: 'page', required: false })
     @ApiQuery({ name: 'limit', required: false })
-    @ApiResponse({ status: 200, description: 'Price alert list' })
+    @ApiOkEnvelope(PriceAlertApiDto, { isArray: true, description: 'Price alert list' })
     async findAll(
         @Query('page') page: string = '1',
         @Query('limit') limit: string = '20',
@@ -78,7 +79,7 @@ export class PriceAlertApiController {
     @UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
     @ApiBearerAuth()
     @ApiOperation({ summary: 'Create a price alert' })
-    @ApiResponse({ status: 201, description: 'Alert created' })
+    @ApiOkEnvelope(PriceAlertApiDto, { status: 201, description: 'Alert created' })
     async create(
         @Body() dto: CreatePriceAlertDto,
         @Req() req: AuthenticatedRequest
@@ -112,7 +113,7 @@ export class PriceAlertApiController {
     @UseGuards(JwtOrApiKeyGuard, ApiRateLimitGuard)
     @ApiBearerAuth()
     @ApiOperation({ summary: 'Update a price alert' })
-    @ApiResponse({ status: 200, description: 'Alert updated' })
+    @ApiOkEnvelope(PriceAlertApiDto, { description: 'Alert updated' })
     async update(
         @Param('id', ParseIntPipe) id: number,
         @Body() dto: UpdatePriceAlertDto,

--- a/src/http/api/price-alert/price-notification-api.controller.ts
+++ b/src/http/api/price-alert/price-notification-api.controller.ts
@@ -21,6 +21,7 @@ import { ApiResponseDto, PaginationMeta } from 'src/http/base/api-response.dto';
 import { PriceNotificationApiDto } from './dto/price-notification-response.dto';
 import { PriceAlertApiPresenter } from './price-alert-api.presenter';
 import { ApiRateLimitGuard } from '../shared/api-rate-limit.guard';
+import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 
 @ApiTags('Notifications')
 @ApiBearerAuth()
@@ -36,7 +37,7 @@ export class PriceNotificationApiController {
     @ApiOperation({ summary: 'List notifications' })
     @ApiQuery({ name: 'page', required: false })
     @ApiQuery({ name: 'limit', required: false })
-    @ApiResponse({ status: 200, description: 'Notification list' })
+    @ApiOkEnvelope(PriceNotificationApiDto, { isArray: true, description: 'Notification list' })
     async findAll(
         @Query('page') page: string = '1',
         @Query('limit') limit: string = '20',


### PR DESCRIPTION
## What

The price-alert and notification API controllers declared bare `@ApiResponse({ status, description })` with no schema on their DTO-returning endpoints, so the generated OpenAPI client typed those bodies as `content?: never`. This applies `ApiOkEnvelope` (the same decorator #557 used for deck/buy-list) to:

- `GET /api/v1/price-alerts` → `PriceAlertApiDto[]`
- `POST /api/v1/price-alerts` → `PriceAlertApiDto`
- `PATCH /api/v1/price-alerts/:id` → `PriceAlertApiDto`
- `GET /api/v1/notifications` → `PriceNotificationApiDto[]`

Trivial acks (`{ deleted }`, `{ count }`, `{ markedRead }`, `{ markedAllRead }`, the internal `process` result) stay bare `@ApiResponse`, matching the convention #557 established on the deck controller.

## Why

#557 typed deck + buy-list but skipped price-alert + notification responses. That's the remaining piece of the mobile #36 dependency, and it was leaving mobile **#32 (price alerts + in-app notifications)** half-blocked — the push-registration half (#37) already landed in #559.

## Unblocks

Mobile #32. After deploy, the mobile client regenerates (`npm run gen:api` against the live spec) and these responses gain types.

## Verification

- `tsc --noEmit` passes clean.
- Decorator-only change (Swagger metadata); no runtime logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)