### PR TITLE
feat: type price-alert request bodies in OpenAPI spec

### DIFF
--- a/src/http/api/price-alert/dto/price-alert-request.dto.ts
+++ b/src/http/api/price-alert/dto/price-alert-request.dto.ts
@@ -1,14 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsBoolean, IsNumber, IsOptional, IsUUID, Min } from 'class-validator';
 
 export class CreatePriceAlertDto {
+    @ApiProperty({ format: 'uuid' })
     @IsUUID()
     readonly cardId: string;
 
+    @ApiPropertyOptional({
+        minimum: 0.01,
+        description:
+            'Alert when the price rises by at least this percent. At least one of increasePct/decreasePct is required.',
+    })
     @IsOptional()
     @IsNumber()
     @Min(0.01)
     readonly increasePct?: number;
 
+    @ApiPropertyOptional({
+        minimum: 0.01,
+        description:
+            'Alert when the price falls by at least this percent. At least one of increasePct/decreasePct is required.',
+    })
     @IsOptional()
     @IsNumber()
     @Min(0.01)
@@ -16,16 +28,19 @@ export class CreatePriceAlertDto {
 }
 
 export class UpdatePriceAlertDto {
+    @ApiPropertyOptional({ minimum: 0.01, nullable: true, description: 'Set null to clear the rise threshold.' })
     @IsOptional()
     @IsNumber()
     @Min(0.01)
     readonly increasePct?: number | null;
 
+    @ApiPropertyOptional({ minimum: 0.01, nullable: true, description: 'Set null to clear the fall threshold.' })
     @IsOptional()
     @IsNumber()
     @Min(0.01)
     readonly decreasePct?: number | null;
 
+    @ApiPropertyOptional()
     @IsOptional()
     @IsBoolean()
     readonly isActive?: boolean;


### PR DESCRIPTION
## What
`CreatePriceAlertDto` and `UpdatePriceAlertDto` had class-validator decorators but no `@ApiProperty`, so the generated OpenAPI client typed their request bodies as `Record<string, never>`. This adds `@ApiProperty`/`@ApiPropertyOptional` (matching the inventory/transaction convention from #549/#550) so the bodies are typed:

- `CreatePriceAlertDto`: `cardId` (uuid), optional `increasePct`/`decreasePct` (min 0.01).
- `UpdatePriceAlertDto`: optional nullable `increasePct`/`decreasePct`, optional `isActive`.

## Why
#562 typed the price-alert/notification *responses*, but the create/update *request* bodies were still untyped — so mobile #32 could list/delete alerts but not create or edit them. This closes that gap.

## Verification
- `tsc --noEmit` passes clean.
- Annotation-only change (Swagger metadata + no runtime logic).

## Follow-up
After deploy, the mobile client regenerates and `CreatePriceAlertDto`/`UpdatePriceAlertDto` gain real fields, unblocking the alert create/edit UI.