### PR TITLE
docs: add cross-repo analysis plan for July 2026

### DIFF
--- a/docs/codebase-analyses-2026-07/mcp.md
+++ b/docs/codebase-analyses-2026-07/mcp.md
@@ -1,0 +1,432 @@
+# Codebase Analysis — Findings & Recommendations
+
+Full review of `iwantmymtg-mcp` at `a152ba6` covering bugs, inconsistencies, and
+deviations from best practices (clean code, DRY, testability, hexagonal
+layering). Build and tests pass (91/91) — everything below is about latent
+defects and maintainability, not currently failing behavior.
+
+**Overall assessment:** this is a well-built, unusually disciplined small
+codebase. Lazy config, the auth-sentinel middleware, generated OpenAPI types,
+the generated tool catalog with CI drift checks, and the release pipeline are
+all above-average patterns. The findings below are mostly consistency and
+hardening issues, with two genuine runtime bugs at the top.
+
+---
+
+## 1. Bugs
+
+### B1 (High) — Empty API responses produce invalid MCP tool results
+
+`src/server.ts:58` serializes every successful handler result with
+`JSON.stringify(result, null, 2)`. When a handler resolves `undefined`,
+`JSON.stringify(undefined)` returns `undefined` (not a string), so the server
+emits:
+
+```json
+{ "content": [{ "type": "text" }] }
+```
+
+`text` is a **required** field on MCP text content; strict clients will reject
+the response, and the user sees a protocol error instead of a success.
+
+This is reachable today: openapi-fetch returns `data: undefined` for any 204
+or empty-body response (the project's own test asserts exactly this —
+`test/api-client.test.ts:73-82`, "returns undefined data for 204 responses").
+Several endpoints are declared with empty success bodies in the generated spec
+(e.g. `TransactionApiController_delete` → `200, content?: never`), so any
+delete/refresh endpoint that returns no body silently corrupts the tool result.
+
+**Fix** in `src/server.ts`:
+
+```ts
+const result = await tool.handler(args.data);
+const text =
+  result === undefined
+    ? "OK"
+    : typeof result === "string"
+      ? result
+      : JSON.stringify(result, null, 2);
+return { content: [{ type: "text", text }] };
+```
+
+(The `typeof result === "string"` branch also fixes B2.)
+
+### B2 (Medium) — `export_inventory` CSV is double-encoded
+
+`export_inventory` (`src/tools/inventory.ts:106-118`) fetches with
+`parseAs: "text"` and returns a raw CSV string. `server.ts` then
+`JSON.stringify`s it, so the model receives:
+
+```
+"id,name\n1,Bolt"
+```
+
+— one giant quoted string with escaped newlines instead of readable CSV. It
+works, but it wastes tokens and makes the output hard for both the model and
+the user to read. The B1 fix (pass strings through unchanged) resolves this.
+
+### B3 (Medium) — `zodToJsonSchema` target `"openApi3"` emits non-JSON-Schema output
+
+`src/server.ts:29` converts input schemas with `{ target: "openApi3" }`.
+OpenAPI 3.0 represents nullability as `nullable: true`, which is **not** JSON
+Schema. Verified output for `update_price_alert`:
+
+```json
+"increasePct": { "type": "number", "minimum": 0.01, "nullable": true }
+```
+
+MCP `inputSchema` is defined as JSON Schema. A client that validates arguments
+strictly will see `"type": "number"`, ignore the unknown `nullable` keyword,
+and reject `null` — which breaks the *documented* "pass null for a threshold
+to clear it" feature of `update_price_alert` (`src/tools/alerts.ts:43`).
+
+**Fix:** drop the target option (the default `jsonSchema7` emits
+`"type": ["number", "null"]`):
+
+```ts
+inputSchema: zodToJsonSchema(t.inputSchema) as Record<string, unknown>,
+```
+
+Verify with an MCP client that consumed the openApi3 shape before shipping.
+
+### B4 (Low) — `update_price_alert` accepts an empty patch
+
+`create_price_alert` refines "at least one threshold required"
+(`src/tools/alerts.ts:24-30`), but `update_price_alert` has no equivalent: a
+call with only `id` passes validation and PATCHes an empty body `{}` — a
+guaranteed server-side rejection (or worse, a silent no-op) that zod could
+catch locally with a clearer message:
+
+```ts
+.refine((v) => v.increasePct !== undefined || v.decreasePct !== undefined || v.isActive !== undefined,
+  { message: "Provide at least one field to update." })
+```
+
+---
+
+## 2. Inconsistencies
+
+### I1 — The format enum is duplicated and diverges between tools
+
+The generated spec defines the format enum
+(`"standard" | "commander" | ... | "pioneer"`) for both card search and decks.
+The codebase handles it three different ways:
+
+- `src/tools/decks.ts:11-23` hand-copies it as `FORMATS` (will silently drift
+  when the API adds a format — the weekly sync updates the spec types, not
+  this list).
+- `src/tools/search-cards.ts:19-21` accepts free-form `z.string()`, so a typo
+  (`"cmmander"`) becomes an API 400 instead of a local validation error.
+- `src/tools/sets.ts:40` (`list_set_cards`) — same free string.
+
+**Fix:** declare the enum once (e.g. `src/tools/shared.ts`), derive its type
+from the generated spec so drift becomes a compile error, and reuse the same
+`z.enum` in all three places:
+
+```ts
+import type { operations } from "../generated/api-types.js";
+type ApiFormat = NonNullable<operations["searchCards"]["parameters"]["query"]>["format"];
+export const FORMATS = ["standard", "commander", /* ... */] as const satisfies readonly ApiFormat[];
+```
+
+### I2 — Card-key schema duplicated
+
+`{ setCode, setNumber }` with identical descriptions is defined in
+`src/tools/get-card.ts:4-7` and re-written inline in
+`src/tools/sell-tools.ts:14-19`. Export the one schema (and the `CardKey`
+type) and reuse it.
+
+### I3 — Three different conventions for numeric ID inputs
+
+- `z.coerce.number().int()` — alerts (`alerts.ts:45,63`), notifications
+  (`notifications.ts:32`)
+- `z.number().int().min(1)` — transactions (`transactions.ts:68,84`), decks
+  (`decks.ts:30-34`)
+
+Coercing IDs accepts `"42"` from imprecise models (a nice affordance);
+non-coercing ones reject it. Pick one shared helper —
+`const id = z.coerce.number().int().min(1)` — and use it everywhere.
+
+### I4 — `cardId` validation differs across tools
+
+Inventory, decks, buy-list, and alerts validate `cardId` as
+`z.string().uuid()`; transactions (`src/tools/transactions.ts:5`) accept any
+string. Same underlying identifier, different strictness. Share a single
+`cardId` schema (buy-list.ts:10-13 already has the right one, description
+included).
+
+### I5 — Update-tool input shapes differ
+
+`update_transaction` nests changes under a `patch` object
+(`transactions.ts:67-70`); `update_price_alert` and `update_deck` flatten
+fields alongside `id`. Flat inputs are easier for models to produce and match
+the rest of the registry — flatten `update_transaction` (`{ id, quantity?,
+pricePerUnit?, ... }`) and spread into the body.
+
+### I6 — Query-param serialization handled three ways
+
+- `get_set_price_history` converts: `{ days: String(days) }` (`sets.ts:75`)
+- `get_cash_vs_credit` converts: `{ bonus: String(input.bonus) }` (`sell-tools.ts:57`)
+- `get_portfolio_history` passes the raw number: `{ days } as never` (`portfolio.ts:26`)
+- `get_cost_basis` passes a raw boolean where the spec says `isFoil?: string` (`transactions.ts:109`)
+
+All serialize to the same URL string, so the `String()` calls are noise —
+but the inconsistency makes readers wonder which one is load-bearing. Pick
+one style (raw values; the URL serializer stringifies) and note why once.
+
+### I7 — `search_cards` lags the API spec
+
+The generated spec exposes `groupBy: "name"` ("one representative printing per
+distinct card name") on `searchCards` — arguably the most LLM-friendly search
+mode — but the tool doesn't surface it (`search-cards.ts:4-28`). The spec also
+documents that `legality` without `format` is a 400; a
+`.refine((v) => !v.legality || !!v.format)` would catch that locally.
+
+### I8 — `as never` casts are broader than necessary
+
+The casts exist because the spec types many query params as `unknown` — fair.
+But some casts fight *typed* spec entries: `transactions.ts:73,87` cast
+`{ path: { id } as never }` even though the spec declares `id: number`, and
+`portfolio.ts` casts fully-typed query objects. Each unnecessary `as never`
+silently disables the type-checking the generated spec exists to provide.
+Sweep them; keep casts only where the spec is genuinely `unknown`, and
+consider fixing the upstream OpenAPI annotations (the source API's
+`@ApiQuery` types) so even those disappear.
+
+### I9 — `colors` drop-logic duplicated
+
+`getPortfolioBreakdownTool` and `getPortfolioBreakdownCardsTool` both repeat
+`input.by === "color" ? input.colors : undefined` (`portfolio.ts:92,120`).
+Trivial, but a shared helper (or a `.transform` on a shared schema fragment)
+keeps the rule in one place.
+
+### I10 — `inventoryItem.quantity` semantics differ between add and update
+
+One schema serves both `add_inventory` and `update_inventory`
+(`inventory.ts:4-8`) with `min(0)` and the description "0 removes the row."
+For **add**, quantity 0 is nonsensical; the description is only true for
+update. Split into `min(1)` for add and keep `min(0)` + the removal note for
+update.
+
+### I11 — Auth-ness is convention-by-description-suffix
+
+Whether a tool needs auth is encoded three separate ways:
+
+1. The literal string "Requires IWMM_API_KEY." at the end of each description.
+2. A regex over that string in `scripts/gen-tools-doc.ts:20`.
+3. A hardcoded `readOnly` allow-list in `test/tools.test.ts:78-90`.
+
+The test admirably keeps the convention honest, but this is stringly-typed
+metadata maintained in triplicate. **Fix:** add `requiresAuth: boolean` to
+`ToolDefinition`, derive the description suffix, the doc bucketing, and the
+test assertion from it — and it can then also drive `AUTH_HEADERS`
+automatically instead of every authenticated handler remembering to pass
+`headers: AUTH_HEADERS` (a forgotten header today = confusing 401 at runtime,
+uncaught by any test or type).
+
+---
+
+## 3. Architecture & clean code
+
+### A1 — `ToolDefinition` erases the schema↔handler type link
+
+`src/tools/index.ts:80-85`:
+
+```ts
+handler: (input: any) => Promise<unknown>;
+```
+
+Every tool hand-writes its handler's input type (`decks.ts:164-169` etc.) and
+nothing checks it matches the zod schema — the two can drift silently (e.g. a
+schema gains `.default(false)` but the handler type still says the field is
+optional, or vice versa). Tools also aren't declared against the interface at
+their definition site, so a malformed tool object only fails at the registry
+test, not at compile time.
+
+**Fix:** make the definition generic and add a tiny factory so types are
+inferred, never hand-written:
+
+```ts
+// src/tools/types.ts
+export interface ToolDefinition<S extends z.ZodTypeAny = z.ZodTypeAny> {
+  name: string;
+  description: string;
+  requiresAuth: boolean;          // see I11
+  inputSchema: S;
+  handler: (input: z.output<S>) => Promise<unknown>;
+}
+
+export function defineTool<S extends z.ZodTypeAny>(t: ToolDefinition<S>) {
+  return t;
+}
+```
+
+This deletes ~40 hand-maintained input type annotations, catches
+schema/handler drift at compile time, and gives `z.output` semantics (defaults
+applied) for free.
+
+### A2 — `ToolDefinition` lives in the registry module
+
+The shared contract is declared in `src/tools/index.ts`, the same file that
+imports every tool module. Tool modules can't reference their own contract
+without creating an import cycle. Move it to `src/tools/types.ts` (as above).
+In hexagonal terms: `ToolDefinition` is the port; `server.ts` is the driving
+adapter; `api-client.ts` is the driven adapter — the port shouldn't live
+inside the composition root.
+
+### A3 — Proxy-based `apiClient` rebuilds the client on every property access
+
+`src/api-client.ts:60-65` constructs a fresh `createClient` + re-registers the
+middleware on **every** `apiClient.GET/POST/...` access. The laziness goal
+(tests stubbing `globalThis.fetch` late, live `baseUrl`) is already satisfied
+by the existing `fetch: (...args) => globalThis.fetch(...args)` indirection
+and by memoizing per base URL:
+
+```ts
+let cached: { baseUrl: string; client: ApiClient } | undefined;
+function buildClient(): ApiClient {
+  if (cached?.baseUrl !== config.baseUrl) {
+    const client = createClient<paths>({ baseUrl: config.baseUrl, fetch: (...a) => globalThis.fetch(...a) });
+    client.use(authMiddleware);
+    cached = { baseUrl: config.baseUrl, client };
+  }
+  return cached.client;
+}
+```
+
+Cheap, removes per-call allocation, and is far less surprising than a Proxy.
+
+### A4 — Missing MCP tool annotations
+
+Many tools are real writes — `delete_deck` is documented as *permanent* —
+but no tool declares MCP annotations (`readOnlyHint`, `destructiveHint`,
+`idempotentHint`). Descriptions saying "This is a real write" help the model;
+annotations are the structured contract that lets **clients** gate/confirm
+destructive calls. With `requiresAuth` (I11) and a `readOnly`/`destructive`
+flag on `ToolDefinition`, `server.ts` can emit them in `ListTools` and the
+existing description conventions can be generated instead of hand-typed.
+
+### A5 — Raw zod error dump in argument failures
+
+`src/server.ts:49` returns `args.error.message`, which is the JSON-stringified
+issue array — verbose and noisy for a model to parse. Prefer a flattened,
+per-field summary:
+
+```ts
+const issues = args.error.issues
+  .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+  .join("; ");
+```
+
+### A6 — Minor error-formatter polish
+
+- `formatApiError` 429 branch echoes `X-RateLimit-Reset` raw
+  (`error-formatter.ts:24`); when it's epoch seconds the model sees
+  "Resets at 1700000000." Convert numeric values with
+  `new Date(reset * 1000).toISOString()`.
+- `extractApiMessage` joins `message` arrays without checking element types
+  (`error-formatter.ts:41`); a non-string entry renders "[object Object]".
+  Filter with `.filter((m) => typeof m === "string")`.
+
+---
+
+## 4. Testing gaps
+
+### T1 — Tool tests bypass the schema, so the production input path is untested
+
+`test/tools.test.ts:42-47` deliberately skips `inputSchema` parsing ("we trust
+zod"). But parsing is not just validation — it *transforms*: defaults
+(`get_cost_basis` `isFoil.default(false)`), coercions
+(`update_price_alert` `z.coerce.number()`), and refinements all run only
+through parse. The handlers are therefore tested with inputs they never
+receive in production, and a schema/handler mismatch (see A1) passes tests.
+One-line fix in the helper:
+
+```ts
+await tool.handler(tool.inputSchema.parse(input));
+```
+
+(Then tests like `get_cost_basis` can drop their manually supplied defaults —
+asserting the default itself.)
+
+### T2 — No test that every authenticated tool actually sends auth
+
+The `readOnly` set test (tools.test.ts:77) checks *descriptions*, and
+individual endpoint tests spot-check `Authorization`. But nothing asserts the
+general invariant "every non-read-only tool sends `Bearer ...`" — the exact
+failure mode of forgetting `headers: AUTH_HEADERS` in a new tool. With
+`requiresAuth` on the definition (I11) this becomes a loop:
+call each tool with minimal valid input, assert the Authorization header
+matches `requiresAuth`.
+
+### T3 — No test for the server request handlers
+
+`src/server.ts`'s CallTool handler (unknown tool, invalid args, thrown
+`ApiError` → `formatError`, undefined result → B1) has no coverage; it's the
+one file gluing everything together. Extract the handler bodies into exported
+functions (or test via an in-memory transport) and cover those four branches —
+B1 would have been caught.
+
+---
+
+## 5. Tooling / CI / config
+
+### C1 — No linter or formatter
+
+There is no ESLint/Biome/Prettier config and no CI lint step. For a
+public, published package with outside contributors (CONTRIBUTING.md exists),
+add one — Biome is a good single-tool fit for a codebase this size — and wire
+it into `ci.yml` next to `check:tools-doc`.
+
+### C2 — `moduleResolution: "Bundler"` for a tsc-compiled Node app
+
+`tsconfig.json` uses `module: ES2022` + `moduleResolution: Bundler`, but the
+output runs directly on Node (no bundler). "Bundler" does not verify that
+import specifiers are runtime-resolvable — it would happily accept
+extension-less relative imports that then crash at `node dist/index.js`. The
+code currently survives because every import hand-writes `.js`, but nothing
+enforces it. Switch to `module`/`moduleResolution: "NodeNext"`, which
+enforces the exact semantics the runtime uses. Also `resolveJsonModule` is
+enabled but unused (`version.ts` uses `createRequire` instead — which is the
+right call, since importing package.json would change the dist layout; just
+drop the unused flag).
+
+### C3 — CI tests only Node 24; engines say `>=20`
+
+`package.json` declares `engines: { node: ">=20" }` but `ci.yml` builds and
+tests only on Node 24. Test the floor you promise — a small matrix
+(`[20, 24]`) or at least Node 20.
+
+### C4 — `sync.yml` force-pushes a shared branch pattern
+
+`git push -u origin "$BRANCH" --force` (sync.yml:55) with a date-stamped
+branch name is fine in practice, but if the job runs twice the same day with a
+human commit added to the PR meanwhile, that commit is destroyed. Prefer
+`--force-with-lease`.
+
+---
+
+## 6. Prioritized action list
+
+| # | Finding | Severity | Effort |
+|---|---------|----------|--------|
+| B1 | `undefined` results emit invalid MCP content | High | XS |
+| B3 | `openApi3` schema target breaks `null` inputs | Medium | XS |
+| B2 | CSV export double-encoded | Medium | XS (folded into B1) |
+| A1/A2 | Generic `ToolDefinition` + `defineTool`, move to own module | Medium | M |
+| I11/A4/T2 | `requiresAuth` flag → auto headers, annotations, doc, test | Medium | M |
+| T1 | Parse inputs in the tool-test helper | Medium | XS |
+| B4 | Empty-patch refinement on `update_price_alert` | Low | XS |
+| I1 | Single spec-derived format enum | Low | S |
+| I2–I6, I9, I10 | Schema/style consolidation | Low | S |
+| A3 | Memoize the API client | Low | XS |
+| A5, A6 | Error-message polish | Low | XS |
+| T3 | Server handler tests | Medium | S |
+| C1 | Add linter to CI | Medium | S |
+| C2 | `NodeNext` module resolution | Low | XS |
+| C3 | Test Node 20 in CI | Low | XS |
+| C4 | `--force-with-lease` in sync workflow | Low | XS |
+
+A sensible first PR: B1 + B2 + B3 + T1 + B4 (all extra-small, all
+correctness). A second PR: the `ToolDefinition`/`requiresAuth` refactor
+(A1/A2/I11/A4/T2), which mechanically absorbs most of the consistency items.

--- a/docs/codebase-analyses-2026-07/mobile.md
+++ b/docs/codebase-analyses-2026-07/mobile.md
@@ -1,0 +1,226 @@
+# Codebase Analysis: Bugs, Inconsistencies, and Recommendations
+
+**Scope:** full read of the hand-written source (`app/`, `components/`, `lib/`, `scripts/`, `.github/`) — roughly 7,200 lines excluding the generated `lib/api/schema.ts`.
+**Date:** 2026-07-07
+
+## Overall assessment
+
+The codebase is in good shape for its size: strict TypeScript, a typed API client generated from the backend OpenAPI spec with CI drift-checking, a well-designed auth layer (single-flight proactive token refresh with a 401 backstop and careful race guards), consistent theming through tokens, accessibility labels nearly everywhere, and unusually good explanatory comments. The findings below are mostly about (1) a handful of real bugs, (2) heavy copy-paste duplication that has accumulated across screens/components, and (3) missing test/lint infrastructure — not about structural rot.
+
+Severity legend: 🔴 fix soon · 🟡 should fix · 🔵 improvement / polish
+
+---
+
+## 1. Bugs
+
+### 1.1 🔴 Query cache is not cleared on sign-out (cross-account data leak)
+
+`AuthContext.handleSignedOut` (`lib/auth/AuthContext.tsx:66`) clears tokens and push registration but never touches the TanStack Query cache. Only the delete-account flow clears it (`app/account.tsx:42`). All user-scoped queries use user-independent keys (`["inventory"]`, `["decks"]`, `["notifications"]`, `["buy-list"]`, `["transactions"]`, `["user","profile"]`, …), so if User A signs out and User B signs in on the same device within the cache `gcTime` (default 5 min), B is shown A's inventory, decks, profile, and notifications immediately while background refetches run. Even for the same user, stale caches survive an "expired session" sign-out.
+
+**Recommendation:** clear the cache whenever authentication ends. `AuthProvider` renders inside `QueryClientProvider` (`app/_layout.tsx`), so the simplest correct fix is `queryClient.clear()` inside `handleSignedOut` (import the singleton from `lib/queryClient.ts`), or an `isAuthenticated` watcher in `RootNavigator` that clears on the `true → false` transition. `app/account.tsx` can then drop its own `clear()`.
+
+### 1.2 🟡 Browse screen double-pads the top safe area
+
+`app/(tabs)/index.tsx:56` renders the screen with `paddingTop: insets.top + 8`, but the tab navigator does **not** hide headers (`app/(tabs)/_layout.tsx` sets header styles and `headerRight`, so a header is shown). The header already consumes the status-bar inset; adding `insets.top` again leaves a ~50 px dead gap between the header and the search field. No other tab screen does this — it looks like a leftover from a header-less iteration. Compare `app/sign-in.tsx`, which correctly uses insets *because* it sets `headerShown: false`.
+
+**Recommendation:** change to `paddingTop: 8` (and drop the now-unused `useSafeAreaInsets` import).
+
+### 1.3 🟡 Optimistic quantity mutations fail silently
+
+Several optimistic mutations roll back on error without telling the user, so a tapped **+1** quietly reverts a moment later and looks like a glitch:
+
+- `app/(tabs)/inventory.tsx` — `setQuantity.onError` and `remove.onError` (rollback only)
+- `components/BuyListView.tsx` — `setQuantity.onError`, `remove.onError`
+- `components/AddToInventory.tsx`, `components/AddToBuyList.tsx` — `setQty.onError`
+- `app/notifications.tsx` — `markRead.onError`, `markAll.onError`
+
+Meanwhile `app/transactions.tsx` (`remove.onError`) and every deck mutation *do* show an `Alert`. This is both a UX bug and an internal inconsistency.
+
+**Recommendation:** standardize error surfacing (an `Alert` or a small toast helper) in every `onError` alongside the rollback. This falls out naturally from the shared optimistic-mutation helper proposed in §2.5.
+
+### 1.4 🟡 Notification badge fetches the user's entire notification history
+
+`lib/useNotifications.ts` auto-pages the full notifications list (a `useEffect` that keeps calling `fetchNextPage`) so the unread count is exact, and `NotificationBell` — mounted in **every tab header** via `HeaderActions` — uses that hook. For a user with a long history this is a chain of sequential 50-row requests on app start, purely to render a badge, repeated whenever the query refetches (pushes invalidate it too). The backend already exposes `GET /api/v1/notifications/unread-count` (present in `lib/api/schema.ts`, unused by the app).
+
+**Recommendation:** drive the bell badge from the `unread-count` endpoint (tiny payload, one request) and let the inbox screen paginate on scroll (`onEndReached`, as every other list already does) instead of eagerly draining all pages. Keep both under the `NOTIFICATIONS_KEY` family so push-arrival invalidation still refreshes the badge.
+
+### 1.5 🟡 Deck "missing cards" counts go stale after inventory changes
+
+`app/deck/[id].tsx` caches owned quantities under the ad-hoc key `["deck-owned", id, cardIds]`. Inventory mutations elsewhere invalidate the `["inventory"]` prefix only, so this query is never invalidated: add cards to inventory from a card page, navigate back to the deck, and the "need N" / missing-only view shows the old counts until `staleTime` lapses or the screen remounts.
+
+**Recommendation:** put the key under the inventory family — e.g. `["inventory", "quantities", "deck", id]` — so the existing `invalidateQueries({ queryKey: ["inventory"] })` calls cover it. (This is exactly why `AddToInventory` uses `["inventory", "quantities", cardId]`.)
+
+### 1.6 🟡 Unserialized absolute-quantity writes can lose rapid taps
+
+The write APIs set an **absolute** quantity, and stepper taps fire one mutation per tap with no queueing: tapping **+ +** quickly sends `quantity: 2` then `quantity: 3` as independent requests. If the network delivers/handles them out of order, the server ends at 2 while the UI shows 3 — and `setQuantity` in `app/(tabs)/inventory.tsx` (unlike its sibling `remove`) has no `onSettled` invalidation to self-heal, so the drift persists until the next refetch. The same pattern exists in `BuyListView`, `AddToInventory`, `AddToBuyList`, and the deck stepper (the deck one does invalidate on settle).
+
+The related read-modify-write race in `bulkAddToInventory` (`lib/api/inventory.ts`) is already documented in a comment; it has the same root cause.
+
+**Recommendation:** short-term, debounce the write (send the final absolute value ~300 ms after the last tap — one request instead of N, ordering problem gone) and invalidate on settle everywhere. Longer-term, ask the backend for an increment/delta endpoint so bulk-add and steppers stop needing read-then-write.
+
+### 1.7 🔵 CI depends on the live production API
+
+`.github/workflows/ci.yml` regenerates `lib/api/schema.ts` from `https://iwantmymtg.net/api/openapi.json` on every PR and fails on drift. This is a deliberate, documented tradeoff, but it makes CI non-hermetic: a backend deploy (or backend downtime) breaks every open PR regardless of its content, and the failure lands on whoever pushes next.
+
+**Recommendation:** keep the drift check but move it to a separate, non-required job (or a scheduled workflow that opens an issue/PR when the spec drifts), so `typecheck` remains the gate for merging app changes.
+
+### 1.8 🔵 Small correctness/UX nits
+
+- **`lib/format.ts` `formatPrice`** renders negatives as `$-3.00`; `app/portfolio.tsx` works around it with a local `formatSigned`. Use `Intl.NumberFormat("en-US", { style: "currency", currency: "USD" })` (adds thousands separators too) and move `formatSigned` into `lib/format.ts`.
+- **`lib/api/envelope.ts` `errMessage`** only reads the envelope's `error` field; the schema also declares `message?: string`, which often carries the human-readable text. Fall back `error → message → fallback`.
+- **`app/sign-in.tsx`** password input lacks `autoComplete="current-password"` / `textContentType="password"`, so iOS/Android password-manager autofill doesn't engage (email has `autoComplete="email"`).
+- **`lib/auth/AuthContext.tsx:53-54`** assigns `accessRef.current`/`refreshRef.current` during render. It works, but writing refs during render is discouraged (unsafe under concurrent rendering); move the mirroring into `applySession`/handlers (most already set the refs explicitly — the render-time assignment is nearly redundant).
+- **`components/NotificationBell.tsx`** hardcodes `"#fff"` for badge text instead of a theme token — the only hardcoded color outside `colors.ts`/`CardPriceHistory`'s deliberate chart palette. Use `colors.onAccent` or add an `onDanger` token.
+- **`lib/auth/tokenStore.ts`**: `expo-secure-store` warns (and on some Android versions fails) for values over 2 KB. JWTs are usually smaller, but if the backend ever grows claims this breaks persistence silently — worth a size guard or at least awareness.
+
+---
+
+## 2. Duplication (DRY)
+
+This is the largest maintainability drag. Each item below is a copy-paste cluster where a fix or style tweak currently has to be made in N places.
+
+### 2.1 🟡 `nextPage` pagination helper — 6 copies
+
+Identical logic in `app/(tabs)/index.tsx:24`, `app/(tabs)/inventory.tsx:61`, `app/set/[code].tsx:24`, `app/transactions.tsx:30`, `app/deck/add.tsx:25`, `lib/useNotifications.ts:8`. The generic version already exists in `index.tsx` (`nextPage<T>`).
+
+**Recommendation:** export `nextPage<T>` from `lib/api/catalog.ts` (next to `Page<T>`) or a new `lib/api/pagination.ts`, and delete the copies. Pure and trivially unit-testable.
+
+### 2.2 🟡 `InventoryListItem` vs `BuyListListItem` — ~95% identical
+
+`components/InventoryListItem.tsx` and `components/BuyListListItem.tsx` are the same component (thumb + name + set/number + foil badge + price + stepper with trash-at-1) with different item types and stepper sizes (32 px vs 32 px — even those match). Only the accessibility label wording differs.
+
+**Recommendation:** merge into one `CardQuantityRow` taking `{ cardName, cardId, setCode, cardNumber, imgSrc, isFoil, quantity, price, onIncrement, onDecrement, onRemove }`. Both DTOs already share those fields.
+
+### 2.3 🟡 `AddToInventory` vs `AddToBuyList` — ~85% identical, including a wholesale duplicated `FinishStepper`
+
+`components/AddToInventory.tsx` and `components/AddToBuyList.tsx` each define the *same* private `FinishStepper` component and near-identical `createStyles`. The outer components differ only in data source and optimistic-cache shape.
+
+**Recommendation:** extract `FinishStepper` (or a general `QuantityStepper`) into `components/`, and share the card-panel chrome (container/heading/loading/error states). The stepper is also re-implemented inline in `app/deck/[id].tsx`, `BulkAddBar.tsx`, and the merged row from §2.2 — one component with a `size` prop covers all five.
+
+### 2.4 🟡 Segmented controls and chips — 7 hand-rolled copies
+
+The two-button segment (`surface` background, active = `accent`) is re-implemented in `app/(tabs)/watchlist.tsx`, `app/deck/new.tsx`, `app/deck/add.tsx`, `app/account.tsx`, and `components/BulkAddBar.tsx`. The pill "chip" is re-implemented in `app/(tabs)/inventory.tsx`, `app/deck/new.tsx` (private `Chip`), and `components/CardPriceHistory.tsx` (another private `Chip`). All are visually the same control with slightly drifted paddings/font sizes.
+
+**Recommendation:** add `components/SegmentedControl.tsx` and `components/Chip.tsx` (label, active, onPress, optional icon). This removes ~200 lines and makes future design changes single-point.
+
+### 2.5 🟡 Optimistic-mutation boilerplate — 8 copies
+
+The `onMutate` cancel → snapshot → `setQueryData` → return `{ previous }`, `onError` rollback pattern is copy-pasted in `inventory.tsx` (×2), `transactions.tsx`, `notifications.tsx` (×2), `BuyListView.tsx` (×2), `AddToInventory.tsx`, `AddToBuyList.tsx`, and `deck/[id].tsx`.
+
+**Recommendation:** a small generic helper, e.g.:
+
+```ts
+// lib/useOptimisticMutation.ts
+function useOptimisticMutation<TData, TVars>(opts: {
+  queryKey: QueryKey;
+  mutationFn: (vars: TVars) => Promise<unknown>;
+  apply: (old: TData | undefined, vars: TVars) => TData | undefined;
+  errorTitle: string;           // fixes finding 1.3 uniformly
+  invalidateOnSettled?: QueryKey[];
+})
+```
+
+This also gives one place to enforce the settle-time invalidation and error alert conventions (findings 1.3 and 1.6).
+
+### 2.6 🔵 `mapItems` InfiniteData helper — 2 copies
+
+`app/(tabs)/inventory.tsx:53` and `app/notifications.tsx:33` define the same "map every page's items" helper. Move next to the pagination helper from §2.1.
+
+### 2.7 🔵 Route-param normalization — 3 different idioms
+
+`Array.isArray(v) ? v[0] : v` inline (`app/set/[code].tsx`, `app/card/[setCode]/[number].tsx`, `app/deck/add.tsx`), a local `str()` (`app/deck/new.tsx`), and a local `one()` (`app/transaction/new.tsx`). Same job, three names.
+
+**Recommendation:** one `firstParam(v: string | string[] | undefined): string` in `lib/` (or use expo-router's typed params) and use it everywhere.
+
+### 2.8 🔵 Misc small duplications
+
+- Capitalize-first-letter for deck formats appears in `app/(tabs)/decks.tsx`, `app/deck/[id].tsx`, and `app/deck/new.tsx` — add `formatDeckFormat()` to `lib/format.ts`.
+- The `useMemo(() => query.data?.pages.flatMap((p) => p.items) ?? [], [query.data])` flatten appears in 6 screens — it can live in a tiny `usePagedItems(query)` hook, or fold into a broader `usePagedList` that also bundles `nextPage`/footer-spinner/refresh-control conventions (see how similar `SetResults` and `CardResults` in `app/(tabs)/index.tsx` already are).
+- `const styles = useMemo(() => createStyles(colors), [colors])` is repeated in ~25 files — a one-line `useThemedStyles(createStyles)` hook in `lib/theme/` removes the boilerplate and the awkward `styles`-as-prop drilling in `index.tsx`, `deck/new.tsx`, `card/[setCode]/[number].tsx`, and `CardPriceHistory.tsx`.
+
+---
+
+## 3. Architecture & consistency
+
+### 3.1 🟡 Query keys are only half-centralized
+
+`decks.ts`, `buyList.ts`, `notifications.ts`, and `priceAlerts.ts` export key constants (`DECKS_KEY`, `deckKey`, …) — good. But the other domains use scattered string literals that must stay in sync by convention:
+
+- `["inventory"]` — declared as a local `KEY` in `inventory.tsx`, and as raw literals in `app/set/[code].tsx`, `app/transaction/new.tsx`, `app/transactions.tsx`, and (as a prefix contract) `AddToInventory.tsx`'s `["inventory", "quantities", cardId]`
+- `["transactions"]` — local `KEY` in `transactions.tsx`, literal in `transaction/new.tsx`
+- `["portfolio", "summary"]` in `portfolio.tsx` vs `["portfolio"]` prefix invalidations in two other files
+- `["sets"]`, `["cards","search",q]`, `["card",setCode,number]`, `["set",code,"cards"]`, `["user","profile"]`, `["deck-owned",…]` — inline only
+
+A typo in any literal silently breaks invalidation (exactly the class of bug in finding 1.5).
+
+**Recommendation:** follow the pattern already established: every `lib/api/*.ts` module exports its key(s)/key factories, screens import them, and prefix relationships (e.g. quantities under `["inventory"]`) are visible in one file per domain.
+
+### 3.2 🟡 Layering: data access leaks into presentational components
+
+The codebase has an implicit ports-and-adapters shape — `lib/api/*` are clean adapters (transport + envelope unwrapping only), screens compose UI — but the middle layer is inconsistent. Some data flows live at screen level (`inventory.tsx`, `transactions.tsx`), while `AddToInventory`, `AddToBuyList`, `CardPriceAlert`, `BuyListView`, `PriceAlertsView`, and `NotificationBell` each embed their own queries, mutations, and optimistic-cache surgery inside presentation components. That makes the domain behavior (how quantities upsert, how alerts toggle) untestable without rendering UI, and it's why the same optimistic logic is duplicated (§2.5).
+
+**Recommendation:** introduce a thin hooks layer — `lib/hooks/useInventoryQuantities(cardId)`, `useBuyList()`, `usePriceAlerts()`, etc. — that owns query keys, fetching, and optimistic mutations, and keep components purely presentational (`useNotifications.ts` already models this). Combined with §2.5 and §3.1 this concentrates all cache semantics in `lib/`, which is the hexagonal boundary the codebase is already reaching for.
+
+### 3.3 🔵 "New" screens doing double duty as edit screens
+
+`app/transaction/new.tsx` and `app/deck/new.tsx` both handle editing, with the entity serialized through route params (`id`, `name`, `type`, `quantity`, `price`, `isFoil`, `date`, `notes`, …). This works but is fragile: params are stringly-typed (`one(params.isFoil) === "true"`), can go stale relative to the server, and the route name lies about its purpose.
+
+**Recommendation:** pass only the `id` and read the entity from the query cache (`queryClient.getQueryData`) with a fetch fallback. Optionally rename routes to `transaction/edit/[id]` / keep `new` for creation — clearer navigation semantics and less param plumbing.
+
+### 3.4 🔵 Inconsistent empty/error affordances
+
+- Most screens use `ErrorState` with Retry; `AddToInventory`/`AddToBuyList`/`CardPriceAlert` and the account profile card show plain error text with no retry; `CardPriceHistory` hand-rolls its own retry row. A compact `inline` variant of `ErrorState` would unify these.
+- Pull-to-refresh exists on most lists but not the Browse search results footer state or `deck/add` results. Minor, but users notice.
+
+### 3.5 🔵 Dead code
+
+`components/PlaceholderScreen.tsx` is referenced nowhere (its "temporary v1 shell" purpose is complete). Delete it.
+
+### 3.6 🔵 Backend spec smells visible from the client
+
+Not fixable in this repo, but worth backend tickets since they force client workarounds:
+
+- `page`/`limit` on `/notifications` and `days` on price-history are typed `string` in the OpenAPI spec, forcing `String(page)` casts (`lib/api/notifications.ts`, `catalog.ts`) while `/sets`/`/cards` take numbers.
+- Absolute-quantity-only writes force the racy read-modify-write in `bulkAddToInventory` (finding 1.6).
+- `DeckImportApiResultDto.errors` is specced as `Record<string, never>[]` (an empty-object type) though it carries `{ row, name?, error }` — the deck import screen can only count errors, not display them (the buy-list import DTO gets this right with `string[]`).
+
+---
+
+## 4. Testing & tooling
+
+### 4.1 🔴 No tests and no test infrastructure
+
+There is no test runner, no test files, and no CI test step. Significant, subtle, *pure* logic is untested:
+
+- `lib/auth/jwt.ts` — hand-rolled base64url decode + `exp` extraction (security-adjacent; an off-by-one here breaks proactive refresh silently)
+- `lib/auth/AuthContext.tsx` — single-flight refresh, mid-flight session-change guards (the trickiest code in the app)
+- `lib/images.ts` — Scryfall URL normalization (has documented edge cases)
+- `lib/api/inventory.ts` `bulkAddToInventory` — quantity math
+- `components/CardPriceHistory.tsx` `buildSeries` — min/max/current/gap handling (move it to `lib/` so it's importable without rendering)
+- `.github/scripts/next-version.sh` — release versioning (a regression here mis-versions a store release)
+
+**Recommendation:** add `jest-expo` + `@testing-library/react-native`, a `npm test` script, and a CI step. Start with the pure modules above (no rendering needed, fast wins), then cover the optimistic-mutation helper from §2.5 once extracted.
+
+### 4.2 🟡 No linter or formatter
+
+Only `tsc --noEmit` runs. ESLint with `eslint-config-expo` + `eslint-plugin-react-hooks` would have flagged real issues found in this review — e.g. the whole `query` object in effect dependency arrays (`lib/useNotifications.ts`, `app/(tabs)/inventory.tsx`), which makes the auto-page effect re-run on every render (currently a guarded no-op, but a footgun). Prettier (or ESLint stylistic rules) would keep the drifting paddings/orderings in check.
+
+**Recommendation:** `npx expo lint` scaffolds this; add `npm run lint` to CI next to typecheck.
+
+---
+
+## 5. Suggested order of attack
+
+| # | Item | Findings | Effort |
+|---|------|----------|--------|
+| 1 | Clear query cache on sign-out | 1.1 | XS |
+| 2 | Fix Browse double inset; silent-rollback alerts; settle-time invalidations | 1.2, 1.3, 1.6 | S |
+| 3 | Bell badge → `unread-count`; inbox paginates on scroll | 1.4 | S |
+| 4 | Re-key deck-owned under `["inventory", …]`; centralize query keys | 1.5, 3.1 | S |
+| 5 | Add ESLint + jest-expo; test `jwt`, `images`, `format`, `nextPage`, `buildSeries` | 4.1, 4.2 | M |
+| 6 | Extract shared UI: stepper, card row, chip, segmented control, `useThemedStyles` | 2.2–2.4, 2.8 | M |
+| 7 | Extract `useOptimisticMutation` + `lib/hooks/*` layer | 2.5, 3.2 | M |
+| 8 | CI: decouple spec-drift check from PR gating | 1.7 | XS |
+| 9 | Edit screens read from cache by id instead of param-packing | 3.3 | M |
+
+Items 1–4 are behavior fixes shippable independently; 5 locks in a safety net before the refactors in 6–7 & 9.

--- a/docs/codebase-analyses-2026-07/scry.md
+++ b/docs/codebase-analyses-2026-07/scry.md
@@ -1,0 +1,279 @@
+# Scry Codebase Analysis — Findings & Recommendations
+
+**Date:** 2026-07-07
+**Scope:** full `src/`, `tests/`, CI workflow, Dockerfile, scripts.
+**Verification:** `cargo check --all-targets` (clean, 2 warnings), `cargo clippy` (~60 warnings), all 118 unit tests pass. SQL claims below were verified against the real PostgreSQL parser (libpg_query via `pglast`), not guessed.
+
+Findings are grouped by severity. Each has a file/line reference and a concrete recommendation.
+
+---
+
+## 1. Correctness bugs (fix first)
+
+### 1.1 `post-ingest-prune` as a standalone command silently never prunes foreign unpriced cards
+
+`CardService` records foreign-card candidates in an **in-memory** `Arc<Mutex<Vec<String>>>` during ingest (`src/card/service.rs:29`, populated at `src/card/service.rs:151-160`), and `prune_foreign_unpriced` (`src/card/service.rs:305`) reads only that vector. When `cargo run -- post-ingest-prune` runs as its own process (as documented in CLAUDE.md and the interactive menu), the vector is empty, so the prune is a silent no-op — it only works when run inside the same process as a full ingest.
+
+Root cause: `Card.language` is `#[sqlx(skip)]` (`src/card/domain/card.rs:41`), so foreignness cannot be re-derived from the DB.
+
+**Recommendation:** persist the signal — either a `language` column or an `is_foreign` boolean on `card` — and have `prune_foreign_unpriced` query `card LEFT JOIN price` directly. That makes the prune idempotent, process-independent, and removes the shared-mutable-state field from the service entirely.
+
+### 1.2 `DELETE FROM … CASCADE` does nothing — `CASCADE` is parsed as a table alias
+
+`src/card/repository.rs:307-312` (`delete_table`: `DELETE FROM {} CASCADE`) and `src/set/repository.rs:276-279` (`DELETE FROM set CASCADE`). PostgreSQL's `DELETE` has no `CASCADE` clause; the parser accepts these statements only because `CASCADE` becomes the table **alias** (verified with libpg_query: `alias: {aliasname: 'cascade'}`). Nothing cascades.
+
+Today it happens to work because `reset_data` (`src/cli/controller.rs:723`) deletes prices → cards → sets in dependency order. But:
+
+### 1.3 `ingest -r` (reset) will hit FK violations once dependent tables have rows
+
+The delete paths don't cover all FK dependents of `card`:
+
+- `CardRepository::delete_all` (`src/card/repository.rs:273`) deletes `legality` then `card` — but `price_history`, `inventory`, and `granular_price_history` all reference `card(id)`, and per the schema mirror (`tests/fixtures/schema.sql`) `price_history` and `inventory` have **no** `ON DELETE CASCADE`. In production, `price_history` always has rows, so `DELETE FROM card` should fail.
+- `PriceRepository::delete_all` (`src/price/repository.rs:129`) deletes only `price`, not `price_history` / `granular_price`.
+- `delete_cards_batch` (`src/card/repository.rs:280`) deletes `legality`, `price`, `inventory` — but not `price_history` or `granular_price_history`, so cleanup/prune of a card that has history rows fails.
+- `delete_set_batch` (`src/set/repository.rs:281`) has the same gap.
+
+**Recommendation:** centralize "delete cards by id" in one place that handles the *complete* dependent-table list (or better: get `ON DELETE CASCADE` added in the web repo's migrations and delete only from `card`). For `reset`, `TRUNCATE card, legality, price, price_history, … CASCADE` in one statement is simpler, faster, and atomic. Add an integration test that deletes a card which has `price_history` rows — the current tests never exercise that path.
+
+### 1.4 Streaming parser can spin forever on a persistent network failure
+
+`src/utils/json_stream_parser.rs:67-98`: when `fill_buf()` returns `Err`, the code logs once, breaks out of the fill loop, and `next_event()` returns `NeedMoreInput` again — which `handle_parse_event` treats as `Ok(true)` (line 113), so the outer loop calls `get_next_event` again, `fill_buf` fails again, and so on. `error_count` only increments for *parser* errors, never for feeder/IO errors. A connection dropped mid-download (a 200 MB file over ~minutes — it will happen) becomes a silent busy-loop instead of an error.
+
+Also in the same function: the fill loop on success always performs 3 `fill_buf` calls regardless of whether data arrived (`fill_attempts >= 3` with `continue` on every `Ok`), which is wasted work and suggests the retry logic doesn't do what was intended.
+
+**Recommendation:** propagate feeder IO errors as hard failures (return `Err` from `get_next_event`), and fill until `next_event()` stops returning `NeedMoreInput` or EOF rather than a fixed 3 attempts. Separately, reconsider "tolerate 10 parser errors and continue" (`json_stream_parser.rs:135-147`): after a real tokenizer error actson's state is not trustworthy; the safer behavior is to abort on the first parse error.
+
+### 1.5 Interactive prompts `.unwrap()` — panics in non-TTY environments
+
+`src/cli/controller.rs:513-517`, `540-546`, `724-728`: `Confirm::new()…interact().unwrap()`. In cron/Docker (how this tool actually runs in production per CLAUDE.md), stdin is not a TTY and `interact()` returns `Err` → panic with a backtrace instead of a clean message. `truncate-history`, `backfill --truncate`, and `ingest -r` are all affected.
+
+**Recommendation:** handle the `Err` as "not confirmed" with a clear log line ("non-interactive session: refusing destructive operation without --yes"), and/or add a `--yes` flag for scripted use. Elsewhere the same file already handles dialoguer errors gracefully (`interactive_mode` line 138-143) — make it consistent.
+
+### 1.6 Split-card mana-cost merge is batch-local
+
+`merge_and_filter_cards` (`src/card/service.rs:444`) can only merge a split card's faces if both are in the same batch. During streaming ingest, batches flush every 500 cards mid-set (`src/card/event_processor.rs:146-148`), so a face pair straddling a batch boundary is silently not merged: side "b" is dropped by `should_filter`, and side "a" keeps a partial mana cost. Low frequency, invisible when it happens.
+
+**Recommendation:** flush only on set boundaries (the processor already flushes at end of each set's `cards` array), or buffer side-"b" faces per set in the processor and attach them to the batch that carries the "a" face. A unit test with a face pair split across two batches would lock the behavior in.
+
+### 1.7 Price rows can be written with a 1970-01-01 date
+
+`PriceAccumulator::into_price` (`src/price/domain/price_accumulator.rs:59-64`) falls back to `1970-01-01` when the provider date is missing or unparseable. Epoch-dated rows would poison `price` (breaking `clean_up_prices`, which keeps only the max date — an epoch row is "old" so it gets deleted, but only *after* being written and counted) and `price_history` retention (kept forever if the 1st of the month).
+
+**Recommendation:** return an error (or skip with a `warn!`) when no valid date was accumulated. Also note the accumulator sums `f64` and converts to `Decimal` at the end — fine for averaging retail prices, but if exactness ever matters, accumulate `Decimal` directly.
+
+### 1.8 Divergent skip-state machines: card processor can wedge in skip mode
+
+`SealedProductEventProcessor` clears `is_skipping_value` when the skipped value turns out to be a scalar (`src/sealed_product/event_processor.rs:39-45`); `CardEventProcessor` does not (`src/card/event_processor.rs:31-45`, `_ => {}`). If the card processor ever starts skipping at a field whose value is a scalar (the `json_depth >= 3 && current_set_code.is_none()` branch at `event_processor.rs:226-236` can do this), `is_skipping_value` stays `true` forever and the rest of the file is silently ignored. It happens not to trigger with today's MTGJSON shape — it's a landmine, and the two implementations having diverged is exactly how it was planted.
+
+**Recommendation:** fix the card processor's scalar case to match the sealed one, then extract the shared skip logic (see §4.1).
+
+### 1.9 Unknown rarity silently mapped to `common`
+
+`src/card/mapper.rs:42-44`: `rarity_str.parse().unwrap_or(CardRarity::Common)`. When MTGJSON adds a rarity (it has before: `bonus`, `special`), every affected card is silently misclassified.
+
+**Recommendation:** log a `warn!` with the unknown value (and ideally count them), so a feed change is visible instead of silent data corruption.
+
+### 1.10 One bad card aborts a whole set in the `-k` path — but not in the streaming path
+
+`CardMapper::map_to_cards` (`src/card/mapper.rs:23-31`) collects `Result`s, so a single card missing `scryfallId` fails the entire `ingest -k <set>` call. The streaming path (`event_processor.rs:150-155`) warns and continues per card. Two different error policies for the same operation.
+
+**Recommendation:** make the set-cards path warn-and-skip per card like the streaming path.
+
+---
+
+## 2. Bugs of the "wrong number / wrong claim" kind
+
+### 2.1 The documented concurrency does not exist
+
+CLAUDE.md and the code both claim bounded-concurrency batch saving ("`Semaphore` for bounded concurrency (6 concurrent tasks)"). In reality `save_card_batch` (`src/card/service.rs:113-173`) spawns a task and then **immediately awaits it** (`handle.await`, line 167) inside the closure that `parse_stream` awaits before continuing. Batches are therefore processed strictly sequentially; the `Semaphore`, `tokio::spawn`, and the `Arc<Mutex<…>>` set-existence cache are pure overhead. `cleanup_cards` (`service.rs:276-280`) likewise acquires a permit for inline sequential work.
+
+**Recommendation:** decide which you want:
+- *Sequential (simplest):* delete the semaphore/spawn/mutex machinery — behavior is unchanged and the code shrinks considerably; or
+- *Actually concurrent:* have the closure push `JoinHandle`s into a `FuturesUnordered`/`JoinSet` bounded by the semaphore and await them after `parse_stream` completes (plus error collection).
+
+Either way, update CLAUDE.md's "Key Design Patterns" to match reality.
+
+### 2.2 Granular prices are parsed and then always thrown away in the MTGJSON paths
+
+`rustc` itself flags it: `field granular is never read` (`src/price/domain/granular_price.rs:71`). Both `PriceEventProcessor` and `HistoricalPriceEventProcessor` painstakingly build `GranularPrice` rows for every card (`record_granular`), and `PriceService::save_prices` / `save_price_history_only` (`src/price/service.rs:272-329`) drop them. Since CK-direct is now the sole granular writer (ROADMAP 10.10 per comments), this is dead work on every daily ingest of a ~multi-hundred-MB file, plus dead code to maintain.
+
+**Recommendation:** remove `CardPrices.granular`, `record_granular`, and `GRANULAR_PROVIDERS` usage from both MTGJSON processors (keep the CK path). If the historical granular backfill is still wanted someday, that's what git history is for.
+
+### 2.3 Copy-paste log messages and misleading counts
+
+- `CardService::delete_all` logs "Deleting all **prices**." (`src/card/service.rs:254`).
+- `SetRepository`/`CardRepository` upserts use conditional `DO UPDATE … WHERE … IS DISTINCT FROM …`, so `rows_affected` excludes unchanged rows — but callers log it as "cards saved"/"sets ingested" (`src/set/service.rs:49-50`, controller totals). The numbers under-report and have confused more than one ETL postmortem in other projects. Rename the logs ("rows changed") or count inputs.
+- `main.rs:74`: `eprint!` (no newline) for the fatal error path.
+
+### 2.4 Portfolio queries disagree about unpriced cards, and services disagree about "today"
+
+- `calculate_portfolio_summaries` uses `JOIN price` (`src/portfolio/repository.rs:119`) — a user's cards with no `price` row are excluded from `total_value` **and** from `total_cards`/`total_quantity`. `calculate_card_performance` uses `LEFT JOIN price` (`repository.rs:188`) and treats missing prices as 0. Same concept, two semantics; summary totals and per-card rows won't reconcile.
+- "Today" is computed three ways: `chrono::Local::now()` (`src/portfolio/service.rs:29`), `chrono::Utc::now()` (`src/price/service.rs:161`, published-deck source), and `America/New_York` (`src/price/domain/price.rs:51`). Depending on container TZ, snapshots, CK rows, and MTGJSON rows can carry different dates around midnight.
+
+**Recommendation:** make `LEFT JOIN` + `COALESCE(…, 0)` the single semantics, and add one `fn today() -> NaiveDate` helper (pick UTC or New_York deliberately) used everywhere.
+
+### 2.5 Integration-test schema fixture has drifted from the code
+
+`tests/fixtures/schema.sql` defines `portfolio_value_history(id, total_value, date)` — but `save_snapshots` (`src/portfolio/repository.rs:57-73`) inserts `user_id, total_value, total_cost, total_cards, date` with `ON CONFLICT (user_id, date)`. Any integration test touching that table would fail immediately; none exists, which is how the drift went unnoticed. `transaction`, `portfolio_summary`, `portfolio_card_performance`, `published_deck`, and `published_deck_card` are missing from the fixture entirely, so the portfolio and published-deck repositories have **zero** integration coverage — and they contain the most intricate SQL in the codebase.
+
+**Recommendation:** sync the fixture with the web repo's migrations (ideally generate it from them) and add repository-level integration tests for portfolio and published-deck, following the existing `set_repository_test.rs` pattern.
+
+### 2.6 `config.rs` oddities
+
+`src/config.rs:18-33`: `DATABASE_URL` is checked twice (lines 19-21 make the `env::var("DATABASE_URL").or_else(…)` at line 22 unreachable for the Ok case); and when the URL is assembled from `DB_*` parts, the password is not percent-encoded — a password containing `@`, `/`, or `#` produces a broken URL. Drop the duplicate lookup and percent-encode user/password.
+
+---
+
+## 3. Architecture / hexagonal consistency
+
+The README/CLAUDE.md describe a ports-and-adapters-ish layout (domain / mapper / repository / service), and the file layout follows it, but the dependency rules that make that architecture pay off are not enforced:
+
+### 3.1 No ports (traits) — nothing is mockable
+
+`CliController` holds concrete services; services hold concrete repositories, a concrete `Arc<ConnectionPool>`, and a concrete `Arc<HttpClient>`. The single trait in the codebase, `DecklistSource` (`src/published_deck/source.rs:13`), is also the only place a service can be tested with a fake — and not coincidentally `PublishedDeckService` has the best service-level unit test. Everywhere else, service logic (pipeline ordering, prune policies, batch orchestration) is untestable without a live Postgres + network.
+
+**Recommendation:** you don't need traits for everything. Two ports buy most of the value:
+1. a `CardDataSource`-style trait over `HttpClient` (streams + JSON fetches), and
+2. per-module repository traits (or `#[cfg(test)]`-mockable structs).
+
+Then service tests can drive `ingest_all` with a canned byte stream and an in-memory repo, which is exactly the coverage this codebase is missing (the current unit tests only cover pure functions).
+
+### 3.2 Cross-module reach-through
+
+- `CardService` takes a `SealedProductRepository` parameter and knows sealed batch sizes (`src/card/service.rs:182-197`) — the card module orchestrating another module's persistence.
+- `CardService` holds `Arc<PriceService>` and performs price mutations inside `prune_duplicate_foils` (`service.rs:367-399`).
+- `SealedProductService` constructs its own `SetRepository` (`src/sealed_product/service.rs:26`) rather than asking the set module's service.
+
+**Recommendation:** move cross-domain orchestration up. The single-pass card+sealed ingest is inherently cross-module — put its orchestration in `ingest.rs` (which already owns the tee processor) or an application-layer service, with `CardService`/`SealedProductService` exposing narrow "save batch" operations. `prune_duplicate_foils` is really a *pricing-aware dedup* use case; it belongs in an application service that uses both modules' public APIs.
+
+### 3.3 The controller is doing three jobs
+
+`src/cli/controller.rs` (822 lines) mixes: command dispatch, interactive menu UI, and business orchestration/policy — including the magic number `min_price_pct = 0.36` (`controller.rs:751`), the CK-buylist "best-effort but fail the exit code" policy (`controller.rs:656-698`), and the full pipeline definition (`run_full_ingest_pipeline`). The interactive submenus duplicate knowledge of what the pipeline does in their label strings.
+
+**Recommendation:** extract an `IngestPipeline` (application service) that owns ordering, the prune threshold constant, and the first-error-wins aggregation; leave the controller with dispatch + prompts + display. This also lets the pipeline be tested.
+
+### 3.4 Leaky `ConnectionPool` abstraction
+
+`src/database.rs` mixes safe `QueryBuilder` execution with raw-string entry points: `count(&str)`, `execute_raw(&str)`, and `row_exists` which `format!`s identifiers into SQL (`database.rs:59-63`). They're all called with constants today, so there's no injection *bug*, but the API invites one, and repositories inconsistently choose between `db.count(format!(…))` and query-builder equivalents.
+
+**Recommendation:** keep `execute_raw` for the schema fixture only (gate it `#[cfg(test)]`-adjacent or document it), give `count` a table-enum or move per-table counts fully into repositories, and replace `row_exists`'s formatted identifiers with dedicated methods (`set_exists` is its only caller).
+
+### 3.5 `main.rs` re-declares the whole module tree instead of using the library
+
+`src/main.rs:10-21` declares `mod card; mod cli; …` in parallel with `src/lib.rs`. Consequences: the entire crate compiles **twice** (lib + bin), every unit test compiles and runs twice (118 tests × 2 in the test output), `cli` is unreachable from integration tests, and lib vs bin can silently diverge.
+
+**Recommendation:** make `main.rs` a thin shim (`use scry::…`), move `cli` into `lib.rs`, delete the duplicate `mod` block. This roughly halves build and unit-test time by itself.
+
+---
+
+## 4. DRY violations
+
+### 4.1 Four hand-rolled JSON state machines, two of them near-identical twins
+
+- `PriceEventProcessor` vs `HistoricalPriceEventProcessor`: ~90 % identical (event dispatch, `at_price_value`, `record_granular`, path tracking). The only real difference is one accumulator vs a per-date map. Extract a shared path-tracking core, or parameterize one processor over "single date vs multi date".
+- `CardEventProcessor` vs `SealedProductEventProcessor`: both re-implement "rebuild the current object as a JSON string, then `serde_json::from_str` it" — including duplicated, subtly divergent (see §1.8) escaping and comma logic across ~10 handler methods each.
+
+**Recommendation:** extract one `SubtreeCollector` utility that, given "start collecting at this depth", accumulates events into a `serde_json::Value` (build the `Value` directly — `Map`/`Vec` pushes — instead of string concatenation + reparse). That removes the manual string escaping, the float re-serialization (`current_float()?.to_string()` can change number representation), and both copies of the comma logic. All four processors then become small routing shells, and the `CardSealedEventProcessor` tee stops depending on two independent depth counters staying in sync.
+
+### 4.2 Duplicated retention SQL, ×3
+
+The weekly/monthly tiered-retention CTE is copy-pasted for `price_history` (`src/price/repository.rs:214-242`), `set_price_history` (`src/set/repository.rs:229-256`), and `portfolio_value_history` (`src/portfolio/repository.rs:76-103`) — same intervals, same DOW/day-of-month rules. One helper taking a table name (from a fixed allow-list) removes six near-identical query blocks and guarantees the tiers can't drift apart.
+
+### 4.3 Duplicated set-price upsert SQL
+
+`SetRepository::update_prices` and `save_set_price_history` (`src/set/repository.rs:143-205`) differ only in table name and one conflict-target/date column. Same treatment.
+
+### 4.4 Assorted repetition
+
+- The `ON CONFLICT … WHERE col IS DISTINCT FROM EXCLUDED.col` change-detection lists in `save_cards` / `save_sets` / `save` repeat every column three times (insert list, SET list, WHERE list). A small macro or codegen helper would keep the three lists in lockstep; today adding a column requires touching three places per table and nothing fails if you miss one (the column silently stops updating).
+- `calculate_set_prices` builds its `IN` list with a manual loop (`src/set/repository.rs:132-137`) while every sibling uses `= ANY(push_bind(vec))` — use `ANY` for consistency.
+- `SetService::save_set_prices` (`src/set/service.rs:177-193`) chunks the same vec twice in two loops (current + history) and ignores the history save's count; one loop, both writes.
+- Count return types alternate between `i64` and `u64` across repositories (`CardRepository::count -> u64`, `SetRepository::count -> i64`). Pick one (`i64`, since that's what Postgres returns).
+
+---
+
+## 5. Performance
+
+- **§2.1** (no actual concurrency) and **§2.2** (dead granular parsing) are the two biggest wins.
+- `prune_duplicate_foils` (`src/card/service.rs:336-409`) does per-card `save_cards(&[one])` and `delete_cards_batch(&[one id])` inside a loop over sets — N round trips where 2–3 batched statements per set would do. Also the `dup_foil_sets` list is a hard-coded policy living inside a service method; lift it to a documented constant like `BONUS_MAIN_SET_OVERRIDES`.
+- `clean_up_prices` (`src/price/service.rs:217-235`) fetches all distinct dates then issues one `DELETE` per stale date. `DELETE FROM price WHERE date < (SELECT MAX(date) FROM price)` is one statement.
+- `FbettegaSource::fetch_recent` (`src/published_deck/source.rs:182-213`) is fully sequential: days × feeds listing calls, then one GET per file. `futures::stream::iter(...).buffer_unordered(8)` over the file fetches would cut wall time substantially without hammering the API.
+- `save_deck` (`src/published_deck/repository.rs:47-96`) does upsert + delete children + insert children as three non-transactional statements. Besides the atomicity issue (a crash strands a deck with no cards), it's 3 round trips per deck × hundreds of decks. Wrap in a transaction; optionally batch.
+
+---
+
+## 6. Reliability / transactionality
+
+No repository operation uses a database transaction. The places where that is a correctness issue rather than a style point:
+
+| Operation | Statements | Failure mode |
+|---|---|---|
+| `save_legalities` (`card/repository.rs:206`) | DELETE then INSERT | crash between → card loses all legalities |
+| `delete_cards_batch` (`card/repository.rs:280`) | 4 DELETEs per chunk | partial delete leaves orphan-check to FKs |
+| `published_deck::save_deck` | upsert + DELETE + INSERT | deck row with no cards |
+| `reset_data` (controller) | 3 service calls | partially reset DB |
+
+`delete_set_batch` gets it right with a single CTE — use that as the pattern, or add a `ConnectionPool::transaction` helper. Since these all re-run idempotently on the next ingest, this is medium severity, but `save_legalities` runs on every card batch of every ingest.
+
+---
+
+## 7. CLI / UX inconsistencies
+
+- `ingest -c -k xyz`: `-k` is silently ignored (`src/cli/controller.rs:419` gates set-cards on `!cards`). Either make clap declare `conflicts_with` (as `buylist` already does) or log why it's skipped.
+- `IngestCardsSealed` (`src/cli/commands.rs:48`) is documented as a "perf prototype" to compare against the two-pass flow — but the single-pass path is now the default inside `ingest`. The standalone command is vestigial; remove it or re-document it as a supported alias.
+- The retention doc comment on `Retention {}` (`commands.rs:94-96`) mentions only `price_history`; the command actually also processes `set_price_history` and `portfolio_value_history` (and CLAUDE.md adds `granular_price_history`, which the code does **not** touch — see §8).
+- Destructive-flow inconsistency: `reset_data` returns `Ok` when the user declines, so the rest of the pipeline continues after "Skipped data reset" — reasonable, but `handle_backfill` aborts entirely when truncate is declined. Pick one convention.
+
+---
+
+## 8. Documentation drift (CLAUDE.md / comments)
+
+CLAUDE.md is the on-ramp for every future contributor (and for AI tooling); it's currently wrong about:
+
+- **Modules:** `portfolio/`, `published_deck/`, `sealed_product/` are absent from the architecture tree; `price/domain` file list is missing `granular_price.rs`; `cardkingdom.rs`, `write_timings.rs`, `historical_event_processor.rs` unlisted.
+- **Data source:** `http_client.rs` is described as a "Scryfall API client" — every URL in it is MTGJSON or Card Kingdom (`src/utils/http_client.rs:15-20`). The interactive help text (`controller.rs:291-293`) repeats the "from Scryfall" claim.
+- **Concurrency:** "Semaphore for bounded concurrency (6 concurrent tasks)" — see §2.1.
+- **Retention:** CLAUDE.md says the `retention` command covers `granular_price_history`; no code touches that table's retention. Either implement it (it will grow unboundedly from CK-direct daily writes!) or fix the doc. **This one may be an actual missing feature, not just a doc bug — worth checking what prunes `granular_price_history` in production.**
+- **Commands list:** `ingest -b`, `ingest-decks`, `backfill`, `backfill-set-price-history`, `portfolio-summary` are missing from the Common Commands block.
+
+---
+
+## 9. Tooling, CI, Docker
+
+- **CI has no `clippy` or `rustfmt` gate.** Clippy currently reports ~60 warnings (needless borrows, `clone()` on `Copy` types, missing `Default` impls for `HttpClient`/`FbettegaSource`, `or_insert_with(default)`, a large enum-variant size difference on `IngestRecord`). Add `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` jobs, fix the existing warnings once.
+- **Dockerfile:** `development` stage copies `Cargo.toml` but not `Cargo.lock` (non-reproducible dev builds — the build stage gets it right); `production` runs as **root** on unpinned `alpine:latest` — add a `USER` and pin the base (e.g. `alpine:3.20`).
+- Neither Docker stage caches dependencies separately from `src` — every source change recompiles all dependencies. The usual "copy manifests, build a dummy `main.rs`, then copy `src`" (or `cargo-chef`) layering would cut CI image builds dramatically.
+
+---
+
+## 10. Minor nits (roll into a cleanup PR)
+
+| Location | Issue |
+|---|---|
+| `src/set/repository.rs:5` | `use anyhow::{Ok, Result}` shadows `std::result::Result::Ok` — a well-known source of confusing type errors; import only `Result`. |
+| `src/card/service.rs:64` | `fetch_set_cards(&set_code)` passes `&&str`. |
+| `src/card/service.rs:75` | `let _ = …await?;` — the `let _ =` is redundant with `?`. |
+| `src/price/service.rs:224` | `max_date.clone()` on a `Copy` type; `.map(\|d\| *d)` at `service.rs:240` is `.copied()`. |
+| `src/price/domain/price.rs:10` | `Price.id` is always `None` and never read — dead field. |
+| `src/health_check/service.rs:55` | `FROM set` unquoted; every other query quotes `"set"`. (Parses fine — `set` is non-reserved — but be consistent.) |
+| `src/utils/json_stream_parser.rs:49` | `io::Error::new(ErrorKind::Other, e)` → `io::Error::other(e)`. |
+| `src/published_deck/source.rs:139` | `&d[..d.len().min(10)]` byte-slices a string — panics on a multi-byte char at the boundary; use `d.get(..10)` or `chars().take(10)`. |
+| `src/ingest.rs:20` | `IngestRecord::Card(Card)` is much larger than `Sealed` (clippy: large variant); `Box<Card>` if it matters. |
+| `main.rs:33-35, 77-79` | Banner logged before `dotenvy`/config; "Scry - MTG Data Management Tool" logged twice in different words. Cosmetic. |
+| `tests/common/mod.rs:52` | `create_test_card` dead in one test binary — move helpers behind `#[allow(dead_code)]` or split per-suite. |
+
+---
+
+## Prioritized action plan
+
+1. **(Bug)** Persist foreignness and make `prune_foreign_unpriced` DB-driven (§1.1).
+2. **(Bug)** Fix delete/reset FK coverage; remove fake `CASCADE`; single CTE or TRUNCATE for reset (§1.2–1.3).
+3. **(Bug)** Harden `JsonStreamParser` against stream failures; abort on parser errors (§1.4).
+4. **(Bug)** Non-TTY-safe confirmations + `--yes` flag (§1.5).
+5. **(Feature-or-doc bug)** Decide who prunes `granular_price_history` (§8).
+6. **(Simplify)** Delete the no-op concurrency machinery *or* make it actually concurrent; delete dead granular parsing (§2.1–2.2). Big code shrink, measurable ingest speedup.
+7. **(Structure)** Thin `main.rs` to use the lib crate (§3.5) — halves compile/test time.
+8. **(Structure)** Extract `IngestPipeline` from the controller; move cross-module orchestration out of `CardService` (§3.2–3.3).
+9. **(DRY)** Shared subtree-collector for the four event processors (§4.1); shared retention/upsert helpers (§4.2–4.3).
+10. **(Testing)** Sync `tests/fixtures/schema.sql` with the web migrations; add portfolio/published-deck integration tests; add ports/traits so services get unit tests (§2.5, §3.1).
+11. **(Hygiene)** Clippy+fmt in CI, fix current warnings, Docker hardening, CLAUDE.md refresh (§8–9).

--- a/docs/codebase-analyses-2026-07/web.md
+++ b/docs/codebase-analyses-2026-07/web.md
@@ -1,0 +1,249 @@
+# Codebase Analysis — Bugs, Inconsistencies & Recommendations
+
+**Date:** 2026-07-07
+**Scope:** Full `src/` tree (~32k lines TS), configs, tests. Verified against `npx tsc --noEmit` (clean) and `npm test` (113 suites / 1366 tests, all passing — with a leaked-handle warning, see [C7](#c7-jest-worker-leaked-handle-warning)).
+
+Each finding lists severity, location, the problem, and a recommended fix. Severity scale:
+**🔴 High** = user-visible wrong behavior or data-integrity risk · **🟠 Medium** = latent bug, security/perf concern · **🟡 Low** = maintainability / consistency.
+
+---
+
+## Part 1 — Bugs (correctness)
+
+### B1. Error-to-HTTP mapping is keyword matching on error message strings 🔴
+
+`src/http/http.error.handler.ts:20-35` maps exceptions to HTTP statuses by substring-matching `error.message` (`includes('not found')` → 404, `includes('invalid')` → 400, else 500). Every HBS orchestrator (46 call sites) funnels errors through it. This produces concrete wrong results today:
+
+1. **401s become 404s.** `HttpErrorHandler.validateAuthenticatedRequest` throws `UnauthorizedException('User not found in request')` *inside* orchestrator `try` blocks (e.g. `set.orchestrator.ts:309`). The catch passes it to `toHttpException`, which matches `'not found'` **first** and rethrows it as `NotFoundException` — an unauthenticated POST gets 404 instead of 401, so the exception filter never sets `returnUrl` for the login redirect (`http.exception.filter.ts:52`).
+2. **User-input errors become 500s.** `TransactionService` throws `Error('Cannot sell 5 units. Only 3 remaining.')` — no keyword matches, so a routine over-sell attempt surfaces as `500 An unexpected error occurred` through the HBS flow, and as a raw 500 through the API controllers, which don't catch it at all (`transaction-api.controller.ts` `create`/`update` have no try/catch and no filter maps generic `Error` → 4xx).
+3. **Infrastructure errors become 400s.** Postgres messages like `invalid input syntax for type uuid` contain `'invalid'` → the client is told its request was bad when the server broke.
+4. The service layer *wraps* every error (`throw new Error(\`Error finding cards…: ${error.message}\`)`), so whether a page 404s or 500s depends on the wording of a message two layers down. The mapping is load-bearing prose.
+
+**Recommendation.** The codebase already contains the right building blocks — `src/core/errors/domain.errors.ts` (`DomainNotFoundError`, `DomainNotAuthorizedError`, `DomainValidationError`), used correctly by the newer `price-alert` / `api-tier` modules and `mcp.error.ts`. Make that the single convention:
+
+- In `toHttpException`: first `if (error instanceof HttpException) throw error;` then map `instanceof Domain*Error` to the matching HTTP exception; delete the keyword matching.
+- Migrate core services to throw `Domain*Error` (e.g. `DomainValidationError('Cannot sell…')`, `DomainNotFoundError('Set with code X not found')`).
+- Add a mapping for `Domain*Error` in the global `HttpExceptionFilter` so API controllers get correct statuses without per-controller catches (the per-controller `instanceof` blocks in `api-key-api.controller.ts` / `price-alert-api.controller.ts` can then be deleted).
+
+### B2. `InventoryRepository.ensureAtLeastOne` always reports 0 saved 🔴
+
+`src/database/inventory/inventory.repository.ts:248-257` runs a raw `INSERT … ON CONFLICT DO NOTHING` via `repository.query()` and reads `result?.rowCount`. Verified against the installed TypeORM 0.3.26 (`PostgresQueryRunner.query`): for an `INSERT`, `query()` returns `raw.rows` — a plain array with **no `rowCount` property**. So `saved` is always `0` and `skipped` is always `items.length`. Any CSV import row without a quantity ("ensure at least one") is persisted correctly but reported to the user as skipped.
+
+**Fix.** Append `RETURNING card_id` and use `result.length`, or call through a query runner with `useStructuredResult = true` and read `.affected`. Add an integration-test assertion on the returned counts (the current tests only assert DB state).
+
+### B3. Fire-and-forget delete inside `InventoryService.save` 🔴
+
+`src/core/inventory/inventory.service.ts:28-36`:
+
+```ts
+} else {
+    // await omitted intentionally
+    this.repository.delete(item.userId, item.cardId, item.isFoil);
+}
+```
+
+Two problems: (1) if the delete rejects, nothing handles it — an unhandled promise rejection **terminates the Node process** on Node ≥ 15; (2) callers (`TransactionService.adjustInventory`, quantity updates from the UI) get a success response before the delete has happened, and a failed delete is silent data corruption (transaction ledger says sold-out, inventory row still shows copies). `await` it — the latency of one indexed `DELETE` is not worth a crash vector. If batching matters, collect keys and issue one `DELETE … WHERE (user_id, card_id, foil) IN (…)`.
+
+### B4. Ledger writes and inventory sync are not transactional 🟠
+
+`TransactionService.create/update/delete` (`src/core/transaction/transaction.service.ts:67-80, 172-186, 210-215`) persist the transaction row, then adjust inventory in a separate call. A failure between the two leaves the ledger and inventory permanently inconsistent (there is no reconciliation job). Same shape in `DeckImportService.importDecklist` (deck created, then cards added) and `InventoryImportService` (deletes, saves, ensures as separate steps).
+
+Additionally, the sell-validation is check-then-act: `getRemainingQuantity()` then `save()` — two concurrent SELL requests can both pass validation and oversell (`create`, lines 55-66).
+
+**Recommendation.** Introduce a unit-of-work port in `src/core` (e.g. `TransactionRunnerPort` with `run<T>(fn): Promise<T>`) implemented in `src/database` over TypeORM's `DataSource.transaction()`, and wrap ledger + inventory mutation in it. That keeps the hexagonal direction intact. The oversell race then closes for free if the remaining-quantity read happens inside the same transaction (with `SELECT … FOR UPDATE` or a serializable isolation level).
+
+### B5. Postgres pool configured with MySQL options — pool limits are inert 🟠
+
+`src/app.module.ts:36-40` (both branches):
+
+```ts
+extra: { connectionLimit: 10, queueLimit: 0, waitForConnections: true },
+```
+
+These are **mysql2** pool options. `extra` is passed to `pg.Pool`, which ignores all three (its knobs are `max`, `idleTimeoutMillis`, `connectionTimeoutMillis`). The app currently runs on pg's defaults (`max: 10`) by coincidence; the queue behavior you think you configured does not exist. Replace with `extra: { max: 10 }` (plus explicit timeouts), and delete the duplicated TypeORM config block by extracting a single factory that takes `url | host-parts` (the two branches differ only in connection fields but duplicate logging/ssl/extra).
+
+### B6. Dead `CardRepository.totalValueForSet` contains an inverted filter 🟠
+
+`src/database/card/card.repository.ts:170-192` — `AND c.in_main = $2` bound to `baseOnly`. With `baseOnly = false` this filters to **only non-main cards** instead of *all* cards. The method is not on `CardRepositoryPort` and has no callers (the live path is `SetRepository.totalValueForSet`, which reads precomputed `set_price` columns). Delete it (and its tests); if it's ever needed, the filter must become `($2 = false OR c.in_main = true)`.
+
+### B7. In-page filter and search sanitize differently — apostrophe cards unfindable via filter 🟠
+
+`safeAlphaNumeric` (`src/core/query/query.util.ts:17-21`) strips `'`, `,`, `.` etc., and is what `SafeQueryOptions.filter` uses; `safeSearchTerm` (line 24) deliberately allows `-',.;:/`. Consequence: typing `Urza's` into a set page's filter box sends fragment `Urzas`, and `ILIKE '%Urzas%'` matches nothing — cards named with apostrophes/commas (a large chunk of MTG) can't be filtered, while the same text works in the search bar. Align `filter` on `safeSearchTerm`'s character set (parameterized ILIKE already makes the extra characters safe).
+
+### B8. No upper bound on `limit` — unbounded page sizes on public endpoints 🟠
+
+`sanitizeInt` (`query.util.ts:9-14`) rejects values `< 1` but has **no maximum**, and `SafeQueryOptions` applies it everywhere. Only the price-alert controllers clamp locally (`Math.min(100, …)`, `price-alert-api.controller.ts:64`). Every other list endpoint — `/sets`, set card pages, search, inventory, transactions, the public RapidAPI card search — accepts `?limit=1000000` and will happily build a giant join. The burst rate-limit guard does not help; a handful of such requests saturates Postgres. Add a cap in one place (`sanitizeInt(value, default, max = 100)` or a clamp in the `SafeQueryOptions` constructor) rather than per-controller.
+
+### B9. Global exception filter leaks internal error details 🟠
+
+`src/http/http.exception.filter.ts:33-53` — for non-`HttpException` errors (i.e., genuine 500s), the response body/toast is `exception.message`: raw TypeORM/Postgres messages (table/column names, constraint names) or whatever an internal `Error` said, sent to API clients and rendered into error-page toasts. For status ≥ 500, respond with a generic message and keep the detail in the log (the correlation-id infrastructure already exists to tie them together).
+
+### B10. Signup reveals which emails are registered 🟡
+
+`user.orchestrator.ts:80-83` throws `'A user with this email already exists'` while unknown emails proceed to "check your email" — a classic account-enumeration oracle, compounded by a timing oracle in `AuthService.validateUser` (`auth.service.ts:22-24`: no bcrypt compare at all when the email is unknown, so unknown-email logins return measurably faster). Recommendation: return the same "check your email" response whether or not the account exists (optionally emailing "you already have an account" instead), and do a dummy bcrypt compare on unknown emails.
+
+### B11. `bootstrap()` is a floating promise 🟡
+
+`src/main.ts:113` — `bootstrap();` with no `.catch`. Startup failures (`assertProdEnv`, port in use) surface as unhandled rejections. Use `bootstrap().catch((err) => { console.error(err); process.exit(1); })`. An ESLint `no-floating-promises` rule would have flagged both this and B3 — see C2.
+
+### B12. Set page runs inventory SQL for anonymous users, and an O(n²) map rebuild 🟡
+
+`set.orchestrator.ts` `createSetResponseDto`:
+- Lines 691, 702 call `totalInventoryItemsForSet(userId, …)` / `ownedValueForSet(userId, …)` unconditionally — with `userId = 0` for anonymous visitors, issuing two pointless queries on one of the highest-traffic pages (and sequentially, not `Promise.all`).
+- Line 713: `InventoryPresenter.toQuantityMap(inventory)` is invoked **inside** `set.cards.map(...)` — the quantity map is rebuilt for every card. For a 700-card set with a large collection this is O(cards × inventory). Hoist it above the `.map`.
+
+### B13. Stripe webhook sync trusts event payloads blindly on two axes 🟡
+
+`subscription.service.ts:113` casts `stripeSub.status as SubscriptionStatus` unvalidated (an unrecognized status string is persisted and will make `isActive()` behave arbitrarily), and `syncFromStripeSubscription` has no defense against **out-of-order webhook delivery** (an older `customer.subscription.updated` arriving after a newer one regresses the row — Stripe explicitly does not guarantee ordering). Validate the status against the enum, and either compare event `created` timestamps before writing or re-fetch the subscription from the API (as `syncFromCheckoutSessionId` already does).
+
+### B14. Minor defects
+
+| Where | Issue |
+|---|---|
+| `src/shared/decorators/timing.decorator.ts:16` | Log template typo: `[$class.$method)}]`. Also forces every wrapped method async. |
+| `src/http/base/http.util.ts:7` (`toDollar`) | `if (amount)` — `0` renders `'-'` while `0.001` renders `'$0.00'`; negatives render `'$-3.99'`. Use explicit `amount == null` checks; `formatChange`-style sign handling belongs inside. |
+| `src/core/auth/jwt.strategy.ts:104` | `parseInt(payload.sub)` without radix (radix-10 given everywhere else). |
+| `app.config.ts` hbs helpers | `toUpperCase`/`capitalize` throw on non-string/undefined input → template render becomes a 500. Guard like `money` does. |
+| `set.controller.ts:88-91` | `days` has no upper clamp (`?days=99999999` → full-history scan). Clamp like the orchestrator clamps rows elsewhere. |
+| `jwt.strategy.ts:validate` | A DB `findById` on **every** authenticated request. Fine at current scale, but worth noting: the JWT already carries `email`/`role`; consider trusting the (60-min) token and reserving the DB read for sensitive routes. |
+
+---
+
+## Part 2 — Architecture & hexagonal inconsistencies
+
+### A1. Three competing error conventions in `src/core` 🔴 (root cause of B1)
+
+- Plain `Error` with keyword-significant messages: `card.service.ts` (14×), `transaction.service.ts` (12×), `set.service.ts`, `user.service.ts`, `auth.service.ts`…
+- `Domain*Error`: `price-alert`, `api-tier` (the newer, better pattern).
+- **NestJS HTTP exceptions thrown from the domain layer**: `deck.service.ts` imports `BadRequestException`/`NotFoundException` from `@nestjs/common` — HTTP concerns inside core, which inverts the port-adapter direction the rest of the codebase carefully maintains.
+
+Standardize on `Domain*Error` in core (add `DomainConflictError` if needed), and map once at the boundary (see B1). `deck.service.ts` is a mechanical migration.
+
+### A2. Catch-wrap-rethrow boilerplate in every service method 🔴
+
+The dominant service pattern (`CardService`, `SetService`, and others) is:
+
+```ts
+try {
+    return await this.repository.x(...);
+} catch (error) {
+    throw new Error(`Error doing x: ${error.message}`);
+}
+```
+
+This (a) **destroys the stack trace and error type** — the original error class, code, and stack are gone by the time anything logs it; (b) is why B1's string matching exists; (c) adds ~6 lines of noise per method — `CardService` is 195 lines of which maybe 60 do work. Remove the try/catch entirely (let errors propagate; the global filter logs them with stack via `exception.stack`), or where context genuinely helps, use `throw new DomainXError(msg, { cause: error })` so the chain is preserved.
+
+### A3. `BaseRepository` hard-codes card-table queries into every repository 🟠
+
+`src/database/base.repository.ts` gives *every* repository (`SetRepository`, `InventoryRepository`, …) `totalCards()` / `totalCardsInSet()` that run `SELECT COUNT(*) FROM card` — regardless of the repository's own table. Downstream this produces the genuinely confusing `InventoryService.totalCards()` ("Get total number of cards in existence") which returns the **catalog** size through the inventory port (used by `inventory.orchestrator.ts:77`). Move these two queries to `CardRepository` (where a `totalCards` belongs), expose them via `CardService`, and delete `BaseRepository`/`BaseRepositoryPort` — with the card queries gone, the base class holds only three string constants.
+
+### A4. Dead port surface & dead code 🟠
+
+- `CardRepositoryPort.save`, `.delete`, `.findById`, `.deleteLegality` — no callers anywhere in the app (writes happen in the external Scry ETL). ~120 lines of implementation + port docs + tests maintained for nothing, and `save`/`delete` on the web app's port is a standing invitation to bypass the ETL. Remove them.
+- `CardRepository.totalValueForSet` — dead and buggy (B6).
+- `UserOrchestrator.create` — the controller only uses `initiateSignup` (email-verification flow); the direct-create path is unreachable legacy.
+- `CardRepository.findById(uuid, _relations)` — parameter named `_relations` (the "unused" convention) but it *is* used; rename to `relations`.
+
+### A5. Non-domain data smuggled through entities via `as any` 🟠
+
+`transaction.orchestrator.ts:62` and `transaction-api.presenter.ts:8` do `const tx = t as any;` to read `cardName`, `cardSetCode`, `cardImgSrc` that the repository glued onto `Transaction` beyond its declared type. This defeats the whole mapper/entity discipline: the fields are invisible to the type system, unmapped, and each consumer re-discovers them by cast. Define an explicit read model (`TransactionWithCard`) returned by a dedicated repository method, and map it like everything else.
+
+Related: domain entities are documented as immutable value objects, but `set.orchestrator.ts:220` mutates one (`set.cards.push(...cards)`). Prefer building the view from `set` + `cards` as separate inputs.
+
+### A6. The latest-price join subquery is copy-pasted 7× 🟡
+
+`'prices.date = (SELECT MAX(p2.date) FROM price p2 WHERE p2.card_id = card.id)'` appears in `card.repository.ts` (5×) and `inventory.repository.ts` (+ the raw-SQL variant in 3 aggregate queries). One drift and "latest price" means different things on different pages. Extract a constant/helper next to `QueryBuilderHelper` (e.g. `latestPriceJoin(cardAlias)`), and consider replacing the correlated subquery with a `LATERAL` join or a `latest_price` view for performance on big sets.
+
+### A7. Two sources of truth for "how many cards are in this set" 🟡
+
+`CardRepository.totalInSet` (counts rows with filters) vs `SetRepository.totalInSet` (returns stored `baseSize`/`totalSize`). `SetOrchestrator` picks one or the other depending on whether a filter is present (`findBySetCode`, `getLastCardPage`). If MTGJSON's stored sizes ever disagree with actual card rows, pagination totals and displayed counts diverge on the same page. At minimum, document the invariant; better, always count when correctness matters and reserve the stored sizes for the completion-rate denominator.
+
+### A8. Controller/orchestrator responsibility drift 🟡
+
+The documented rule is "view assembly in orchestrators; controllers thin". Mostly true, but controllers mutate view DTOs after the fact (`set.controller.ts:60-65, 124-128` set `title`, `metaDescription`, `canonicalUrl`, `ogImage`), and `SetOrchestrator.createSetPriceDto` is a 110-line formatting method (with three inline closure helpers) that is presenter work — `CardPresenter`/`SealedProductHbsPresenter` already establish the right home. Also inconsistent: `transaction.orchestrator.ts:79` calls `req.isAuthenticated()` directly while everything else uses the `isAuthenticated(req)` helper. Pick one (the helper) and move SEO fields into the orchestrator's DTO construction.
+
+### A9. Orchestrators `return` a function that never returns 🟡
+
+`return HttpErrorHandler.toHttpException(error, 'ctx')` — the method is typed `never` and always throws, so the `return` is a fiction that makes the code read as if an error page DTO comes back. Write `throw`-free style: `HttpErrorHandler.toHttpException(error, 'ctx');` as a statement, or once A1/A2 land, delete most of these catch blocks entirely.
+
+### A10. `await import('../inventory.entity')` mid-method 🟡
+
+`inventory-import.service.ts:127` dynamically imports the `Inventory` entity inside the import loop — presumably a circular-dependency workaround. It's the only dynamic import in the codebase, invisible to refactoring tools. Break the cycle properly (the entity could live in a types-only module) and use a static import.
+
+---
+
+## Part 3 — Performance
+
+### P1. Per-row card resolution in imports (N+1 at scale) 🟠
+
+`InventoryImportService.importCards` and `DeckImportService.importDecklist` `await this.cardResolver.resolveCard(row)` **sequentially per row**, with `MAX_IMPORT_ROWS = 2000` — a worst-case import issues 2000+ serial queries inside one HTTP request (minutes of wall time, one connection pinned). Batch it: group rows by resolution strategy (id / set+number / name) and resolve each group with one `IN (…)` query; `verifyCardsExist` already shows the batched pattern. Same for `DeckBuildabilityService.addMissingToBuyList` (`deck-buildability.service.ts:53-56`) — one `buyListService.add` await per missing card.
+
+### P2. `getRemainingQuantity` loads full transaction history to compute a sum 🟡
+
+`transaction.service.ts:224-232` fetches all buy lots and all sells for a card and reduces in JS on every create/update/delete. A single `SELECT COALESCE(SUM(CASE WHEN type='BUY' THEN quantity ELSE -quantity END),0)` does it in one round trip. (Bundling it inside the B4 transaction makes this the natural moment to fix.)
+
+### P3. Sequential awaits where `Promise.all` fits 🟡
+
+`createSetResponseDto` (B12), `SubscriptionService.getOrCreateCustomer` (two lookups), `AuthService.refresh`. The codebase uses `Promise.all` well elsewhere (`findFlatSetList`, transaction API `findAll`) — apply it consistently.
+
+---
+
+## Part 4 — Configuration, tooling, tests
+
+### C1. TypeScript strictness is off 🔴 (highest-leverage long-term fix)
+
+`tsconfig.json`: `strictNullChecks: false`, `noImplicitAny: false`. This is why `let user: User = null` (auth.service), `toValidNumber(value: any)`, and the `as any` smuggling (A5) compile silently, and why the mapper layer can't guarantee what it promises. Migrate incrementally: enable `strict` in a `tsconfig.strict.json` used by CI on a growing include list, or flip `strictNullChecks` on and fix the ~few-hundred errors module by module (start with `src/core`, where the domain invariants matter most).
+
+### C2. ESLint has no type-aware rules 🟠
+
+`.eslintrc.json` uses only the syntactic `recommended` sets. Adding `plugin:@typescript-eslint/recommended-type-checked` (or at minimum `@typescript-eslint/no-floating-promises` + `no-misused-promises` with `parserOptions.project`) would have caught B3 and B11 mechanically. Also consider raising `no-explicit-any` from `warn` to `error` once A5 is fixed (only 6 `as any` sites remain).
+
+### C3. Duplicated formatting logic across server and client 🟡
+
+`toDollar` + thousands-separator regex exists in `src/http/base/http.util.ts`, again in `set.orchestrator.ts` `formatChange`, and again in `src/http/public/js/ajaxUtils.js` — with already-divergent behavior (client returns `'-'` for `0`, server helper `money` in `app.config.ts` returns `'—'`, `toDollar` returns `'-'`). Server-side: collapse to one util (and prefer `Intl.NumberFormat('en-US', { style: 'currency' })` over the regex). Client-side duplication is inherent to the SSR+AJAX split, but the AJAX endpoints could return pre-formatted strings from the same server util (several already do), letting `ajaxUtils.toDollar` shrink or disappear.
+
+### C4. Logging conventions 🟡
+
+- Orchestrator catches log real failures at `debug` level (`this.LOGGER.debug(\`Error finding list of sets…\`)`) — invisible in production (`error`-only logging). Errors that reach `toHttpException` get logged there at `error`, but the several `catch → return []` paths (e.g. `findSealedProductsForSet`) hide failures at `debug`. Use `warn`/`error` for caught failures.
+- Nearly every repository/service method logs entry + exit at `debug` (two lines per call, ~500 sites). Since `TimingDecorator` exists for the timing use case and correlation IDs exist for tracing, consider trimming exit logs; it's a lot of hand-maintained noise (several already drifted, logging wrong method names).
+
+### C5. Verification/reset tokens stored in plaintext while refresh tokens are hashed 🟡
+
+`RefreshTokenService` deliberately stores only SHA-256 hashes (well done, including atomic rotation). But `pending_user` verification tokens (`verification-token.util.ts` + `pendingUserService.findByToken`) — and password-reset tokens, which share the util — are stored and looked up raw. A DB read (backup leak, SQLi elsewhere) yields live account-takeover tokens. Same fix as refresh tokens: store `sha256(token)`, look up by hash. Low effort, consistent policy.
+
+### C6. In-memory rate limiting & upload tracking pin the app to one instance 🟡
+
+`ApiRateLimitGuard` and `upload-rate-limit.guard.ts` keep state in process-local `Map`s. Correct today (single Lightsail box), but it's an undocumented scaling constraint — a second instance silently doubles every limit. A one-line comment on each guard (and a ROADMAP note to move to Postgres/Redis when scaling) is enough for now; the daily quota is already DB-backed and fine.
+
+### C7. Jest worker leaked-handle warning 🟡
+
+`npm test` passes but ends with "A worker process has failed to exit gracefully… Active timers can also cause this". Something under test starts a timer without `unref` (the `ApiRateLimitGuard` interval *is* unref'd; likely another `setInterval`/`setTimeout` in a service or a test missing teardown). Run `jest --detectOpenHandles` once and fix; leaked handles eventually mask real hangs in CI.
+
+### C8. Test coverage skew 🟡
+
+113 unit suites and a strong integration suite, but only 9 of 17 HBS orchestrators have specs — and the orchestrators contain exactly the logic that has bugs in this report (B1, B12, `createSetPriceDto` dedup cascade). When A8 moves formatting into presenters, add presenter specs; pure functions there are cheap to test.
+
+---
+
+## Part 5 — Things that are in good shape (keep doing these)
+
+Worth stating so the fixes above don't read as a verdict on the whole codebase:
+
+- **Port-adapter discipline is real**: services depend on `*RepositoryPort` tokens, DI bindings live in `DatabaseModule`, mappers isolate ORM entities. Violations (A1/A5) are the exception, not the rule.
+- **SQL injection posture is good**: user input consistently goes through parameter binding; the `QueryBuilderHelper` `allowedSorts` allowlist + `resolveSort` design (with the fail-fast constructor check) is a genuinely nice solution to the ORDER-BY-injection/unjoined-alias class of bugs.
+- **`RefreshTokenService`** — hashed storage, atomic single-use rotation with race handling, revoke-before-password-write ordering in `UserService.updatePassword` — is textbook.
+- **`validateApiQuery`** (strict 400s for API, lenient fallbacks for HBS bookmarks) is a thoughtful split, well documented, and derives its allowed values from the same enums the sanitizers use.
+- **Pure pricing policies** (`buylist.policy.ts`, `cash-vs-credit.policy.ts`, `sell-value.policy.ts`) are exactly where that logic should live — pure, documented, testable.
+- Auth cookies are `httpOnly` + `sameSite=lax` + `secure` in prod; Stripe webhook raw-body scoping in `main.ts` is done correctly; Handlebars escaping is relied on properly (the only `{{{ }}}` sites are JSON-LD and server-rendered markdown).
+
+---
+
+## Suggested fix order
+
+| Priority | Items | Rationale |
+|---|---|---|
+| 1 | B1 + A1 + A2 (error handling overhaul) | One coherent refactor; removes the largest bug class and ~500 lines of boilerplate. |
+| 2 | B3, B2, B4 (inventory/ledger integrity) | Data-integrity and crash risks in the money paths. |
+| 3 | B7, B8, B12, B5 (user-visible / capacity) | Small, independent, high user impact. |
+| 4 | C1 + C2 (strictness & lint) | Prevents regressions of everything above. |
+| 5 | A3–A10, P1–P3, C3–C8 | Steady-state cleanup; each is an afternoon or less. |

--- a/docs/cross-repo-analysis-plan-2026-07.md
+++ b/docs/cross-repo-analysis-plan-2026-07.md
@@ -92,49 +92,49 @@ Independent tracks can proceed in parallel; the arrows are the only hard orderin
 
 | # | Title | Findings | Priority |
 |---|---|---|---|
-| W1 | Error handling overhaul: domain errors end to end | B1, A1, A2, A9, part of B9 | 1 |
-| W2 | Inventory/ledger integrity: transactional writes, fix silent failures | B2, B3, B4, P2 | 1 |
-| W3 | Query/input hardening: filter charset, limit caps, pool config | B7, B8, B5, B14 (days clamp) | 2 |
-| W4 | Security hardening: error leaks, enumeration, token hashing, Stripe sync | B9, B10, C5, B13 | 2 |
-| W5 | Performance: set page, batched imports, Promise.all | B12, P1, P3, A6 | 2 |
-| W6 | TypeScript strictness + type-aware lint | C1, C2, C7 | 3 |
-| W7 | Architecture cleanup: dead code, read models, presenters, logging | A3-A8, A10, B6, B11, B14 rest, C3, C4, C8 | 3 |
-| W8 | OpenAPI spec fixes + delta-quantity endpoint (cross-repo X3, X4) | mobile 3.6, MCP I8, mobile 1.6 | 2 |
-| W9 | Migration: ON DELETE CASCADE for card/set dependents (cross-repo X1) | scry §1.2-1.3 | 1 |
+| [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | Error handling overhaul: domain errors end to end | B1, A1, A2, A9, part of B9 | 1 |
+| [W2](https://github.com/matthewdtowles/i-want-my-mtg/issues/570) | Inventory/ledger integrity: transactional writes, fix silent failures | B2, B3, B4, P2 | 1 |
+| [W3](https://github.com/matthewdtowles/i-want-my-mtg/issues/571) | Query/input hardening: filter charset, limit caps, pool config | B7, B8, B5, B14 (days clamp) | 2 |
+| [W4](https://github.com/matthewdtowles/i-want-my-mtg/issues/572) | Security hardening: error leaks, enumeration, token hashing, Stripe sync | B9, B10, C5, B13 | 2 |
+| [W5](https://github.com/matthewdtowles/i-want-my-mtg/issues/573) | Performance: set page, batched imports, Promise.all | B12, P1, P3, A6 | 2 |
+| [W6](https://github.com/matthewdtowles/i-want-my-mtg/issues/574) | TypeScript strictness + type-aware lint | C1, C2, C7 | 3 |
+| [W7](https://github.com/matthewdtowles/i-want-my-mtg/issues/575) | Architecture cleanup: dead code, read models, presenters, logging | A3-A8, A10, B6, B11, B14 rest, C3, C4, C8 | 3 |
+| [W8](https://github.com/matthewdtowles/i-want-my-mtg/issues/576) | OpenAPI spec fixes + delta-quantity endpoint (cross-repo X3, X4) | mobile 3.6, MCP I8, mobile 1.6 | 2 |
+| [W9](https://github.com/matthewdtowles/i-want-my-mtg/issues/577) | Migration: ON DELETE CASCADE for card/set dependents (cross-repo X1) | scry §1.2-1.3 | 1 |
 
 ### scry
 
 | # | Title | Findings | Priority |
 |---|---|---|---|
-| S1 | Fix post-ingest-prune: persist card foreignness | §1.1 | 1 |
-| S2 | Delete/reset FK coverage; remove fake CASCADE (cross-repo X1, after W9) | §1.2-1.3 | 1 |
-| S3 | Ingest robustness: stream failures, non-TTY prompts, batch-boundary and mapping bugs | §1.4-1.10 | 1 |
-| S4 | Implement granular_price_history retention (cross-repo X2) | §8 | 1 |
-| S5 | Remove no-op concurrency and dead granular parsing; fix misleading counts | §2.1-2.4, 2.6 | 2 |
-| S6 | Structure: thin main.rs, extract IngestPipeline, add ports for testability | §3.1-3.5 | 2 |
-| S7 | DRY, perf, and transactionality cleanup | §4, §5, §6, §7, §10 | 3 |
-| S8 | Tooling: clippy/fmt CI gates, Docker hardening, schema fixture sync (X5), docs refresh | §2.5, §8 (docs), §9 | 2 |
+| [S1](https://github.com/matthewdtowles/scry/issues/35) | Fix post-ingest-prune: persist card foreignness | §1.1 | 1 |
+| [S2](https://github.com/matthewdtowles/scry/issues/36) | Delete/reset FK coverage; remove fake CASCADE (cross-repo X1, after W9) | §1.2-1.3 | 1 |
+| [S3](https://github.com/matthewdtowles/scry/issues/37) | Ingest robustness: stream failures, non-TTY prompts, batch-boundary and mapping bugs | §1.4-1.10 | 1 |
+| [S4](https://github.com/matthewdtowles/scry/issues/38) | Implement granular_price_history retention (cross-repo X2) | §8 | 1 |
+| [S5](https://github.com/matthewdtowles/scry/issues/39) | Remove no-op concurrency and dead granular parsing; fix misleading counts | §2.1-2.4, 2.6 | 2 |
+| [S6](https://github.com/matthewdtowles/scry/issues/40) | Structure: thin main.rs, extract IngestPipeline, add ports for testability | §3.1-3.5 | 2 |
+| [S7](https://github.com/matthewdtowles/scry/issues/41) | DRY, perf, and transactionality cleanup | §4, §5, §6, §7, §10 | 3 |
+| [S8](https://github.com/matthewdtowles/scry/issues/42) | Tooling: clippy/fmt CI gates, Docker hardening, schema fixture sync (X5), docs refresh | §2.5, §8 (docs), §9 | 2 |
 
 ### iwantmymtg-mcp
 
 | # | Title | Findings | Priority |
 |---|---|---|---|
-| M1 | Correctness bundle: undefined results, CSV passthrough, JSON Schema target, empty patch, parse-in-tests | B1, B2, B3, B4, T1 | 1 |
-| M2 | ToolDefinition refactor: generics, requiresAuth, annotations, auth invariant test | A1, A2, I11, A4, T2 | 2 |
-| M3 | Consistency sweep: shared schemas/enums, client memoization, error polish, as-never sweep (part of X3) | I1-I10, A3, A5, A6, I8 | 3 |
-| M4 | Tooling: linter in CI, NodeNext, Node 20 matrix, force-with-lease, server handler tests | C1-C4, T3 | 2 |
+| [M1](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/19) | Correctness bundle: undefined results, CSV passthrough, JSON Schema target, empty patch, parse-in-tests | B1, B2, B3, B4, T1 | 1 |
+| [M2](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/20) | ToolDefinition refactor: generics, requiresAuth, annotations, auth invariant test | A1, A2, I11, A4, T2 | 2 |
+| [M3](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/21) | Consistency sweep: shared schemas/enums, client memoization, error polish, as-never sweep (part of X3) | I1-I10, A3, A5, A6, I8 | 3 |
+| [M4](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/22) | Tooling: linter in CI, NodeNext, Node 20 matrix, force-with-lease, server handler tests | C1-C4, T3 | 2 |
 
 ### i-want-my-mtg-mobile
 
 | # | Title | Findings | Priority |
 |---|---|---|---|
-| MB1 | Clear query cache on sign-out (cross-account data leak) | 1.1 | 1 |
-| MB2 | Decouple CI spec-drift check from PR gating (unblocks web X3/X4) | 1.7 | 1 |
-| MB3 | Behavior fixes: double inset, silent rollbacks, stepper debounce + settle invalidation, small nits | 1.2, 1.3, 1.6, 1.8 | 2 |
-| MB4 | Notification badge via unread-count; inbox paginates on scroll | 1.4 | 2 |
-| MB5 | Centralize query keys; re-key deck-owned under inventory | 1.5, 3.1 | 2 |
-| MB6 | Test + lint infrastructure (jest-expo, ESLint), cover pure modules | 4.1, 4.2 | 2 |
-| MB7 | Shared UI + hooks layer: steppers, rows, chips, useOptimisticMutation, edit-by-id screens | 2.1-2.8, 3.2-3.5 | 3 |
+| [MB1](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63) | Clear query cache on sign-out (cross-account data leak) | 1.1 | 1 |
+| [MB2](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64) | Decouple CI spec-drift check from PR gating (unblocks web X3/X4) | 1.7 | 1 |
+| [MB3](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/65) | Behavior fixes: double inset, silent rollbacks, stepper debounce + settle invalidation, small nits | 1.2, 1.3, 1.6, 1.8 | 2 |
+| [MB4](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/66) | Notification badge via unread-count; inbox paginates on scroll | 1.4 | 2 |
+| [MB5](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/67) | Centralize query keys; re-key deck-owned under inventory | 1.5, 3.1 | 2 |
+| [MB6](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/68) | Test + lint infrastructure (jest-expo, ESLint), cover pure modules | 4.1, 4.2 | 2 |
+| [MB7](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/69) | Shared UI + hooks layer: steppers, rows, chips, useOptimisticMutation, edit-by-id screens | 2.1-2.8, 3.2-3.5 | 3 |
 
 ## Shared themes (context, not separate issues)
 

--- a/docs/cross-repo-analysis-plan-2026-07.md
+++ b/docs/cross-repo-analysis-plan-2026-07.md
@@ -4,12 +4,14 @@ One plan covering the findings from the four codebase analyses run on 2026-07-07
 
 ## Source documents
 
-| Repo | Analysis doc (on its `claude/codebase-analysis-*` branch) |
+The full per-repo analyses (every finding with file/line references and recommendations) live in this repo, next to this plan:
+
+| Repo | Analysis doc |
 |---|---|
-| [i-want-my-mtg](https://github.com/matthewdtowles/i-want-my-mtg) (web) | [docs/codebase-analysis-2026-07.md](https://github.com/matthewdtowles/i-want-my-mtg/blob/claude/codebase-analysis-review-35frlw/docs/codebase-analysis-2026-07.md) |
-| [scry](https://github.com/matthewdtowles/scry) (ETL) | [CODEBASE_ANALYSIS.md](https://github.com/matthewdtowles/scry/blob/claude/codebase-analysis-review-bt1cur/CODEBASE_ANALYSIS.md) |
-| [iwantmymtg-mcp](https://github.com/matthewdtowles/iwantmymtg-mcp) (MCP server) | [docs/CODEBASE_ANALYSIS.md](https://github.com/matthewdtowles/iwantmymtg-mcp/blob/claude/codebase-analysis-review-8wy2wz/docs/CODEBASE_ANALYSIS.md) |
-| [i-want-my-mtg-mobile](https://github.com/matthewdtowles/i-want-my-mtg-mobile) (mobile) | [docs/codebase-analysis.md](https://github.com/matthewdtowles/i-want-my-mtg-mobile/blob/claude/codebase-analysis-review-cn51ft/docs/codebase-analysis.md) |
+| [i-want-my-mtg](https://github.com/matthewdtowles/i-want-my-mtg) (web) | [codebase-analyses-2026-07/web.md](codebase-analyses-2026-07/web.md) |
+| [scry](https://github.com/matthewdtowles/scry) (ETL) | [codebase-analyses-2026-07/scry.md](codebase-analyses-2026-07/scry.md) |
+| [iwantmymtg-mcp](https://github.com/matthewdtowles/iwantmymtg-mcp) (MCP server) | [codebase-analyses-2026-07/mcp.md](codebase-analyses-2026-07/mcp.md) |
+| [i-want-my-mtg-mobile](https://github.com/matthewdtowles/i-want-my-mtg-mobile) (mobile) | [codebase-analyses-2026-07/mobile.md](codebase-analyses-2026-07/mobile.md) |
 
 Finding IDs below (B1, §1.2, I11, 1.6, ...) refer to those docs.
 

--- a/docs/cross-repo-analysis-plan-2026-07.md
+++ b/docs/cross-repo-analysis-plan-2026-07.md
@@ -1,0 +1,143 @@
+# Cross-Repo Analysis Plan - July 2026
+
+One plan covering the findings from the four codebase analyses run on 2026-07-07. Each repo has its own detailed analysis doc; this file ties them together, resolves the cross-repo dependencies, and defines the work packages that become GitHub issues (all tracked in the "I Want My MTG" GitHub project).
+
+## Source documents
+
+| Repo | Analysis doc (on its `claude/codebase-analysis-*` branch) |
+|---|---|
+| [i-want-my-mtg](https://github.com/matthewdtowles/i-want-my-mtg) (web) | [docs/codebase-analysis-2026-07.md](https://github.com/matthewdtowles/i-want-my-mtg/blob/claude/codebase-analysis-review-35frlw/docs/codebase-analysis-2026-07.md) |
+| [scry](https://github.com/matthewdtowles/scry) (ETL) | [CODEBASE_ANALYSIS.md](https://github.com/matthewdtowles/scry/blob/claude/codebase-analysis-review-bt1cur/CODEBASE_ANALYSIS.md) |
+| [iwantmymtg-mcp](https://github.com/matthewdtowles/iwantmymtg-mcp) (MCP server) | [docs/CODEBASE_ANALYSIS.md](https://github.com/matthewdtowles/iwantmymtg-mcp/blob/claude/codebase-analysis-review-8wy2wz/docs/CODEBASE_ANALYSIS.md) |
+| [i-want-my-mtg-mobile](https://github.com/matthewdtowles/i-want-my-mtg-mobile) (mobile) | [docs/codebase-analysis.md](https://github.com/matthewdtowles/i-want-my-mtg-mobile/blob/claude/codebase-analysis-review-cn51ft/docs/codebase-analysis.md) |
+
+Finding IDs below (B1, §1.2, I11, 1.6, ...) refer to those docs.
+
+## How the four repos relate
+
+```
+            scry (Rust ETL)                    i-want-my-mtg (NestJS web)
+        writes card/set/price data  ------>    owns schema (migrations), serves site + API
+                                                    |
+                                            OpenAPI spec (/api/openapi.json)
+                                               /                \
+                              iwantmymtg-mcp                i-want-my-mtg-mobile
+                              (generated api-types,         (generated schema.ts,
+                               weekly sync workflow)          CI drift check vs live spec)
+```
+
+- The **web repo owns the database schema**. Scry writes into it; a schema change lands via web migrations, and the deploy order rule (publish scry first, deploy web second) already exists in web's CLAUDE.md.
+- The **web repo's OpenAPI spec is the contract** both clients generate from. Spec defects propagate as client workarounds; spec fixes propagate as client regeneration.
+- Mobile's CI regenerates its schema from the **live production** spec on every PR, so web API deploys can break mobile CI immediately.
+
+## Cross-repo work items (the part that must be sequenced)
+
+### X1. Delete integrity: ON DELETE CASCADE migration (web) then scry delete cleanup
+
+Scry §1.2-1.3: the `DELETE FROM ... CASCADE` statements do nothing (`CASCADE` parses as a table alias), and the batch-delete paths miss FK dependents (`price_history`, `granular_price_history`, `inventory`), so pruning a card that has history rows fails.
+
+- **Web**: add a migration putting `ON DELETE CASCADE` on the FKs from `price_history`, `granular_price_history`, and (decide deliberately) `inventory` to `card(id)`. Decide the `inventory` question explicitly: cascading user inventory on card deletion is a product decision, not just hygiene. Also update `docker/postgres/init/001_complete_schema.sql`.
+- **Scry**: after the migration is deployed, simplify the delete paths to delete only from `card` / `set` and remove the fake `CASCADE` tokens; replace `reset_data` with a single `TRUNCATE ... CASCADE`; add an integration test deleting a card that has `price_history` rows.
+- **Order**: web deploys the migration first (migrations run before the scry binary refresh in the same deploy, so a single web deploy after the scry release is also safe per the existing rule). Scry's simplification merges only after the migration is live.
+
+### X2. `granular_price_history` retention is unowned
+
+Scry §8: CLAUDE.md claims the `retention` command covers `granular_price_history`; no code touches it. CK-direct writes grow it daily without bound.
+
+- **Decision**: retention lives in scry (same tiered policy as the other history tables, or a simpler age cutoff if granular data does not need tiering).
+- **Scry**: implement it inside `retention` (reusing the shared retention helper from scry §4.2) and fix the docs.
+- **Web**: no code change; verify table size on prod after the first run.
+
+### X3. OpenAPI spec quality fixes (web) unblock both clients
+
+Mobile 3.6 and MCP I8 independently flag the same upstream defects in web's spec:
+
+- `page`/`limit` on `/notifications` and `days` on price-history endpoints are typed `string` (should be `number`, like `/sets` and `/cards`).
+- `DeckImportApiResultDto.errors` is specced as `Record<string, never>[]` but actually carries `{ row, name?, error }` - clients can only count errors, not show them.
+- Several query params are typed `unknown`, forcing MCP's `as never` casts.
+
+- **Web**: fix the `@ApiQuery`/DTO annotations; regenerate and publish the spec.
+- **MCP**: weekly sync picks it up (or trigger manually); then sweep the now-unnecessary `as never` casts (I8).
+- **Mobile**: regenerate `lib/api/schema.ts`, drop the `String(page)` casts, and render deck-import row errors.
+- **Order constraint**: mobile must first decouple its CI spec-drift check from PR gating (mobile 1.7), otherwise the web deploy breaks every open mobile PR the moment it ships.
+
+### X4. Delta-quantity endpoint (web) then mobile stepper fix
+
+Mobile 1.6: inventory/buy-list writes are absolute-quantity only, so rapid stepper taps race, and `bulkAddToInventory` needs read-modify-write.
+
+- **Web**: add an increment/delta variant to the inventory and buy-list write APIs (and expose it in the spec).
+- **Mobile**: short-term debounce + settle-time invalidation ships independently (no dependency); the delta endpoint adoption is a follow-up.
+- **MCP**: optional follow-up to expose the delta operation as a tool refinement.
+
+### X5. Scry's integration-test schema must track web migrations
+
+Scry §2.5: `tests/fixtures/schema.sql` has drifted (wrong `portfolio_value_history` columns, five tables missing entirely). Since web owns the schema, the fixture should be generated or synced from web's `docker/postgres/init` + `migrations/`, not hand-maintained. One-time sync now, plus a documented refresh step (or script) for future migrations.
+
+### X6. Error-body consistency (web) helps both clients
+
+Web B1/A1 (the domain-error overhaul) changes API error responses: correct statuses (401 vs 404, 400 vs 500) and predictable bodies. MCP's `extractApiMessage` and mobile's `errMessage` both parse `error`/`message` fields; after the web overhaul, verify both clients' error formatting against the new bodies (no code change expected, just verification).
+
+## Global sequencing
+
+Independent tracks can proceed in parallel; the arrows are the only hard orderings.
+
+1. **Mobile 1.7 first** (decouple CI drift check) - tiny, unblocks all web spec work (X3, X4).
+2. **Web migration for X1** -> scry delete cleanup.
+3. **Web spec fixes (X3) + delta endpoint (X4)** -> MCP/mobile regeneration follow-ups.
+4. Everything else is repo-local and unordered; each repo's analysis doc has its own priority table, preserved in the work packages below.
+
+## Work packages (one GitHub issue each)
+
+### i-want-my-mtg (web)
+
+| # | Title | Findings | Priority |
+|---|---|---|---|
+| W1 | Error handling overhaul: domain errors end to end | B1, A1, A2, A9, part of B9 | 1 |
+| W2 | Inventory/ledger integrity: transactional writes, fix silent failures | B2, B3, B4, P2 | 1 |
+| W3 | Query/input hardening: filter charset, limit caps, pool config | B7, B8, B5, B14 (days clamp) | 2 |
+| W4 | Security hardening: error leaks, enumeration, token hashing, Stripe sync | B9, B10, C5, B13 | 2 |
+| W5 | Performance: set page, batched imports, Promise.all | B12, P1, P3, A6 | 2 |
+| W6 | TypeScript strictness + type-aware lint | C1, C2, C7 | 3 |
+| W7 | Architecture cleanup: dead code, read models, presenters, logging | A3-A8, A10, B6, B11, B14 rest, C3, C4, C8 | 3 |
+| W8 | OpenAPI spec fixes + delta-quantity endpoint (cross-repo X3, X4) | mobile 3.6, MCP I8, mobile 1.6 | 2 |
+| W9 | Migration: ON DELETE CASCADE for card/set dependents (cross-repo X1) | scry §1.2-1.3 | 1 |
+
+### scry
+
+| # | Title | Findings | Priority |
+|---|---|---|---|
+| S1 | Fix post-ingest-prune: persist card foreignness | §1.1 | 1 |
+| S2 | Delete/reset FK coverage; remove fake CASCADE (cross-repo X1, after W9) | §1.2-1.3 | 1 |
+| S3 | Ingest robustness: stream failures, non-TTY prompts, batch-boundary and mapping bugs | §1.4-1.10 | 1 |
+| S4 | Implement granular_price_history retention (cross-repo X2) | §8 | 1 |
+| S5 | Remove no-op concurrency and dead granular parsing; fix misleading counts | §2.1-2.4, 2.6 | 2 |
+| S6 | Structure: thin main.rs, extract IngestPipeline, add ports for testability | §3.1-3.5 | 2 |
+| S7 | DRY, perf, and transactionality cleanup | §4, §5, §6, §7, §10 | 3 |
+| S8 | Tooling: clippy/fmt CI gates, Docker hardening, schema fixture sync (X5), docs refresh | §2.5, §8 (docs), §9 | 2 |
+
+### iwantmymtg-mcp
+
+| # | Title | Findings | Priority |
+|---|---|---|---|
+| M1 | Correctness bundle: undefined results, CSV passthrough, JSON Schema target, empty patch, parse-in-tests | B1, B2, B3, B4, T1 | 1 |
+| M2 | ToolDefinition refactor: generics, requiresAuth, annotations, auth invariant test | A1, A2, I11, A4, T2 | 2 |
+| M3 | Consistency sweep: shared schemas/enums, client memoization, error polish, as-never sweep (part of X3) | I1-I10, A3, A5, A6, I8 | 3 |
+| M4 | Tooling: linter in CI, NodeNext, Node 20 matrix, force-with-lease, server handler tests | C1-C4, T3 | 2 |
+
+### i-want-my-mtg-mobile
+
+| # | Title | Findings | Priority |
+|---|---|---|---|
+| MB1 | Clear query cache on sign-out (cross-account data leak) | 1.1 | 1 |
+| MB2 | Decouple CI spec-drift check from PR gating (unblocks web X3/X4) | 1.7 | 1 |
+| MB3 | Behavior fixes: double inset, silent rollbacks, stepper debounce + settle invalidation, small nits | 1.2, 1.3, 1.6, 1.8 | 2 |
+| MB4 | Notification badge via unread-count; inbox paginates on scroll | 1.4 | 2 |
+| MB5 | Centralize query keys; re-key deck-owned under inventory | 1.5, 3.1 | 2 |
+| MB6 | Test + lint infrastructure (jest-expo, ESLint), cover pure modules | 4.1, 4.2 | 2 |
+| MB7 | Shared UI + hooks layer: steppers, rows, chips, useOptimisticMutation, edit-by-id screens | 2.1-2.8, 3.2-3.5 | 3 |
+
+## Shared themes (context, not separate issues)
+
+- **Lint/CI gates are missing or weak in all four repos** (web C2, scry §9, MCP C1, mobile 4.2). Each repo's tooling issue covers its own.
+- **All four analyses praise the same discipline**: generated types with drift checks (MCP, mobile), port-adapter boundaries (web), allowlist-driven SQL safety (web), hashed refresh tokens (web), single-flight auth refresh (mobile). The work above extends those patterns rather than replacing them.
+- **Nothing in the four docs conflicts.** The only orderings that matter are X1 (web migration before scry cleanup) and X3/X4 (mobile CI decoupling before web spec changes); everything else is repo-local.


### PR DESCRIPTION
Synthesizes the four codebase analyses (web, scry, mcp, mobile) from the claude/codebase-analysis-* branches into one plan: cross-repo dependency map (X1-X6), global sequencing, and the work packages that become GitHub issues in each repo, all tracked in the I Want My MTG project.