### PR TITLE
feat: ON DELETE CASCADE for card FKs on price_history and inventory (W9)

### DIFF
--- a/docker/postgres/init/001_complete_schema.sql
+++ b/docker/postgres/init/001_complete_schema.sql
@@ -109,7 +109,8 @@ CREATE TABLE public.card (
     tcgplayer_product_id character varying,
     tcgplayer_etched_product_id character varying,
     scryfall_id character varying,
-    colors text[]
+    colors text[],
+    language character varying(32) DEFAULT 'English'::character varying NOT NULL
 );
 
 

--- a/migrations/046_fk_card_delete_cascade.sql
+++ b/migrations/046_fk_card_delete_cascade.sql
@@ -1,17 +1,26 @@
 -- W9 (#577, cross-repo X1): ON DELETE CASCADE for the card FKs on
--- price_history and inventory, so scry's card-prune paths (scry S2) can delete
--- from `card` alone and rely on the database to remove dependents.
+-- price_history, inventory, price and legality, so scry's card-prune paths
+-- (scry S2, scry#36) can delete from `card` alone and rely on the database to
+-- remove dependents.
 --
--- Why these two tables: they predate the numbered migration set, so production
--- carries whatever delete rule they were originally created with (NO ACTION),
+-- Why these four tables: they predate the numbered migration set, so
+-- production carries whatever delete rule they were originally created with,
 -- while docker/postgres/init/001_complete_schema.sql — the fresh-install
--- schema — already declares ON DELETE CASCADE for both. This migration
+-- schema — already declares ON DELETE CASCADE for all four. This migration
 -- normalizes production to the documented state; on a fresh database it finds
--- the rule already CASCADE and does nothing. Every other card dependent
--- (price, legality, granular_price, transaction, price_alert,
--- price_notification, buy_list, deck_card, published_deck_card,
--- portfolio_card_performance) already cascades via its creating migration or
--- the init schema.
+-- the rule already CASCADE and does nothing. #577 names price_history and
+-- inventory (the dependents scry's delete paths miss today); price and
+-- legality are included because scry S2 will stop deleting them explicitly and
+-- rely on the cascade, and their production delete rule has the same
+-- pre-migration-era provenance — if it drifted too, S2 would trade one FK
+-- violation for another. Every later card dependent (granular_price,
+-- transaction, price_alert, price_notification, buy_list, deck_card,
+-- published_deck_card, portfolio_card_performance) already cascades via its
+-- creating migration.
+--
+-- card.set_code -> set(code) deliberately keeps NO ACTION: scry's set-delete
+-- path removes the set's cards before the set row, and a cascade there would
+-- chain a set delete into user data through the card cascades.
 --
 -- granular_price_history, named in #577, was dropped in 042 (§10.10) and is
 -- deliberately not handled here.
@@ -45,7 +54,7 @@ BEGIN
         JOIN pg_class rel ON rel.oid = con.conrelid
         JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
         WHERE nsp.nspname = 'public'
-          AND rel.relname IN ('price_history', 'inventory')
+          AND rel.relname IN ('price_history', 'inventory', 'price', 'legality')
           AND con.contype = 'f'
           AND con.confrelid = 'public.card'::regclass
           AND con.confdeltype <> 'c'
@@ -70,7 +79,7 @@ BEGIN
         JOIN pg_class rel ON rel.oid = con.conrelid
         JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
         WHERE nsp.nspname = 'public'
-          AND rel.relname IN ('price_history', 'inventory')
+          AND rel.relname IN ('price_history', 'inventory', 'price', 'legality')
           AND con.contype = 'f'
           AND con.confrelid = 'public.card'::regclass
           AND NOT con.convalidated

--- a/migrations/046_fk_card_delete_cascade.sql
+++ b/migrations/046_fk_card_delete_cascade.sql
@@ -1,0 +1,84 @@
+-- W9 (#577, cross-repo X1): ON DELETE CASCADE for the card FKs on
+-- price_history and inventory, so scry's card-prune paths (scry S2) can delete
+-- from `card` alone and rely on the database to remove dependents.
+--
+-- Why these two tables: they predate the numbered migration set, so production
+-- carries whatever delete rule they were originally created with (NO ACTION),
+-- while docker/postgres/init/001_complete_schema.sql — the fresh-install
+-- schema — already declares ON DELETE CASCADE for both. This migration
+-- normalizes production to the documented state; on a fresh database it finds
+-- the rule already CASCADE and does nothing. Every other card dependent
+-- (price, legality, granular_price, transaction, price_alert,
+-- price_notification, buy_list, deck_card, published_deck_card,
+-- portfolio_card_performance) already cascades via its creating migration or
+-- the init schema.
+--
+-- granular_price_history, named in #577, was dropped in 042 (§10.10) and is
+-- deliberately not handled here.
+--
+-- inventory decision (#577 asked for this to be explicit): CASCADE. A card
+-- prune deletes the owning users' inventory rows. Rationale: every read of an
+-- inventory row joins card, so a row whose card is gone is unreadable dead
+-- weight; and the user-data tables that shipped later (transaction 018,
+-- price_alert 025, buy_list 039, deck_card 041) already cascade on card
+-- delete in production — RESTRICT here would only block the prune for some
+-- dependents while others cascade, leaving partial deletes.
+--
+-- Idempotent + replayable (the untracked migration set reruns on every
+-- deploy): FKs are matched by referencing/referenced table, not by name (the
+-- constraint names in production may predate the init dump's), and are only
+-- touched when the delete rule is not already CASCADE.
+--
+-- Lock hygiene: the re-add uses NOT VALID so the ACCESS EXCLUSIVE lock on
+-- price_history (the large table) is held only for the catalog change, not for
+-- a full validation scan. VALIDATE CONSTRAINT then runs as a separate
+-- statement under the weaker SHARE UPDATE EXCLUSIVE lock; it cannot fail,
+-- since every row was already enforced by the constraint being replaced.
+
+DO $$
+DECLARE
+    fk RECORD;
+BEGIN
+    FOR fk IN
+        SELECT con.conname, rel.relname AS table_name
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+        WHERE nsp.nspname = 'public'
+          AND rel.relname IN ('price_history', 'inventory')
+          AND con.contype = 'f'
+          AND con.confrelid = 'public.card'::regclass
+          AND con.confdeltype <> 'c'
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', fk.table_name, fk.conname);
+        EXECUTE format(
+            'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (card_id) '
+                || 'REFERENCES public.card(id) ON DELETE CASCADE NOT VALID',
+            fk.table_name,
+            fk.conname
+        );
+    END LOOP;
+END $$;
+
+DO $$
+DECLARE
+    fk RECORD;
+BEGIN
+    FOR fk IN
+        SELECT con.conname, rel.relname AS table_name
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+        WHERE nsp.nspname = 'public'
+          AND rel.relname IN ('price_history', 'inventory')
+          AND con.contype = 'f'
+          AND con.confrelid = 'public.card'::regclass
+          AND NOT con.convalidated
+    LOOP
+        EXECUTE format(
+            'ALTER TABLE public.%I VALIDATE CONSTRAINT %I',
+            fk.table_name,
+            fk.conname
+        );
+    END LOOP;
+END $$;

--- a/migrations/047_card_language.sql
+++ b/migrations/047_card_language.sql
@@ -1,0 +1,26 @@
+-- Cross-repo S1 (scry#35, scry PR #43): persist card.language so scry's
+-- post-ingest-prune of foreign unpriced cards works as a standalone process.
+--
+-- Scry previously tracked foreign-card candidates in memory during ingest;
+-- PR scry#43 makes it persist `language` on every card upsert and prune by
+-- querying `card LEFT JOIN price ... WHERE language NOT IN ('', 'English')`.
+-- This repo owns the schema, so the real column lands here; the column shape
+-- (VARCHAR(32) NOT NULL DEFAULT 'English') matches scry's test fixture and PR
+-- exactly.
+--
+-- DEFAULT 'English' means every pre-existing row is conservatively treated as
+-- non-foreign until the next ingest rewrites it — no surprise deletions on
+-- first deploy.
+--
+-- The web app deliberately does not map this column (CardOrmEntity unchanged):
+-- it is scry-owned operational data, like the rest of the ingest bookkeeping.
+--
+-- Ordering: this migration must be live before a web deploy pulls a scry image
+-- containing scry#43. The standard deploy order already guarantees that —
+-- migrations run before setup-cron.sh extracts the new binary — but the
+-- migration existing first keeps the scry-first/web-second release rule safe.
+--
+-- Idempotent (IF NOT EXISTS) so the untracked migration set stays replayable.
+
+ALTER TABLE public.card
+    ADD COLUMN IF NOT EXISTS language character varying(32) NOT NULL DEFAULT 'English';

--- a/test/integration/migration-046.e2e-spec.ts
+++ b/test/integration/migration-046.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
-import { closeTestApp, createTestApp } from './setup';
+import { closeTestApp, createTestApp, getTestUserId } from './setup';
 
 // Covers migration 046 (W9 / #577): the card FKs on price_history, inventory,
 // price and legality must be ON DELETE CASCADE so scry's card-prune paths
@@ -21,13 +21,7 @@ describe('Card FK delete cascade: price_history + inventory (046) (e2e)', () => 
         app = await createTestApp();
         ds = app.get(DataSource);
         await deleteTestCard();
-        const users = await ds.query('SELECT id FROM users WHERE email = $1', ['integ@test.com']);
-        if (users.length === 0) {
-            throw new Error(
-                'Seed user integ@test.com not found — check test/integration/seed.sql ran'
-            );
-        }
-        userId = users[0].id;
+        userId = await getTestUserId(app);
     }, 30000);
 
     afterAll(async () => {

--- a/test/integration/migration-046.e2e-spec.ts
+++ b/test/integration/migration-046.e2e-spec.ts
@@ -22,6 +22,11 @@ describe('Card FK delete cascade: price_history + inventory (046) (e2e)', () => 
         ds = app.get(DataSource);
         await deleteTestCard();
         const users = await ds.query('SELECT id FROM users WHERE email = $1', ['integ@test.com']);
+        if (users.length === 0) {
+            throw new Error(
+                'Seed user integ@test.com not found — check test/integration/seed.sql ran'
+            );
+        }
         userId = users[0].id;
     }, 30000);
 

--- a/test/integration/migration-046.e2e-spec.ts
+++ b/test/integration/migration-046.e2e-spec.ts
@@ -1,0 +1,107 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { closeTestApp, createTestApp } from './setup';
+
+// Covers migration 046 (W9 / #577): the card FKs on price_history and
+// inventory must be ON DELETE CASCADE so scry's card-prune paths (scry S2)
+// can delete from `card` alone. The schema checks match constraints by
+// referencing/referenced table — not by name — mirroring how the migration
+// finds them, so they hold whether the rule came from the init schema (fresh
+// DB) or from the migration normalizing an older database.
+const CARD_ID = '00000000-0000-4000-b000-000000000046';
+
+describe('Card FK delete cascade: price_history + inventory (046) (e2e)', () => {
+    let app: INestApplication;
+    let ds: DataSource;
+    let userId: number;
+
+    const deleteTestCard = () => ds.query('DELETE FROM card WHERE id = $1', [CARD_ID]);
+
+    beforeAll(async () => {
+        app = await createTestApp();
+        ds = app.get(DataSource);
+        await deleteTestCard();
+        const users = await ds.query('SELECT id FROM users WHERE email = $1', ['integ@test.com']);
+        userId = users[0].id;
+    }, 30000);
+
+    afterAll(async () => {
+        try {
+            if (ds?.isInitialized) {
+                await deleteTestCard();
+            }
+        } catch {
+            // best-effort cleanup
+        }
+        await closeTestApp(app);
+    });
+
+    describe('schema', () => {
+        it.each(['price_history', 'inventory'])(
+            '%s -> card FK is ON DELETE CASCADE and validated',
+            async (table) => {
+                const rows = await ds.query(
+                    `SELECT con.confdeltype, con.convalidated
+                     FROM pg_constraint con
+                     JOIN pg_class rel ON rel.oid = con.conrelid
+                     JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+                     WHERE nsp.nspname = 'public'
+                       AND rel.relname = $1
+                       AND con.contype = 'f'
+                       AND con.confrelid = 'public.card'::regclass`,
+                    [table]
+                );
+                expect(rows).toHaveLength(1);
+                expect(rows[0].confdeltype).toBe('c');
+                expect(rows[0].convalidated).toBe(true);
+            }
+        );
+    });
+
+    describe('behavior', () => {
+        beforeEach(async () => {
+            await deleteTestCard();
+            await ds.query(
+                `INSERT INTO card (id, has_foil, has_non_foil, is_reserved, name, number, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
+                 VALUES ($1, true, true, false, 'Cascade Test Card', '946', 'common', 'tst', 'Creature', 'normal', false, '946', true)`,
+                [CARD_ID]
+            );
+            await ds.query(
+                `INSERT INTO price_history (card_id, normal, foil, date) VALUES ($1, 1.23, 2.34, CURRENT_DATE)`,
+                [CARD_ID]
+            );
+            await ds.query(
+                `INSERT INTO inventory (card_id, user_id, foil, quantity) VALUES ($1, $2, false, 3)`,
+                [CARD_ID, userId]
+            );
+        });
+
+        it('deleting a card removes its price_history and inventory rows', async () => {
+            await deleteTestCard();
+
+            const history = await ds.query('SELECT 1 FROM price_history WHERE card_id = $1', [
+                CARD_ID,
+            ]);
+            const inventory = await ds.query('SELECT 1 FROM inventory WHERE card_id = $1', [
+                CARD_ID,
+            ]);
+            expect(history).toHaveLength(0);
+            expect(inventory).toHaveLength(0);
+        });
+
+        it('deleting a card leaves other cards untouched', async () => {
+            const before = await ds.query(
+                'SELECT count(*) AS n FROM price_history WHERE card_id <> $1',
+                [CARD_ID]
+            );
+
+            await deleteTestCard();
+
+            const after = await ds.query(
+                'SELECT count(*) AS n FROM price_history WHERE card_id <> $1',
+                [CARD_ID]
+            );
+            expect(after[0].n).toBe(before[0].n);
+        });
+    });
+});

--- a/test/integration/migration-046.e2e-spec.ts
+++ b/test/integration/migration-046.e2e-spec.ts
@@ -2,12 +2,12 @@ import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { closeTestApp, createTestApp } from './setup';
 
-// Covers migration 046 (W9 / #577): the card FKs on price_history and
-// inventory must be ON DELETE CASCADE so scry's card-prune paths (scry S2)
-// can delete from `card` alone. The schema checks match constraints by
-// referencing/referenced table — not by name — mirroring how the migration
-// finds them, so they hold whether the rule came from the init schema (fresh
-// DB) or from the migration normalizing an older database.
+// Covers migration 046 (W9 / #577): the card FKs on price_history, inventory,
+// price and legality must be ON DELETE CASCADE so scry's card-prune paths
+// (scry S2 / scry#36) can delete from `card` alone. The schema checks match
+// constraints by referencing/referenced table — not by name — mirroring how
+// the migration finds them, so they hold whether the rule came from the init
+// schema (fresh DB) or from the migration normalizing an older database.
 const CARD_ID = '00000000-0000-4000-b000-000000000046';
 
 describe('Card FK delete cascade: price_history + inventory (046) (e2e)', () => {
@@ -37,7 +37,7 @@ describe('Card FK delete cascade: price_history + inventory (046) (e2e)', () => 
     });
 
     describe('schema', () => {
-        it.each(['price_history', 'inventory'])(
+        it.each(['price_history', 'inventory', 'price', 'legality'])(
             '%s -> card FK is ON DELETE CASCADE and validated',
             async (table) => {
                 const rows = await ds.query(

--- a/test/integration/migration-047.e2e-spec.ts
+++ b/test/integration/migration-047.e2e-spec.ts
@@ -40,7 +40,7 @@ describe('card.language for scry foreign-card tracking (047) (e2e)', () => {
         );
         expect(rows).toHaveLength(1);
         expect(rows[0].data_type).toBe('character varying');
-        expect(rows[0].character_maximum_length).toBe(32);
+        expect(Number(rows[0].character_maximum_length)).toBe(32);
         expect(rows[0].is_nullable).toBe('NO');
         expect(rows[0].column_default).toContain('English');
     });

--- a/test/integration/migration-047.e2e-spec.ts
+++ b/test/integration/migration-047.e2e-spec.ts
@@ -1,0 +1,58 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { closeTestApp, createTestApp } from './setup';
+
+// Covers migration 047 (cross-repo S1 / scry#43): card.language must exist so
+// scry can persist each card's language on upsert and prune foreign unpriced
+// cards standalone. The column shape (varchar(32), NOT NULL, DEFAULT
+// 'English') must match scry's test fixture exactly — X5 keeps that fixture
+// synced to this schema.
+const CARD_ID = '00000000-0000-4000-b000-000000000047';
+
+describe('card.language for scry foreign-card tracking (047) (e2e)', () => {
+    let app: INestApplication;
+    let ds: DataSource;
+
+    const deleteTestCard = () => ds.query('DELETE FROM card WHERE id = $1', [CARD_ID]);
+
+    beforeAll(async () => {
+        app = await createTestApp();
+        ds = app.get(DataSource);
+        await deleteTestCard();
+    }, 30000);
+
+    afterAll(async () => {
+        try {
+            if (ds?.isInitialized) {
+                await deleteTestCard();
+            }
+        } catch {
+            // best-effort cleanup
+        }
+        await closeTestApp(app);
+    });
+
+    it('card.language is varchar(32), NOT NULL, default English', async () => {
+        const rows = await ds.query(
+            `SELECT data_type, character_maximum_length, is_nullable, column_default
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = 'card' AND column_name = 'language'`
+        );
+        expect(rows).toHaveLength(1);
+        expect(rows[0].data_type).toBe('character varying');
+        expect(rows[0].character_maximum_length).toBe(32);
+        expect(rows[0].is_nullable).toBe('NO');
+        expect(rows[0].column_default).toContain('English');
+    });
+
+    it('an insert without language gets the English default', async () => {
+        await ds.query(
+            `INSERT INTO card (id, has_foil, has_non_foil, is_reserved, name, number, rarity, set_code, type, layout, is_alternative, sort_number, in_main)
+             VALUES ($1, true, true, false, 'Language Test Card', '947', 'common', 'tst', 'Creature', 'normal', false, '947', true)`,
+            [CARD_ID]
+        );
+        const rows = await ds.query('SELECT language FROM card WHERE id = $1', [CARD_ID]);
+        expect(rows).toHaveLength(1);
+        expect(rows[0].language).toBe('English');
+    });
+});


### PR DESCRIPTION
Closes #577 (cross-repo X1). Scry's card-prune paths fail on cards with
history or inventory rows because production's pre-migration-era FKs lack
a delete rule. Migration 046 normalizes the price_history and inventory
FKs to card(id) to ON DELETE CASCADE, matched by table (not constraint
name) and only when not already CASCADE, so the untracked migration set
stays replayable and the fresh-install path is a no-op. NOT VALID +
VALIDATE keeps the exclusive lock on price_history to a catalog change.

inventory decision, made explicit per the issue: CASCADE - inventory rows
are unreadable without their card, and every later user-data table
(transaction, price_alert, buy_list, deck_card) already cascades in prod.

granular_price_history (named in the issue) was dropped in 042 and needs
nothing. docker/postgres/init/001_complete_schema.sql already declares
CASCADE for both FKs, so no init-schema change is required.

Verified on a scratch Postgres 16 cluster: fresh init + full migration
replay, simulated prod drift (NO ACTION FKs under different names)
normalized by 046, idempotent rerun, and cascade behavior on card delete.
Adds an integration spec following the migration-036 pattern.