### PR TITLE
refactor: centralize domain-error → HTTP mapping (W1, part 1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -254,6 +254,71 @@ Not blocking the single-pass PR (#33) — the serial pattern predates it and thr
 
 ---
 
+## Phase 11: Cross-Repo Hardening (July 2026 analysis)
+
+The four codebase analyses run **2026-07-07** produced 29 work-package issues spanning all four repos (web, scry, MCP, mobile). This section is the **execution tracker** — it mirrors those issues so the roadmap stays the single reference as we knock them out. It is quality/hardening work (correctness, integrity, security, tooling, structure), not new product surface.
+
+**Source material** (full detail lives outside this file, keep it there):
+- Per-repo findings with file/line refs: [`docs/codebase-analyses-2026-07/`](docs/codebase-analyses-2026-07/) — `web.md`, `scry.md`, `mcp.md`, `mobile.md`.
+- Cross-repo dependencies + sequencing rationale + the work-package → issue mapping: [`docs/cross-repo-analysis-plan-2026-07.md`](docs/cross-repo-analysis-plan-2026-07.md).
+
+**Done so far:** W9 ([#577](https://github.com/matthewdtowles/i-want-my-mtg/issues/577), ON DELETE CASCADE migration, merged in PR #578) and S1 ([scry#35](https://github.com/matthewdtowles/scry/issues/35), post-ingest-prune foreignness). 26 issues remain.
+
+### Cross-repo hard orderings (everything else is repo-local and parallelizable)
+
+- **X1** — web **W9** migration (✅ done) → scry **S2** delete/reset cleanup is now **unblocked**.
+- **X3 / X4** — mobile **MB2** (decouple CI spec-drift check from PR gating) must land **before** web **W8** (OpenAPI spec fixes + delta-quantity endpoint), or the web deploy breaks every open mobile PR. W8 then triggers the client follow-ups: MCP **M3** `as never` sweep + mobile schema regen.
+- **X2** — `granular_price_history` retention is owned by scry **S4** (unbounded daily growth until it lands).
+- **X5** — scry's integration-test schema fixture is synced from web migrations in scry **S8**.
+- **X6** — after web **W1** error overhaul, verify MCP `extractApiMessage` + mobile `errMessage` against the new error bodies (verification only, no code expected).
+
+### Execution order
+
+**Wave 1 — Correctness, integrity, security (do these first; gates the Phase 8 go-to-market push).**
+
+| Issue | Repo | Title | Notes |
+|---|---|---|---|
+| [MB1](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63) | mobile | Clear query cache on sign-out (cross-account data leak) | Security — ship immediately |
+| [MB2](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64) | mobile | Decouple CI spec-drift check from PR gating | Tiny; unblocks W8 (X3/X4) |
+| [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | web | Error handling overhaul: domain errors end to end | Foundational; X6 verifies after |
+| [W2](https://github.com/matthewdtowles/i-want-my-mtg/issues/570) | web | Inventory/ledger integrity: transactional writes, fix silent failures | |
+| [S2](https://github.com/matthewdtowles/scry/issues/36) | scry | Delete/reset FK coverage; remove fake CASCADE | Unblocked by W9 (X1) |
+| [S3](https://github.com/matthewdtowles/scry/issues/37) | scry | Ingest robustness: stream failures, non-TTY prompts, batch/mapping bugs | |
+| [S4](https://github.com/matthewdtowles/scry/issues/38) | scry | Implement `granular_price_history` retention | Unbounded growth (X2) |
+| [M1](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/19) | mcp | Correctness bundle: undefined results, CSV passthrough, JSON Schema, empty patch | |
+
+**Wave 2 — Hardening + the OpenAPI spec chain (P2).**
+
+| Issue | Repo | Title | Notes |
+|---|---|---|---|
+| [W8](https://github.com/matthewdtowles/i-want-my-mtg/issues/576) | web | OpenAPI spec fixes + delta-quantity endpoint | After MB2 (X3/X4); triggers M3 + mobile regen |
+| [W3](https://github.com/matthewdtowles/i-want-my-mtg/issues/571) | web | Query/input hardening: filter charset, limit caps, pool config | |
+| [W4](https://github.com/matthewdtowles/i-want-my-mtg/issues/572) | web | Security hardening: error leaks, enumeration, token hashing, Stripe sync | |
+| [W5](https://github.com/matthewdtowles/i-want-my-mtg/issues/573) | web | Performance: set page, batched imports, Promise.all, latest-price helper | |
+| [S5](https://github.com/matthewdtowles/scry/issues/39) | scry | Remove no-op concurrency + dead granular parsing; fix misleading counts | |
+| [S6](https://github.com/matthewdtowles/scry/issues/40) | scry | Structure: thin `main.rs`, extract `IngestPipeline`, add ports | |
+| [S8](https://github.com/matthewdtowles/scry/issues/42) | scry | Tooling: clippy/fmt CI gates, Docker hardening, schema fixture sync | X5 |
+| [M2](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/20) | mcp | ToolDefinition refactor: generics, requiresAuth, annotations, auth invariant test | |
+| [M4](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/22) | mcp | Tooling: linter in CI, NodeNext, Node 20 matrix, server handler tests | |
+| [MB3](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/65) | mobile | Behavior fixes: double inset, silent rollbacks, stepper debounce + settle invalidation | X4 short-term (debounce) |
+| [MB4](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/66) | mobile | Notification badge via unread-count; inbox paginates on scroll | |
+| [MB5](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/67) | mobile | Centralize query keys; re-key deck-owned under inventory | |
+| [MB6](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/68) | mobile | Test + lint infrastructure (jest-expo, ESLint); cover pure modules | |
+
+**Wave 3 — Structure & cleanup (P3).**
+
+| Issue | Repo | Title | Notes |
+|---|---|---|---|
+| [W6](https://github.com/matthewdtowles/i-want-my-mtg/issues/574) | web | TypeScript strictness + type-aware lint | |
+| [W7](https://github.com/matthewdtowles/i-want-my-mtg/issues/575) | web | Architecture cleanup: dead code, read models, presenters, logging | |
+| [S7](https://github.com/matthewdtowles/scry/issues/41) | scry | DRY, perf, and transactionality cleanup | |
+| [M3](https://github.com/matthewdtowles/iwantmymtg-mcp/issues/21) | mcp | Consistency sweep: shared schemas/enums, client memoization, `as never` sweep | Client follow-up to W8 (X3) |
+| [MB7](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/69) | mobile | Shared UI + hooks layer: steppers, rows, chips, `useOptimisticMutation`, edit-by-id | |
+
+**Sequencing note:** Wave 1 is correctness/integrity/security and should land **before the Phase 8 go-to-market push** — MB1 alone (cross-account data leak) is a hard blocker on marketing the mobile app. Waves 2–3 can interleave with Phase 8/9 as capacity allows.
+
+---
+
 ## Appendix: Freemium model (reference)
 
 Free vs premium feature split, kept for reference (from 3.4).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -264,6 +264,8 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 
 **Done so far:** W9 ([#577](https://github.com/matthewdtowles/i-want-my-mtg/issues/577), ON DELETE CASCADE migration, merged in PR #578) and S1 ([scry#35](https://github.com/matthewdtowles/scry/issues/35), post-ingest-prune foreignness). 26 issues remain.
 
+**In flight (2026-07-09):** MB1 (mobile PR #70), MB2 (mobile PR #71), and W1 **part 1** (web PR #579) have open PRs — see the Wave 1 table. W1 is being split: PR #579 lands the boundary + convention (B1/B9/A1/A9); the A2 catch-wrap-rethrow cleanup + keyword-fallback removal is a follow-up, so #569 stays open until then.
+
 ### Cross-repo hard orderings (everything else is repo-local and parallelizable)
 
 - **X1** — web **W9** migration (✅ done) → scry **S2** delete/reset cleanup is now **unblocked**.
@@ -278,9 +280,9 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 
 | Issue | Repo | Title | Notes |
 |---|---|---|---|
-| [MB1](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63) | mobile | Clear query cache on sign-out (cross-account data leak) | Security — ship immediately |
-| [MB2](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64) | mobile | Decouple CI spec-drift check from PR gating | Tiny; unblocks W8 (X3/X4) |
-| [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | web | Error handling overhaul: domain errors end to end | Foundational; X6 verifies after |
+| [MB1](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63) | mobile | Clear query cache on sign-out (cross-account data leak) | Security — **PR #70 open** |
+| [MB2](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64) | mobile | Decouple CI spec-drift check from PR gating | Unblocks W8 (X3/X4) — **PR #71 open** |
+| [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | web | Error handling overhaul: domain errors end to end | Foundational; X6 verifies after — **part 1 in PR #579**, A2 remainder to follow |
 | [W2](https://github.com/matthewdtowles/i-want-my-mtg/issues/570) | web | Inventory/ledger integrity: transactional writes, fix silent failures | |
 | [S2](https://github.com/matthewdtowles/scry/issues/36) | scry | Delete/reset FK coverage; remove fake CASCADE | Unblocked by W9 (X1) |
 | [S3](https://github.com/matthewdtowles/scry/issues/37) | scry | Ingest robustness: stream failures, non-TTY prompts, batch/mapping bugs | |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -262,9 +262,9 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 - Per-repo findings with file/line refs: [`docs/codebase-analyses-2026-07/`](docs/codebase-analyses-2026-07/) — `web.md`, `scry.md`, `mcp.md`, `mobile.md`.
 - Cross-repo dependencies + sequencing rationale + the work-package → issue mapping: [`docs/cross-repo-analysis-plan-2026-07.md`](docs/cross-repo-analysis-plan-2026-07.md).
 
-**Done so far:** W9 ([#577](https://github.com/matthewdtowles/i-want-my-mtg/issues/577), ON DELETE CASCADE migration, merged in PR #578) and S1 ([scry#35](https://github.com/matthewdtowles/scry/issues/35), post-ingest-prune foreignness). 26 issues remain.
+**Done so far:** W9 ([#577](https://github.com/matthewdtowles/i-want-my-mtg/issues/577), ON DELETE CASCADE migration, PR #578), S1 ([scry#35](https://github.com/matthewdtowles/scry/issues/35), post-ingest-prune foreignness), and — 2026-07-09 — MB1 ([#63](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63), mobile PR #70) + MB2 ([#64](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64), mobile PR #71). 24 issues remain.
 
-**In flight (2026-07-09):** MB1 (mobile PR #70), MB2 (mobile PR #71), and W1 **part 1** (web PR #579) have open PRs — see the Wave 1 table. W1 is being split: PR #579 lands the boundary + convention (B1/B9/A1/A9); the A2 catch-wrap-rethrow cleanup + keyword-fallback removal is a follow-up, so #569 stays open until then.
+**In flight (2026-07-09):** W1 **part 1** (web PR #579). W1 is being split: PR #579 lands the boundary + convention (B1/B9/A1/A9); the A2 catch-wrap-rethrow cleanup + keyword-fallback removal is a follow-up, so #569 stays open until then.
 
 ### Cross-repo hard orderings (everything else is repo-local and parallelizable)
 
@@ -280,8 +280,8 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 
 | Issue | Repo | Title | Notes |
 |---|---|---|---|
-| [MB1](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63) | mobile | Clear query cache on sign-out (cross-account data leak) | Security — **PR #70 open** |
-| [MB2](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64) | mobile | Decouple CI spec-drift check from PR gating | Unblocks W8 (X3/X4) — **PR #71 open** |
+| ~~MB1~~ | mobile | Clear query cache on sign-out (cross-account data leak) | ✅ **done** (PR #70) |
+| ~~MB2~~ | mobile | Decouple CI spec-drift check from PR gating | ✅ **done** (PR #71); unblocked W8 (X3/X4) |
 | [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | web | Error handling overhaul: domain errors end to end | Foundational; X6 verifies after — **part 1 in PR #579**, A2 remainder to follow |
 | [W2](https://github.com/matthewdtowles/i-want-my-mtg/issues/570) | web | Inventory/ledger integrity: transactional writes, fix silent failures | |
 | [S2](https://github.com/matthewdtowles/scry/issues/36) | scry | Delete/reset FK coverage; remove fake CASCADE | Unblocked by W9 (X1) |

--- a/src/core/deck/deck.service.ts
+++ b/src/core/deck/deck.service.ts
@@ -1,5 +1,6 @@
-import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Format } from 'src/core/card/format.enum';
+import { DomainNotFoundError, DomainValidationError } from 'src/core/errors/domain.errors';
 import { getLogger } from 'src/logger/global-app-logger';
 import { Deck } from './deck.entity';
 import { DeckRepositoryPort } from './ports/deck.repository.port';
@@ -29,7 +30,7 @@ export class DeckService {
     async createDeck(userId: number, name: string, format?: Format | null): Promise<Deck> {
         const cleanName = (name ?? '').trim();
         if (!cleanName) {
-            throw new BadRequestException('Deck name is required.');
+            throw new DomainValidationError('Deck name is required.');
         }
         this.LOGGER.debug(`create deck "${cleanName}" for user ${userId}.`);
         return this.repository.create(new Deck({ userId, name: cleanName, format: format ?? null }));
@@ -44,7 +45,7 @@ export class DeckService {
         await this.assertOwner(deckId, userId);
         const cleanName = (name ?? '').trim();
         if (!cleanName) {
-            throw new BadRequestException('Deck name is required.');
+            throw new DomainValidationError('Deck name is required.');
         }
         this.LOGGER.debug(`update deck ${deckId} for user ${userId}.`);
         return this.repository.update(
@@ -114,11 +115,11 @@ export class DeckService {
         await this.repository.removeCard(deckId, cardId, isSideboard);
     }
 
-    /** Throws NotFoundException if the deck is missing or not owned by the user. */
+    /** Throws DomainNotFoundError if the deck is missing or not owned by the user. */
     private async assertOwner(deckId: number, userId: number): Promise<void> {
         const ownerId = await this.repository.getOwnerId(deckId);
         if (ownerId !== userId) {
-            throw new NotFoundException(`Deck ${deckId} not found.`);
+            throw new DomainNotFoundError(`Deck ${deckId} not found.`);
         }
     }
 }

--- a/src/http/hbs/buy-list/buy-list-page.orchestrator.ts
+++ b/src/http/hbs/buy-list/buy-list-page.orchestrator.ts
@@ -29,7 +29,7 @@ export class BuyListPageOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building buy-list view: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildListView');
+            HttpErrorHandler.toHttpException(error, 'buildListView');
         }
     }
 }

--- a/src/http/hbs/card/card.orchestrator.ts
+++ b/src/http/hbs/card/card.orchestrator.ts
@@ -187,7 +187,7 @@ export class CardOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error finding set card ${setCode}/${setNumber}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'findSetCard');
+            HttpErrorHandler.toHttpException(error, 'findSetCard');
         }
     }
 
@@ -199,7 +199,7 @@ export class CardOrchestrator {
             return { cardId, prices: points };
         } catch (error) {
             this.LOGGER.debug(`Error getting price history for ${cardId}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getPriceHistory');
+            HttpErrorHandler.toHttpException(error, 'getPriceHistory');
         }
     }
 
@@ -212,7 +212,7 @@ export class CardOrchestrator {
             return lastPage;
         } catch (error) {
             this.LOGGER.debug(`Error finding last page for ${name}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getPrintingsLastPage');
+            HttpErrorHandler.toHttpException(error, 'getPrintingsLastPage');
         }
     }
 }

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -96,7 +96,7 @@ export class DeckPageOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error importing decklist: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'importDecklist');
+            HttpErrorHandler.toHttpException(error, 'importDecklist');
         }
     }
 
@@ -122,7 +122,7 @@ export class DeckPageOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building deck list view: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildListView');
+            HttpErrorHandler.toHttpException(error, 'buildListView');
         }
     }
 
@@ -175,7 +175,7 @@ export class DeckPageOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building deck detail view: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildDetailView');
+            HttpErrorHandler.toHttpException(error, 'buildDetailView');
         }
     }
 

--- a/src/http/hbs/inventory/inventory.orchestrator.ts
+++ b/src/http/hbs/inventory/inventory.orchestrator.ts
@@ -126,7 +126,7 @@ export class InventoryOrchestrator {
             this.LOGGER.debug(
                 `Error finding inventory for user ${req.user?.id}: ${error?.message}`
             );
-            return HttpErrorHandler.toHttpException(error, 'findByUserWithPagination');
+            HttpErrorHandler.toHttpException(error, 'findByUserWithPagination');
         }
     }
 
@@ -142,7 +142,7 @@ export class InventoryOrchestrator {
             return lastPage;
         } catch (error) {
             this.LOGGER.debug(`Error finding last page for user ${userId}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getLastPage');
+            HttpErrorHandler.toHttpException(error, 'getLastPage');
         }
     }
 
@@ -208,7 +208,7 @@ export class InventoryOrchestrator {
         } catch (error) {
             this.LOGGER.debug(`Error saving inventory for user ${req.user?.id}: ${error?.message}`);
             if (error instanceof HttpException) throw error;
-            return HttpErrorHandler.toHttpException(error, 'save');
+            HttpErrorHandler.toHttpException(error, 'save');
         }
     }
 
@@ -236,7 +236,7 @@ export class InventoryOrchestrator {
             return new ImportResultDto({ ...result, errorCsv, detectedFormat });
         } catch (error) {
             this.LOGGER.debug(`Error importing cards for user ${req.user?.id}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'importCards');
+            HttpErrorHandler.toHttpException(error, 'importCards');
         }
     }
 
@@ -260,7 +260,7 @@ export class InventoryOrchestrator {
             return new ImportResultDto({ ...result, errorCsv });
         } catch (error) {
             this.LOGGER.debug(`Error importing set for user ${req.user?.id}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'importSet');
+            HttpErrorHandler.toHttpException(error, 'importSet');
         }
     }
 
@@ -295,7 +295,7 @@ export class InventoryOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error in sellView for user ${req.user?.id}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'sellView');
+            HttpErrorHandler.toHttpException(error, 'sellView');
         }
     }
 
@@ -315,7 +315,7 @@ export class InventoryOrchestrator {
             this.LOGGER.debug(
                 `Error exporting sell CSV for user ${req.user?.id}: ${error?.message}`
             );
-            return HttpErrorHandler.toHttpException(error, 'exportSellCsv');
+            HttpErrorHandler.toHttpException(error, 'exportSellCsv');
         }
     }
 
@@ -343,7 +343,7 @@ export class InventoryOrchestrator {
             this.LOGGER.debug(
                 `Error exporting inventory for user ${req.user?.id}: ${error?.message}`
             );
-            return HttpErrorHandler.toHttpException(error, 'exportInventory');
+            HttpErrorHandler.toHttpException(error, 'exportInventory');
         }
     }
 
@@ -379,7 +379,7 @@ export class InventoryOrchestrator {
                 `Error deleting inventory item for user ${req.user?.id}, cardId: ${cardId}, isFoil: ${isFoil}: ${error?.message}`
             );
             if (error instanceof HttpException) throw error;
-            return HttpErrorHandler.toHttpException(error, 'delete');
+            HttpErrorHandler.toHttpException(error, 'delete');
         }
     }
 

--- a/src/http/hbs/notification/notification-page.orchestrator.ts
+++ b/src/http/hbs/notification/notification-page.orchestrator.ts
@@ -32,7 +32,7 @@ export class NotificationPageOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building notification list: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildListView');
+            HttpErrorHandler.toHttpException(error, 'buildListView');
         }
     }
 }

--- a/src/http/hbs/optimizer/sell-optimizer.orchestrator.ts
+++ b/src/http/hbs/optimizer/sell-optimizer.orchestrator.ts
@@ -38,7 +38,7 @@ export class SellOptimizerOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building optimizer view: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildView');
+            HttpErrorHandler.toHttpException(error, 'buildView');
         }
     }
 

--- a/src/http/hbs/portfolio/portfolio.orchestrator.ts
+++ b/src/http/hbs/portfolio/portfolio.orchestrator.ts
@@ -136,7 +136,7 @@ export class PortfolioOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error getting portfolio view: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getPortfolioView');
+            HttpErrorHandler.toHttpException(error, 'getPortfolioView');
         }
     }
 
@@ -154,7 +154,7 @@ export class PortfolioOrchestrator {
             return { history: points };
         } catch (error) {
             this.LOGGER.debug(`Error getting portfolio history: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getHistory');
+            HttpErrorHandler.toHttpException(error, 'getHistory');
         }
     }
 
@@ -181,7 +181,7 @@ export class PortfolioOrchestrator {
             return { cashFlow };
         } catch (error) {
             this.LOGGER.debug(`Error getting cash flow: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getCashFlow');
+            HttpErrorHandler.toHttpException(error, 'getCashFlow');
         }
     }
 
@@ -299,7 +299,7 @@ export class PortfolioOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error getting breakdown view: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getBreakdownView');
+            HttpErrorHandler.toHttpException(error, 'getBreakdownView');
         }
     }
 
@@ -385,7 +385,7 @@ export class PortfolioOrchestrator {
             };
         } catch (error) {
             this.LOGGER.debug(`Error getting realized gains: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getRealizedGains');
+            HttpErrorHandler.toHttpException(error, 'getRealizedGains');
         }
     }
 }

--- a/src/http/hbs/price-alert/price-alert-page.orchestrator.ts
+++ b/src/http/hbs/price-alert/price-alert-page.orchestrator.ts
@@ -31,7 +31,7 @@ export class PriceAlertPageOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building price alert list: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildListView');
+            HttpErrorHandler.toHttpException(error, 'buildListView');
         }
     }
 }

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -92,7 +92,7 @@ export class PublishedDeckOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building published deck list: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildListView');
+            HttpErrorHandler.toHttpException(error, 'buildListView');
         }
     }
 
@@ -173,7 +173,7 @@ export class PublishedDeckOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error building published deck detail: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'buildDetailView');
+            HttpErrorHandler.toHttpException(error, 'buildDetailView');
         }
     }
 

--- a/src/http/hbs/sealed-product/sealed-product.orchestrator.ts
+++ b/src/http/hbs/sealed-product/sealed-product.orchestrator.ts
@@ -59,7 +59,7 @@ export class SealedProductOrchestrator {
             });
         } catch (error) {
             if (error instanceof HttpException) throw error;
-            return HttpErrorHandler.toHttpException(error, 'findSealedProduct');
+            HttpErrorHandler.toHttpException(error, 'findSealedProduct');
         }
     }
 }

--- a/src/http/hbs/search/search.orchestrator.ts
+++ b/src/http/hbs/search/search.orchestrator.ts
@@ -72,7 +72,7 @@ export class SearchOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error searching for "${term}": ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'search');
+            HttpErrorHandler.toHttpException(error, 'search');
         }
     }
 

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -71,7 +71,7 @@ export class SetOrchestrator {
             return await this.findBlockSetList(req, breadcrumbs, options, userId);
         } catch (error) {
             this.LOGGER.debug(`Error finding list of sets: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'findSetList');
+            HttpErrorHandler.toHttpException(error, 'findSetList');
         }
     }
 
@@ -176,7 +176,7 @@ export class SetOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error finding spoiler sets: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'findSpoilersList');
+            HttpErrorHandler.toHttpException(error, 'findSpoilersList');
         }
     }
 
@@ -259,7 +259,7 @@ export class SetOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Failed to find set ${setCode}: ${error?.message}.`);
-            return HttpErrorHandler.toHttpException(error, 'findBySetCodeWithPagination');
+            HttpErrorHandler.toHttpException(error, 'findBySetCodeWithPagination');
         }
     }
 
@@ -274,7 +274,7 @@ export class SetOrchestrator {
             return lastPage;
         } catch (error) {
             this.LOGGER.debug(`Error getting last page number: ${error.message}.`);
-            return HttpErrorHandler.toHttpException(error, 'getLastPage');
+            HttpErrorHandler.toHttpException(error, 'getLastPage');
         }
     }
 
@@ -294,7 +294,7 @@ export class SetOrchestrator {
             this.LOGGER.debug(
                 `Error getting last page number for cards in set ${setCode}: ${error.message}.`
             );
-            return HttpErrorHandler.toHttpException(error, 'getLastCardPage');
+            HttpErrorHandler.toHttpException(error, 'getLastCardPage');
         }
     }
 
@@ -318,7 +318,7 @@ export class SetOrchestrator {
             this.LOGGER.debug(
                 `Error adding set ${setCode} to inventory for user ${req.user?.id}: ${error?.message}`
             );
-            return HttpErrorHandler.toHttpException(error, 'addSetToInventory');
+            HttpErrorHandler.toHttpException(error, 'addSetToInventory');
         }
     }
 
@@ -328,7 +328,7 @@ export class SetOrchestrator {
             return await this.checklistService.generateChecklist(setCode, userId);
         } catch (error) {
             this.LOGGER.debug(`Error generating checklist for set ${setCode}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getChecklist');
+            HttpErrorHandler.toHttpException(error, 'getChecklist');
         }
     }
 
@@ -348,7 +348,7 @@ export class SetOrchestrator {
             this.LOGGER.debug(
                 `Error getting set ${setCode} ${includeFoil} value: ${error?.message}.`
             );
-            return HttpErrorHandler.toHttpException(error, 'getSetValue');
+            HttpErrorHandler.toHttpException(error, 'getSetValue');
         }
     }
 
@@ -369,7 +369,7 @@ export class SetOrchestrator {
             return { setCode, prices: points };
         } catch (error) {
             this.LOGGER.debug(`Error getting set price history for ${setCode}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'getSetPriceHistory');
+            HttpErrorHandler.toHttpException(error, 'getSetPriceHistory');
         }
     }
 

--- a/src/http/hbs/transaction/transaction.orchestrator.ts
+++ b/src/http/hbs/transaction/transaction.orchestrator.ts
@@ -99,7 +99,7 @@ export class TransactionOrchestrator {
             this.LOGGER.debug(
                 `Error finding transactions for user ${req.user?.id}: ${error?.message}`
             );
-            return HttpErrorHandler.toHttpException(error, 'findByUser');
+            HttpErrorHandler.toHttpException(error, 'findByUser');
         }
     }
 
@@ -184,7 +184,7 @@ export class TransactionOrchestrator {
             this.LOGGER.debug(
                 `Error importing transactions for user ${req.user?.id}: ${error?.message}`
             );
-            return HttpErrorHandler.toHttpException(error, 'importTransactions');
+            HttpErrorHandler.toHttpException(error, 'importTransactions');
         }
     }
 
@@ -240,7 +240,7 @@ export class TransactionOrchestrator {
             return await this.exportService.exportToCsv(transactions);
         } catch (error) {
             this.LOGGER.debug(`Error exporting CSV for user ${req.user?.id}: ${error?.message}`);
-            return HttpErrorHandler.toHttpException(error, 'exportCsv');
+            HttpErrorHandler.toHttpException(error, 'exportCsv');
         }
     }
 

--- a/src/http/hbs/user/user.orchestrator.ts
+++ b/src/http/hbs/user/user.orchestrator.ts
@@ -220,7 +220,7 @@ export class UserOrchestrator {
             return authToken;
         } catch (error) {
             this.LOGGER.debug(`Error creating user with email: ${createUserDto.email}.`);
-            return HttpErrorHandler.toHttpException(error, 'create');
+            HttpErrorHandler.toHttpException(error, 'create');
         }
     }
 
@@ -248,7 +248,7 @@ export class UserOrchestrator {
             };
         } catch (error) {
             this.LOGGER.debug(`Error finding user ${userId}.`);
-            return HttpErrorHandler.toHttpException(error, 'findUser');
+            HttpErrorHandler.toHttpException(error, 'findUser');
         }
     }
 
@@ -305,7 +305,7 @@ export class UserOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error updating user ${userId}.`);
-            return HttpErrorHandler.toHttpException(error, 'findUser');
+            HttpErrorHandler.toHttpException(error, 'findUser');
         }
     }
 
@@ -334,7 +334,7 @@ export class UserOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error updating password for user ${userId}.`);
-            return HttpErrorHandler.toHttpException(error, 'updatePassword');
+            HttpErrorHandler.toHttpException(error, 'updatePassword');
         }
     }
 
@@ -357,7 +357,7 @@ export class UserOrchestrator {
             });
         } catch (error) {
             this.LOGGER.debug(`Error deleting user ${userId}.`);
-            return HttpErrorHandler.toHttpException(error, 'deleteUser');
+            HttpErrorHandler.toHttpException(error, 'deleteUser');
         }
     }
 }

--- a/src/http/http.error.handler.ts
+++ b/src/http/http.error.handler.ts
@@ -14,6 +14,30 @@ import {
 import { getLogger } from 'src/logger/global-app-logger';
 import { AuthenticatedRequest } from './base/authenticated.request';
 
+/**
+ * Maps a thrown value to the HttpException it should be presented as: an existing
+ * HttpException passes through, a Domain*Error maps to the matching status
+ * (preserving its user-facing message), and anything else returns null (a
+ * genuinely unexpected error the caller should treat as a 500). Single source of
+ * truth for the domain-error → HTTP mapping, shared by the orchestrator handler
+ * below and the global HttpExceptionFilter.
+ */
+export function domainErrorToHttpException(error: unknown): HttpException | null {
+    if (error instanceof HttpException) {
+        return error;
+    }
+    if (error instanceof DomainNotFoundError) {
+        return new NotFoundException(error.message);
+    }
+    if (error instanceof DomainNotAuthorizedError) {
+        return new ForbiddenException(error.message);
+    }
+    if (error instanceof DomainValidationError) {
+        return new BadRequestException(error.message);
+    }
+    return null;
+}
+
 export class HttpErrorHandler {
     private static readonly LOGGER = getLogger(HttpErrorHandler.name);
 
@@ -25,23 +49,13 @@ export class HttpErrorHandler {
      */
     static toHttpException(error: Error, context: string): never {
         this.LOGGER.error(`Error in ${context}: ${error.message}`, error.stack);
-        // An HttpException thrown inside the try block (e.g. an auth guard's
-        // UnauthorizedException) is already the intended response — pass it
-        // through. This must come first: without it the keyword fallback below
-        // re-mapped a 401 "User not found in request" to a 404 (W1/B1).
-        if (error instanceof HttpException) {
-            throw error;
-        }
-        // Domain errors are the single convention for core failures. Map them to
-        // the matching HTTP status, preserving the (user-facing) domain message.
-        if (error instanceof DomainNotFoundError) {
-            throw new NotFoundException(error.message);
-        }
-        if (error instanceof DomainNotAuthorizedError) {
-            throw new ForbiddenException(error.message);
-        }
-        if (error instanceof DomainValidationError) {
-            throw new BadRequestException(error.message);
+        // An existing HttpException (e.g. an auth guard's UnauthorizedException)
+        // or a Domain*Error maps directly. HttpException passthrough must come
+        // first: without it the keyword fallback below re-mapped a 401 "User not
+        // found in request" to a 404 (W1/B1).
+        const mapped = domainErrorToHttpException(error);
+        if (mapped) {
+            throw mapped;
         }
         // Transitional fallback for core services not yet migrated to Domain
         // errors (W1). Once every service throws Domain*Error, delete this block

--- a/src/http/http.error.handler.ts
+++ b/src/http/http.error.handler.ts
@@ -1,10 +1,16 @@
 import {
     BadRequestException,
     ForbiddenException,
+    HttpException,
     InternalServerErrorException,
     NotFoundException,
     UnauthorizedException,
 } from '@nestjs/common';
+import {
+    DomainNotAuthorizedError,
+    DomainNotFoundError,
+    DomainValidationError,
+} from 'src/core/errors/domain.errors';
 import { getLogger } from 'src/logger/global-app-logger';
 import { AuthenticatedRequest } from './base/authenticated.request';
 
@@ -19,6 +25,27 @@ export class HttpErrorHandler {
      */
     static toHttpException(error: Error, context: string): never {
         this.LOGGER.error(`Error in ${context}: ${error.message}`, error.stack);
+        // An HttpException thrown inside the try block (e.g. an auth guard's
+        // UnauthorizedException) is already the intended response — pass it
+        // through. This must come first: without it the keyword fallback below
+        // re-mapped a 401 "User not found in request" to a 404 (W1/B1).
+        if (error instanceof HttpException) {
+            throw error;
+        }
+        // Domain errors are the single convention for core failures. Map them to
+        // the matching HTTP status, preserving the (user-facing) domain message.
+        if (error instanceof DomainNotFoundError) {
+            throw new NotFoundException(error.message);
+        }
+        if (error instanceof DomainNotAuthorizedError) {
+            throw new ForbiddenException(error.message);
+        }
+        if (error instanceof DomainValidationError) {
+            throw new BadRequestException(error.message);
+        }
+        // Transitional fallback for core services not yet migrated to Domain
+        // errors (W1). Once every service throws Domain*Error, delete this block
+        // so unmapped errors are honestly a 500.
         if (error.message.includes('not found')) {
             throw new NotFoundException(error.message);
         }

--- a/src/http/http.exception.filter.ts
+++ b/src/http/http.exception.filter.ts
@@ -1,6 +1,5 @@
 import {
     ArgumentsHost,
-    BadRequestException,
     Catch,
     ExceptionFilter,
     ForbiddenException,
@@ -10,12 +9,8 @@ import {
     UnauthorizedException,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import {
-    DomainNotAuthorizedError,
-    DomainNotFoundError,
-    DomainValidationError,
-} from 'src/core/errors/domain.errors';
 import { getLogger } from 'src/logger/global-app-logger';
+import { domainErrorToHttpException } from './http.error.handler';
 import { InvalidQueryParamException } from './api/shared/query-validation';
 import { ApiResponseDto } from './base/api-response.dto';
 import { LoginFormViewDto } from './hbs/auth/dto/login-form.view.dto';
@@ -35,8 +30,10 @@ export class HttpExceptionFilter implements ExceptionFilter {
         // Normalize domain errors (and pass HttpExceptions through) so API
         // controllers that throw Domain*Error get the right status without a
         // per-controller catch. A null result is a genuinely unexpected error:
-        // it becomes a 500 whose message is never exposed to the client (B9).
-        const httpException = this.toHttpException(exception);
+        // it drives a 500 on the API and page branches (its message is never
+        // exposed to the client - B9); the form-route branch re-renders the form
+        // with a 200 regardless (see handleFormError).
+        const httpException = domainErrorToHttpException(exception);
         const status: number = httpException
             ? httpException.getStatus()
             : HttpStatus.INTERNAL_SERVER_ERROR;
@@ -66,27 +63,6 @@ export class HttpExceptionFilter implements ExceptionFilter {
                     httpException instanceof UnauthorizedException ? request.url : undefined,
             });
         }
-    }
-
-    /**
-     * Maps an arbitrary thrown value to the HttpException it should be presented
-     * as: an existing HttpException passes through, a Domain*Error maps to the
-     * matching status, and anything else returns null (an unexpected 500).
-     */
-    private toHttpException(exception: unknown): HttpException | null {
-        if (exception instanceof HttpException) {
-            return exception;
-        }
-        if (exception instanceof DomainNotFoundError) {
-            return new NotFoundException(exception.message);
-        }
-        if (exception instanceof DomainNotAuthorizedError) {
-            return new ForbiddenException(exception.message);
-        }
-        if (exception instanceof DomainValidationError) {
-            return new BadRequestException(exception.message);
-        }
-        return null;
     }
 
     private isApiRequest(request: Request): boolean {

--- a/src/http/http.exception.filter.ts
+++ b/src/http/http.exception.filter.ts
@@ -1,5 +1,6 @@
 import {
     ArgumentsHost,
+    BadRequestException,
     Catch,
     ExceptionFilter,
     ForbiddenException,
@@ -9,6 +10,11 @@ import {
     UnauthorizedException,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
+import {
+    DomainNotAuthorizedError,
+    DomainNotFoundError,
+    DomainValidationError,
+} from 'src/core/errors/domain.errors';
 import { getLogger } from 'src/logger/global-app-logger';
 import { InvalidQueryParamException } from './api/shared/query-validation';
 import { ApiResponseDto } from './base/api-response.dto';
@@ -26,12 +32,19 @@ export class HttpExceptionFilter implements ExceptionFilter {
         const ctx = host.switchToHttp();
         const response = ctx.getResponse<Response>();
         const request = ctx.getRequest<Request>();
-        const isHttpException = exception instanceof HttpException;
-        const status: number = isHttpException
-            ? exception.getStatus()
+        // Normalize domain errors (and pass HttpExceptions through) so API
+        // controllers that throw Domain*Error get the right status without a
+        // per-controller catch. A null result is a genuinely unexpected error:
+        // it becomes a 500 whose message is never exposed to the client (B9).
+        const httpException = this.toHttpException(exception);
+        const status: number = httpException
+            ? httpException.getStatus()
             : HttpStatus.INTERNAL_SERVER_ERROR;
+        const clientMessage: string = httpException
+            ? httpException.message
+            : 'Internal Server Error';
         if (this.isApiRequest(request)) {
-            const body = ApiResponseDto.error(exception.message || 'Internal Server Error');
+            const body = ApiResponseDto.error(clientMessage);
             if (exception instanceof InvalidQueryParamException) {
                 response.status(status).json({
                     ...body,
@@ -42,16 +55,38 @@ export class HttpExceptionFilter implements ExceptionFilter {
                 response.status(status).json(body);
             }
         } else if (this.isFormRoute(request.url)) {
-            this.handleFormError(response, request, exception);
+            this.handleFormError(response, request, httpException, clientMessage);
         } else {
-            const template = this.getErrorTemplate(exception);
+            const template = this.getErrorTemplate(httpException);
             response.status(status).render(template, {
-                toast: new Toast(exception.message || 'Internal Server Error', ActionStatus.ERROR),
+                toast: new Toast(clientMessage, ActionStatus.ERROR),
                 statusCode: status,
                 authenticated: false,
-                returnUrl: exception instanceof UnauthorizedException ? request.url : undefined,
+                returnUrl:
+                    httpException instanceof UnauthorizedException ? request.url : undefined,
             });
         }
+    }
+
+    /**
+     * Maps an arbitrary thrown value to the HttpException it should be presented
+     * as: an existing HttpException passes through, a Domain*Error maps to the
+     * matching status, and anything else returns null (an unexpected 500).
+     */
+    private toHttpException(exception: unknown): HttpException | null {
+        if (exception instanceof HttpException) {
+            return exception;
+        }
+        if (exception instanceof DomainNotFoundError) {
+            return new NotFoundException(exception.message);
+        }
+        if (exception instanceof DomainNotAuthorizedError) {
+            return new ForbiddenException(exception.message);
+        }
+        if (exception instanceof DomainValidationError) {
+            return new BadRequestException(exception.message);
+        }
+        return null;
     }
 
     private isApiRequest(request: Request): boolean {
@@ -71,9 +106,14 @@ export class HttpExceptionFilter implements ExceptionFilter {
         );
     }
 
-    private handleFormError(response: Response, request: Request, exception: any): void {
-        let errorMessage = exception.message || 'An error occurred';
-        if (exception instanceof UnauthorizedException) {
+    private handleFormError(
+        response: Response,
+        request: Request,
+        httpException: HttpException | null,
+        clientMessage: string
+    ): void {
+        let errorMessage = clientMessage;
+        if (httpException instanceof UnauthorizedException) {
             errorMessage = 'Invalid email or password';
         }
         if (request.url.includes('/user/create')) {
@@ -113,7 +153,7 @@ export class HttpExceptionFilter implements ExceptionFilter {
         });
     }
 
-    private getErrorTemplate(exception: HttpException): string {
+    private getErrorTemplate(exception: HttpException | null): string {
         if (exception instanceof NotFoundException) {
             return 'errors/404';
         }

--- a/test/core/deck/deck.service.spec.ts
+++ b/test/core/deck/deck.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { DomainNotFoundError, DomainValidationError } from 'src/core/errors/domain.errors';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Format } from 'src/core/card/format.enum';
 import { Deck } from 'src/core/deck/deck.entity';
@@ -51,7 +51,7 @@ describe('DeckService', () => {
             expect(deck.format).toBe(Format.Modern);
         });
         it('throws BadRequest (400) on an empty name', async () => {
-            await expect(service.createDeck(7, '   ')).rejects.toBeInstanceOf(BadRequestException);
+            await expect(service.createDeck(7, '   ')).rejects.toBeInstanceOf(DomainValidationError);
             expect(repo.create).not.toHaveBeenCalled();
         });
     });
@@ -65,7 +65,7 @@ describe('DeckService', () => {
         it('throws NotFound when the deck is not the user’s', async () => {
             repo.getOwnerId.mockResolvedValue(99);
             await expect(service.addCard(1, 7, 'card-1', false, 1)).rejects.toBeInstanceOf(
-                NotFoundException
+                DomainNotFoundError
             );
             expect(repo.addCard).not.toHaveBeenCalled();
         });
@@ -93,7 +93,7 @@ describe('DeckService', () => {
     describe('deleteDeck', () => {
         it('throws NotFound when not the owner', async () => {
             repo.getOwnerId.mockResolvedValue(99);
-            await expect(service.deleteDeck(1, 7)).rejects.toBeInstanceOf(NotFoundException);
+            await expect(service.deleteDeck(1, 7)).rejects.toBeInstanceOf(DomainNotFoundError);
             expect(repo.delete).not.toHaveBeenCalled();
         });
         it('deletes when the owner', async () => {

--- a/test/http/http.error.handler.spec.ts
+++ b/test/http/http.error.handler.spec.ts
@@ -23,7 +23,16 @@ describe('HttpErrorHandler.toHttpException', () => {
     // redirect.
     it('rethrows an existing HttpException unchanged', () => {
         const unauthorized = new UnauthorizedException('User not found in request');
-        expect(call(unauthorized)).toThrow(unauthorized);
+        try {
+            HttpErrorHandler.toHttpException(unauthorized, 'test');
+            fail('expected toHttpException to throw');
+        } catch (e) {
+            // Assert the exact instance/class, not just the message: a message
+            // match would still pass if the 401 were remapped to a 404
+            // NotFoundException('User not found in request') - the B1 regression.
+            expect(e).toBe(unauthorized);
+            expect(e).toBeInstanceOf(UnauthorizedException);
+        }
     });
 
     it('maps DomainNotFoundError to 404', () => {

--- a/test/http/http.error.handler.spec.ts
+++ b/test/http/http.error.handler.spec.ts
@@ -1,0 +1,58 @@
+import {
+    BadRequestException,
+    ForbiddenException,
+    HttpException,
+    InternalServerErrorException,
+    NotFoundException,
+    UnauthorizedException,
+} from '@nestjs/common';
+import {
+    DomainNotAuthorizedError,
+    DomainNotFoundError,
+    DomainValidationError,
+} from 'src/core/errors/domain.errors';
+import { HttpErrorHandler } from 'src/http/http.error.handler';
+
+describe('HttpErrorHandler.toHttpException', () => {
+    const call = (error: Error) => () => HttpErrorHandler.toHttpException(error, 'test');
+
+    // Regression for B1: an HttpException thrown inside an orchestrator try block
+    // (e.g. validateAuthenticatedRequest's UnauthorizedException) must be
+    // rethrown unchanged, not re-mapped by message. Previously the 'not found'
+    // in "User not found in request" turned a 401 into a 404, breaking the login
+    // redirect.
+    it('rethrows an existing HttpException unchanged', () => {
+        const unauthorized = new UnauthorizedException('User not found in request');
+        expect(call(unauthorized)).toThrow(unauthorized);
+    });
+
+    it('maps DomainNotFoundError to 404', () => {
+        expect(call(new DomainNotFoundError('Set X not found'))).toThrow(NotFoundException);
+    });
+
+    it('maps DomainNotAuthorizedError to 403', () => {
+        expect(call(new DomainNotAuthorizedError('Not your deck'))).toThrow(ForbiddenException);
+    });
+
+    it('maps DomainValidationError to 400', () => {
+        expect(call(new DomainValidationError('Name is required'))).toThrow(BadRequestException);
+    });
+
+    it('preserves the domain error message on the mapped exception', () => {
+        try {
+            HttpErrorHandler.toHttpException(new DomainValidationError('Name is required'), 'test');
+        } catch (e) {
+            expect((e as HttpException).message).toBe('Name is required');
+        }
+    });
+
+    it('maps an unknown error to a 500 without leaking its message', () => {
+        try {
+            HttpErrorHandler.toHttpException(new Error('DB connection string is postgres://secret'), 'test');
+            fail('expected throw');
+        } catch (e) {
+            expect(e).toBeInstanceOf(InternalServerErrorException);
+            expect((e as HttpException).message).toBe('An unexpected error occurred');
+        }
+    });
+});

--- a/test/http/http.exception.filter.spec.ts
+++ b/test/http/http.exception.filter.spec.ts
@@ -1,0 +1,87 @@
+import { ArgumentsHost, UnauthorizedException } from '@nestjs/common';
+import { DomainNotFoundError, DomainValidationError } from 'src/core/errors/domain.errors';
+import { HttpExceptionFilter } from 'src/http/http.exception.filter';
+
+type Rendered = { status: number; template?: string; json?: any; view?: any };
+
+function hostFor(url: string, headers: Record<string, string> = {}): {
+    host: ArgumentsHost;
+    result: Rendered;
+} {
+    const result: Rendered = { status: 0 };
+    const response = {
+        status(code: number) {
+            result.status = code;
+            return this;
+        },
+        json(body: any) {
+            result.json = body;
+            return this;
+        },
+        render(template: string, view: any) {
+            result.template = template;
+            result.view = view;
+            return this;
+        },
+    };
+    const request = { url, headers, body: {} };
+    const host = {
+        switchToHttp: () => ({
+            getResponse: () => response,
+            getRequest: () => request,
+        }),
+    } as unknown as ArgumentsHost;
+    return { host, result };
+}
+
+describe('HttpExceptionFilter', () => {
+    const filter = new HttpExceptionFilter();
+
+    describe('API requests (JSON)', () => {
+        it('maps a DomainNotFoundError to 404 with its message', () => {
+            const { host, result } = hostFor('/api/v1/cards/x');
+            filter.catch(new DomainNotFoundError('Card x not found'), host);
+            expect(result.status).toBe(404);
+            expect(result.json.error).toBe('Card x not found');
+        });
+
+        it('maps a DomainValidationError to 400', () => {
+            const { host, result } = hostFor('/api/v1/decks');
+            filter.catch(new DomainValidationError('Name is required'), host);
+            expect(result.status).toBe(400);
+            expect(result.json.error).toBe('Name is required');
+        });
+
+        it('returns a generic 500 body for an unexpected error (no leak)', () => {
+            const { host, result } = hostFor('/api/v1/cards');
+            filter.catch(new Error('connect ECONNREFUSED 10.0.0.5:5432'), host);
+            expect(result.status).toBe(500);
+            expect(result.json.error).toBe('Internal Server Error');
+        });
+    });
+
+    describe('page requests (HBS)', () => {
+        it('renders errors/404 for a DomainNotFoundError', () => {
+            const { host, result } = hostFor('/sets/xyz');
+            filter.catch(new DomainNotFoundError('Set xyz not found'), host);
+            expect(result.status).toBe(404);
+            expect(result.template).toBe('errors/404');
+        });
+
+        it('renders errors/401 with returnUrl for an UnauthorizedException', () => {
+            const { host, result } = hostFor('/inventory');
+            filter.catch(new UnauthorizedException('not logged in'), host);
+            expect(result.status).toBe(401);
+            expect(result.template).toBe('errors/401');
+            expect(result.view.returnUrl).toBe('/inventory');
+        });
+
+        it('renders errors/500 with a generic toast for an unexpected error (no leak)', () => {
+            const { host, result } = hostFor('/sets');
+            filter.catch(new Error('secret db dsn postgres://u:p@h/db'), host);
+            expect(result.status).toBe(500);
+            expect(result.template).toBe('errors/500');
+            expect(result.view.toast.message).toBe('Internal Server Error');
+        });
+    });
+});


### PR DESCRIPTION
Work package **W1** from the July 2026 cross-repo analysis (Priority 1). First part of the error-handling overhaul — the boundary + convention, with **no behavior regression**.

## What this fixes
- **B1 (High):** `HttpErrorHandler.toHttpException` mapped errors by substring-matching message strings. A `401 UnauthorizedException` thrown inside an orchestrator `try` (e.g. `validateAuthenticatedRequest`'s "User **not found** in request") matched `'not found'` first and was rethrown as **404**, so the exception filter never set `returnUrl` for the login redirect. Now an existing `HttpException` is rethrown unchanged first, then `Domain*Error` is mapped by type.
- **B9 (part):** the global filter no longer leaks internal error text on unexpected 500s — clients get a generic `Internal Server Error`; the full stack is still logged server-side.
- **A1:** `deck.service` now throws `Domain*Error` instead of Nest HTTP exceptions (keeps the 404-for-not-owned resource-hiding via `DomainNotFoundError`).
- **A9:** dropped the `return` from the `never`-returning `toHttpException` calls in 14 orchestrators.

## Design notes
- `HttpExceptionFilter` maps `Domain*Error` → status/template centrally, so API controllers and pages get correct codes without per-controller catches.
- **Keyword matching is kept as an explicitly-transitional fallback** so core services not yet migrated to `Domain*Error` don't regress to 500s. It's deleted once migration completes.
- Per-controller `instanceof` blocks (api-key / price-alert / price-notification) are **left intact** — they also customize user-facing messages, so removing them isn't purely mechanical.

## Tests
- New unit specs: `test/http/http.error.handler.spec.ts`, `test/http/http.exception.filter.spec.ts` (domain mapping, HttpException passthrough, no-leak 500).
- Updated `deck.service.spec` to assert domain error types.
- Full suite green: **115 suites / 1378 tests**, `tsc --noEmit` clean.

## Remaining W1 (follow-up PR)
- Remove catch-wrap-rethrow boilerplate (**A2**) across `card`/`transaction`/`set`/etc. and migrate their genuine domain conditions to `Domain*Error`.
- Then delete the transitional keyword fallback.
- **X6:** verify MCP `extractApiMessage` and mobile `errMessage` against the new API error bodies (no client change expected).

Also bundles the ROADMAP **Phase 11** tracker (separate commit) per the plan to keep the roadmap as the central reference.

Refs #569