### PR TITLE
refactor: remove A2 catch-wrap-rethrow + migrate core services to Domain errors (W1 part 2)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -264,7 +264,7 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 
 **Done so far:** W9 ([#577](https://github.com/matthewdtowles/i-want-my-mtg/issues/577), ON DELETE CASCADE migration, PR #578), S1 ([scry#35](https://github.com/matthewdtowles/scry/issues/35), post-ingest-prune foreignness), and — 2026-07-09 — MB1 ([#63](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63), mobile PR #70) + MB2 ([#64](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64), mobile PR #71). 24 issues remain.
 
-**In flight (2026-07-09):** W1 **part 1** (web PR #579). W1 is being split: PR #579 lands the boundary + convention (B1/B9/A1/A9); the A2 catch-wrap-rethrow cleanup + keyword-fallback removal is a follow-up, so #569 stays open until then.
+**In flight (2026-07-09):** W1 is being delivered in three parts — **part 1** (PR #579): the boundary + convention (B1/B9/A1/A9); **part 2** (stacked PR): remove A2 catch-wrap-rethrow + migrate the core services (card/set/transaction/user/validation/set-checklist) to `Domain*Error`; **part 3** (remaining): migrate the HBS orchestrators/presenters off plain keyword-significant Errors, then delete the transitional keyword fallback in `toHttpException`. #569 stays open until part 3 lands.
 
 ### Cross-repo hard orderings (everything else is repo-local and parallelizable)
 
@@ -282,7 +282,7 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 |---|---|---|---|
 | ~~MB1~~ | mobile | Clear query cache on sign-out (cross-account data leak) | ✅ **done** (PR #70) |
 | ~~MB2~~ | mobile | Decouple CI spec-drift check from PR gating | ✅ **done** (PR #71); unblocked W8 (X3/X4) |
-| [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | web | Error handling overhaul: domain errors end to end | Foundational; X6 verifies after — **part 1 in PR #579**, A2 remainder to follow |
+| [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | web | Error handling overhaul: domain errors end to end | Foundational; X6 verifies after — **parts 1 (#579) + 2 in PRs**, part 3 (http-layer + fallback removal) to follow |
 | [W2](https://github.com/matthewdtowles/i-want-my-mtg/issues/570) | web | Inventory/ledger integrity: transactional writes, fix silent failures | |
 | [S2](https://github.com/matthewdtowles/scry/issues/36) | scry | Delete/reset FK coverage; remove fake CASCADE | Unblocked by W9 (X1) |
 | [S3](https://github.com/matthewdtowles/scry/issues/37) | scry | Ingest robustness: stream failures, non-TTY prompts, batch/mapping bugs | |

--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -22,42 +22,26 @@ export class CardService {
 
     async findByIds(ids: string[]): Promise<Card[]> {
         this.LOGGER.debug(`Find ${ids.length} cards by ids.`);
-        try {
-            return await this.repository.findByIds(ids);
-        } catch (error) {
-            throw new Error(`Error finding cards by ids: ${error.message}`);
-        }
+        return this.repository.findByIds(ids);
     }
 
     async findByIdsWithPrices(ids: string[]): Promise<Card[]> {
         this.LOGGER.debug(`Find ${ids.length} cards by ids with latest prices.`);
-        try {
-            return await this.repository.findByIds(ids, { includeLatestPrice: true });
-        } catch (error) {
-            throw new Error(`Error finding cards by ids with prices: ${error.message}`);
-        }
+        return this.repository.findByIds(ids, { includeLatestPrice: true });
     }
 
     async findWithName(name: string, options: SafeQueryOptions): Promise<Card[]> {
         this.LOGGER.debug(`Find cards with name ${name}.`);
-        try {
-            const cards = await this.repository.findWithName(name, options);
-            this.LOGGER.debug(`Found ${cards?.length} with name ${name}.`);
-            return cards;
-        } catch (error) {
-            throw new Error(`Error finding cards with name ${name}: ${error.message}`);
-        }
+        const cards = await this.repository.findWithName(name, options);
+        this.LOGGER.debug(`Found ${cards?.length} with name ${name}.`);
+        return cards;
     }
 
     async findBySet(code: string, query: SafeQueryOptions): Promise<Card[]> {
         this.LOGGER.debug(`Find cards in set ${code}.`);
-        try {
-            const cards = await this.repository.findBySet(code, query);
-            this.LOGGER.debug(`Found ${cards?.length} in set ${code}.`);
-            return cards;
-        } catch (error) {
-            throw new Error(`Error finding cards in set ${code}: ${error.message}`);
-        }
+        const cards = await this.repository.findBySet(code, query);
+        this.LOGGER.debug(`Found ${cards?.length} in set ${code}.`);
+        return cards;
     }
 
     async findBySetCodeAndNumber(code: string, number: string): Promise<Card | null> {
@@ -65,103 +49,61 @@ export class CardService {
         // so normalize here (one place for every caller — REST/MCP/HBS).
         code = code?.trim().toLowerCase();
         this.LOGGER.debug(`Find card no. ${number} in set ${code}.`);
-        try {
-            const card = await this.repository.findBySetCodeAndNumber(code, number, [
-                'set',
-                'legalities',
-                'prices',
-            ]);
-            this.LOGGER.debug(
-                `Card no. ${number} in set ${code}: ${card ? card.id : 'Not found'}.`
-            );
-            return card;
-        } catch (error) {
-            throw new Error(
-                `Error finding card with set code ${code} and number ${number}: ${error.message}`
-            );
-        }
+        const card = await this.repository.findBySetCodeAndNumber(code, number, [
+            'set',
+            'legalities',
+            'prices',
+        ]);
+        this.LOGGER.debug(`Card no. ${number} in set ${code}: ${card ? card.id : 'Not found'}.`);
+        return card;
     }
 
     async totalWithName(name: string): Promise<number> {
         this.LOGGER.debug(`Find total number of cards with name ${name}.`);
-        try {
-            const total = await this.repository.totalWithName(name);
-            this.LOGGER.debug(`Total cards with name ${name}: ${total}.`);
-            return total;
-        } catch (error) {
-            throw new Error(`Error counting cards with name ${name}: ${error.message}`);
-        }
+        const total = await this.repository.totalWithName(name);
+        this.LOGGER.debug(`Total cards with name ${name}: ${total}.`);
+        return total;
     }
 
     async searchByName(filter: string, options: SafeQueryOptions): Promise<Card[]> {
         this.LOGGER.debug(`Search cards by name: ${filter}.`);
-        try {
-            return await this.repository.searchByName(filter, options);
-        } catch (error) {
-            throw new Error(`Error searching cards by name "${filter}": ${error.message}`);
-        }
+        return this.repository.searchByName(filter, options);
     }
 
     async totalSearchByName(filter: string, options?: SafeQueryOptions): Promise<number> {
         this.LOGGER.debug(`Count search results for: ${filter}.`);
-        try {
-            return await this.repository.totalSearchByName(filter, options);
-        } catch (error) {
-            throw new Error(`Error counting card search results for "${filter}": ${error.message}`);
-        }
+        return this.repository.totalSearchByName(filter, options);
     }
 
     async searchByNameGrouped(filter: string, options: SafeQueryOptions): Promise<Card[]> {
         this.LOGGER.debug(`Grouped search cards by name: ${filter}.`);
-        try {
-            return await this.repository.searchByNameGrouped(filter, options);
-        } catch (error) {
-            throw new Error(`Error grouped-searching cards by name "${filter}": ${error.message}`);
-        }
+        return this.repository.searchByNameGrouped(filter, options);
     }
 
     async totalSearchByNameGrouped(filter: string, options?: SafeQueryOptions): Promise<number> {
         this.LOGGER.debug(`Count grouped search results for: ${filter}.`);
-        try {
-            return await this.repository.totalSearchByNameGrouped(filter, options);
-        } catch (error) {
-            throw new Error(
-                `Error counting grouped card search results for "${filter}": ${error.message}`
-            );
-        }
+        return this.repository.totalSearchByNameGrouped(filter, options);
     }
 
     async totalInSet(code: string, options: SafeQueryOptions): Promise<number> {
         this.LOGGER.debug(
             `Find total number of cards in set ${code}, options: ${JSON.stringify(options)}.`
         );
-        try {
-            const total = await this.repository.totalInSet(code, options);
-            this.LOGGER.debug(`Total cards in set ${code}: ${total}.`);
-            return total;
-        } catch (error) {
-            throw new Error(`Error counting cards in set ${code}: ${error.message}`);
-        }
+        const total = await this.repository.totalInSet(code, options);
+        this.LOGGER.debug(`Total cards in set ${code}: ${total}.`);
+        return total;
     }
 
     async findPriceHistory(cardId: string, days?: number): Promise<Price[]> {
         this.LOGGER.debug(`Find price history for card ${cardId}, days=${days}.`);
-        try {
-            const prices = await this.priceHistoryRepository.findByCardId(cardId, days);
-            this.LOGGER.debug(`Found ${prices?.length} price history records for card ${cardId}.`);
-            return prices;
-        } catch (error) {
-            throw new Error(`Error finding price history for card ${cardId}: ${error.message}`);
-        }
+        const prices = await this.priceHistoryRepository.findByCardId(cardId, days);
+        this.LOGGER.debug(`Found ${prices?.length} price history records for card ${cardId}.`);
+        return prices;
     }
 
     async findCurrentBuylist(cardId: string): Promise<GranularPrice[]> {
         this.LOGGER.debug(`Find current buylist for card ${cardId}.`);
-        try {
-            return await this.granularPriceRepository.findCurrentBuylistByCardId(cardId);
-        } catch (error) {
-            throw new Error(`Error finding buylist for card ${cardId}: ${error.message}`);
-        }
+        return this.granularPriceRepository.findCurrentBuylistByCardId(cardId);
     }
 
     /**
@@ -176,20 +118,15 @@ export class CardService {
         if (cardIds.length === 0) {
             return grouped;
         }
-        try {
-            const offers =
-                await this.granularPriceRepository.findCurrentBuylistByCardIds(cardIds);
-            for (const offer of offers) {
-                const list = grouped.get(offer.cardId);
-                if (list) {
-                    list.push(offer);
-                } else {
-                    grouped.set(offer.cardId, [offer]);
-                }
+        const offers = await this.granularPriceRepository.findCurrentBuylistByCardIds(cardIds);
+        for (const offer of offers) {
+            const list = grouped.get(offer.cardId);
+            if (list) {
+                list.push(offer);
+            } else {
+                grouped.set(offer.cardId, [offer]);
             }
-            return grouped;
-        } catch (error) {
-            throw new Error(`Error finding buylist for cards: ${error.message}`);
         }
+        return grouped;
     }
 }

--- a/src/core/set/checklist/set-checklist.service.ts
+++ b/src/core/set/checklist/set-checklist.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { stringify } from 'csv-stringify';
 import { CardRepositoryPort } from 'src/core/card/ports/card.repository.port';
+import { DomainNotFoundError } from 'src/core/errors/domain.errors';
 import { Inventory } from 'src/core/inventory/inventory.entity';
 import { InventoryRepositoryPort } from 'src/core/inventory/ports/inventory.repository.port';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
@@ -24,7 +25,7 @@ export class SetChecklistService {
         this.LOGGER.debug(`generateChecklist for set ${setCode}, user ${userId}.`);
 
         const set = await this.setRepository.findByCode(setCode);
-        if (!set) throw new Error(`Set not found: ${setCode}`);
+        if (!set) throw new DomainNotFoundError(`Set not found: ${setCode}`);
 
         const allOptions = new SafeQueryOptions({ limit: '10000' });
         const cards = await this.cardRepository.findBySet(setCode, allOptions.withBaseOnly(false));

--- a/src/core/set/set.service.ts
+++ b/src/core/set/set.service.ts
@@ -60,31 +60,19 @@ export class SetService {
 
     async searchSets(filter: string, options: SafeQueryOptions): Promise<Set[]> {
         this.LOGGER.debug(`Search sets: ${filter}.`);
-        try {
-            return await this.repository.searchSets(filter, options);
-        } catch (error) {
-            throw new Error(`Error searching sets for "${filter}": ${error.message}`);
-        }
+        return this.repository.searchSets(filter, options);
     }
 
     async totalSearchSets(filter: string): Promise<number> {
         this.LOGGER.debug(`Count set search results for: ${filter}.`);
-        try {
-            return await this.repository.totalSearchSets(filter);
-        } catch (error) {
-            throw new Error(`Error counting set search results for "${filter}": ${error.message}`);
-        }
+        return this.repository.totalSearchSets(filter);
     }
 
     async totalCardsInSet(setCode: string, options: SafeQueryOptions): Promise<number> {
         this.LOGGER.debug(`Find total number of cards in set ${setCode}.`);
-        try {
-            const total = await this.repository.totalInSet(setCode, options);
-            this.LOGGER.debug(`Total cards in set ${setCode}: ${total}.`);
-            return total;
-        } catch (error) {
-            throw new Error(`Error counting cards in set ${setCode}: ${error.message}`);
-        }
+        const total = await this.repository.totalInSet(setCode, options);
+        this.LOGGER.debug(`Total cards in set ${setCode}: ${total}.`);
+        return total;
     }
 
     async totalValueForSet(
@@ -95,29 +83,17 @@ export class SetService {
         this.LOGGER.debug(
             `Get total value of cards in set ${setCode} ${includeFoil ? 'with foils' : ''}, baseOnly: ${options.baseOnly}.`
         );
-        try {
-            const total = await this.repository.totalValueForSet(setCode, includeFoil, options);
-            this.LOGGER.debug(
-                `Total value for set ${setCode} ${includeFoil ? 'with foils' : ''}: ${total}.`
-            );
-            return total;
-        } catch (error) {
-            throw new Error(
-                `Error getting total value of ${includeFoil ? '' : 'non-foil '}cards for set ${setCode}: ${error.message}.`
-            );
-        }
+        const total = await this.repository.totalValueForSet(setCode, includeFoil, options);
+        this.LOGGER.debug(
+            `Total value for set ${setCode} ${includeFoil ? 'with foils' : ''}: ${total}.`
+        );
+        return total;
     }
 
     async findSetPriceHistory(setCode: string, days?: number): Promise<SetPriceHistory[]> {
         this.LOGGER.debug(`Find set price history for set ${setCode}, days=${days}.`);
-        try {
-            const prices = await this.priceHistoryRepository.findBySetCode(setCode, days);
-            this.LOGGER.debug(
-                `Found ${prices?.length} set price history records for set ${setCode}.`
-            );
-            return prices;
-        } catch (error) {
-            throw new Error(`Error finding set price history for set ${setCode}: ${error.message}`);
-        }
+        const prices = await this.priceHistoryRepository.findBySetCode(setCode, days);
+        this.LOGGER.debug(`Found ${prices?.length} set price history records for set ${setCode}.`);
+        return prices;
     }
 }

--- a/src/core/transaction/transaction.service.ts
+++ b/src/core/transaction/transaction.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { DomainNotFoundError, DomainValidationError } from 'src/core/errors/domain.errors';
 import { Inventory } from 'src/core/inventory/inventory.entity';
 import { InventoryService } from 'src/core/inventory/inventory.service';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
@@ -42,13 +43,13 @@ export class TransactionService {
         );
 
         if (transaction.quantity <= 0) {
-            throw new Error('Transaction quantity must be positive.');
+            throw new DomainValidationError('Transaction quantity must be positive.');
         }
         if (transaction.pricePerUnit < 0) {
-            throw new Error('Price per unit cannot be negative.');
+            throw new DomainValidationError('Price per unit cannot be negative.');
         }
         if (transaction.type !== 'BUY' && transaction.type !== 'SELL') {
-            throw new Error('Transaction type must be BUY or SELL.');
+            throw new DomainValidationError('Transaction type must be BUY or SELL.');
         }
 
         if (transaction.type === 'SELL') {
@@ -58,7 +59,7 @@ export class TransactionService {
                 transaction.isFoil
             );
             if (transaction.quantity > remainingQty) {
-                throw new Error(
+                throw new DomainValidationError(
                     `Cannot sell ${transaction.quantity} units. Only ${remainingQty} remaining.`
                 );
             }
@@ -127,16 +128,16 @@ export class TransactionService {
         this.LOGGER.debug(`Updating transaction ${id} for user ${userId}.`);
         const existing = await this.repository.findById(id);
         if (!existing || existing.userId !== userId) {
-            throw new Error('Transaction not found.');
+            throw new DomainNotFoundError('Transaction not found.');
         }
 
         this.assertWithinEditWindow(existing.createdAt, 'edited');
 
         if (fields.quantity !== undefined && fields.quantity <= 0) {
-            throw new Error('Transaction quantity must be positive.');
+            throw new DomainValidationError('Transaction quantity must be positive.');
         }
         if (fields.pricePerUnit !== undefined && fields.pricePerUnit < 0) {
-            throw new Error('Price per unit cannot be negative.');
+            throw new DomainValidationError('Price per unit cannot be negative.');
         }
 
         const newQuantity = fields.quantity ?? existing.quantity;
@@ -151,7 +152,7 @@ export class TransactionService {
                 // Add back the old sell quantity, then check if the new sell quantity fits
                 const available = remainingQty + existing.quantity;
                 if (newQuantity > available) {
-                    throw new Error(
+                    throw new DomainValidationError(
                         `Cannot sell ${newQuantity} units. Only ${available} remaining.`
                     );
                 }
@@ -159,7 +160,7 @@ export class TransactionService {
                 // Reducing a BUY lot: ensure total bought doesn't drop below total sold
                 const reduction = existing.quantity - newQuantity;
                 if (reduction > remainingQty) {
-                    throw new Error(
+                    throw new DomainValidationError(
                         `Cannot reduce buy to ${newQuantity} units. ${remainingQty} unsold units remaining in this card's ledger.`
                     );
                 }
@@ -190,7 +191,7 @@ export class TransactionService {
         this.LOGGER.debug(`Deleting transaction ${id} for user ${userId}.`);
         const existing = await this.repository.findById(id);
         if (!existing || existing.userId !== userId) {
-            throw new Error('Transaction not found.');
+            throw new DomainNotFoundError('Transaction not found.');
         }
 
         this.assertWithinEditWindow(existing.createdAt, 'deleted');
@@ -202,7 +203,7 @@ export class TransactionService {
                 existing.isFoil
             );
             if (existing.quantity > remainingQty) {
-                throw new Error(
+                throw new DomainValidationError(
                     `Cannot delete buy of ${existing.quantity} units. Only ${remainingQty} unsold units remaining in this card's ledger.`
                 );
             }
@@ -332,7 +333,7 @@ export class TransactionService {
     ): void {
         const timestamp = createdAt ? new Date(createdAt).getTime() : NaN;
         if (isNaN(timestamp) || Date.now() - timestamp >= EDIT_WINDOW_MS) {
-            throw new Error(`Transactions can only be ${action} within 24 hours of creation.`);
+            throw new DomainValidationError(`Transactions can only be ${action} within 24 hours of creation.`);
         }
     }
 

--- a/src/core/user/user.service.ts
+++ b/src/core/user/user.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { RefreshTokenService } from 'src/core/auth/refresh-token.service';
+import { DomainValidationError } from 'src/core/errors/domain.errors';
 import { getLogger } from 'src/logger/global-app-logger';
 import { User } from './user.entity';
 import { UserRepositoryPort } from './ports/user.repository.port';
@@ -47,7 +48,7 @@ export class UserService {
     async update(user: User): Promise<User | null> {
         this.LOGGER.debug(`Update user ID ${user?.id}.`);
         if (user.password) {
-            throw new Error('Password must be updated separately.');
+            throw new DomainValidationError('Password must be updated separately.');
         }
         return (await this.repository.update(user)) ?? null;
     }

--- a/src/core/validation.util.ts
+++ b/src/core/validation.util.ts
@@ -1,7 +1,11 @@
+import { DomainValidationError } from './errors/domain.errors';
+
 export function validateInit<T>(init: Partial<T>, requiredFields: (keyof T)[]): void {
     for (const field of requiredFields) {
         if (undefined === init[field] || null === init[field]) {
-            throw new Error(`Invalid initialization: ${String(field)} is required.`);
+            throw new DomainValidationError(
+                `Invalid initialization: ${String(field)} is required.`
+            );
         }
     }
 }

--- a/src/http/http.error.handler.ts
+++ b/src/http/http.error.handler.ts
@@ -42,10 +42,12 @@ export class HttpErrorHandler {
     private static readonly LOGGER = getLogger(HttpErrorHandler.name);
 
     /**
-     * Handles errors by logging them and throwing standardized HTTP exceptions.
+     * Logs the error and throws the standardized HTTP exception for it: an
+     * existing HttpException or a mapped Domain*Error, else a keyword fallback
+     * (transitional), else a generic 500.
      * @param error the error that occurred
      * @param context the context in which the error occurred, used for logging
-     * @returns never, throws an appropriate HTTP exception based on the error message
+     * @returns never — always throws
      */
     static toHttpException(error: Error, context: string): never {
         this.LOGGER.error(`Error in ${context}: ${error.message}`, error.stack);
@@ -57,9 +59,11 @@ export class HttpErrorHandler {
         if (mapped) {
             throw mapped;
         }
-        // Transitional fallback for core services not yet migrated to Domain
-        // errors (W1). Once every service throws Domain*Error, delete this block
-        // so unmapped errors are honestly a 500.
+        // Transitional fallback for the HBS orchestrators/presenters not yet
+        // migrated to Domain errors (they still throw plain Error with
+        // keyword-significant messages, e.g. "Set with code X not found"). The
+        // core services are migrated (W1 part 2); this block is deleted once the
+        // http layer follows, so unmapped errors become an honest 500.
         if (error.message.includes('not found')) {
             throw new NotFoundException(error.message);
         }

--- a/src/http/http.error.handler.ts
+++ b/src/http/http.error.handler.ts
@@ -59,11 +59,12 @@ export class HttpErrorHandler {
         if (mapped) {
             throw mapped;
         }
-        // Transitional fallback for the HBS orchestrators/presenters not yet
-        // migrated to Domain errors (they still throw plain Error with
-        // keyword-significant messages, e.g. "Set with code X not found"). The
-        // core services are migrated (W1 part 2); this block is deleted once the
-        // http layer follows, so unmapped errors become an honest 500.
+        // Transitional fallback for callers still throwing plain Error with
+        // keyword-significant messages: the HBS orchestrators/presenters (e.g.
+        // "Set with code X not found") plus a few defensive core guards
+        // (auth.service.login's "User not found"). W1 part 2 migrated the core
+        // domain conditions; this block is deleted in part 3 once those remaining
+        // throws move to Domain*Error, so unmapped errors become an honest 500.
         if (error.message.includes('not found')) {
             throw new NotFoundException(error.message);
         }

--- a/test/core/card/card.service.spec.ts
+++ b/test/core/card/card.service.spec.ts
@@ -118,7 +118,7 @@ describe('CardService', () => {
             repository.findWithName.mockRejectedValue(new Error('Database error'));
 
             await expect(service.findWithName('Test Card', mockQueryOptions)).rejects.toThrow(
-                'Error finding cards with name Test Card'
+                'Database error'
             );
         });
     });
@@ -147,7 +147,7 @@ describe('CardService', () => {
             repository.findBySet.mockRejectedValue(new Error('Database error'));
 
             await expect(service.findBySet('TST', mockQueryOptions)).rejects.toThrow(
-                'Error finding cards in set TST'
+                'Database error'
             );
         });
     });
@@ -185,7 +185,7 @@ describe('CardService', () => {
             repository.findBySetCodeAndNumber.mockRejectedValue(new Error('Database error'));
 
             await expect(service.findBySetCodeAndNumber('TST', '123')).rejects.toThrow(
-                'Error finding card with set code tst and number 123'
+                'Database error'
             );
         });
     });
@@ -212,7 +212,7 @@ describe('CardService', () => {
             repository.totalWithName.mockRejectedValue(new Error('Database error'));
 
             await expect(service.totalWithName('Test Card')).rejects.toThrow(
-                'Error counting cards with name Test Card'
+                'Database error'
             );
         });
     });
@@ -239,7 +239,7 @@ describe('CardService', () => {
             repository.totalInSet.mockRejectedValue(new Error('Database error'));
 
             await expect(service.totalInSet('TST', mockQueryOptions)).rejects.toThrow(
-                'Error counting cards in set TST'
+                'Database error'
             );
         });
     });
@@ -267,7 +267,7 @@ describe('CardService', () => {
             repository.searchByName.mockRejectedValue(new Error('Database error'));
 
             await expect(service.searchByName('Test', mockQueryOptions)).rejects.toThrow(
-                'Error searching cards by name "Test"'
+                'Database error'
             );
         });
     });
@@ -294,7 +294,7 @@ describe('CardService', () => {
             repository.totalSearchByName.mockRejectedValue(new Error('Database error'));
 
             await expect(service.totalSearchByName('Test')).rejects.toThrow(
-                'Error counting card search results for "Test"'
+                'Database error'
             );
         });
     });
@@ -315,7 +315,7 @@ describe('CardService', () => {
 
             await expect(
                 service.searchByNameGrouped('Test', mockQueryOptions)
-            ).rejects.toThrow('Error grouped-searching cards by name "Test"');
+            ).rejects.toThrow('Database error');
         });
     });
 
@@ -333,7 +333,7 @@ describe('CardService', () => {
             repository.totalSearchByNameGrouped.mockRejectedValue(new Error('Database error'));
 
             await expect(service.totalSearchByNameGrouped('Test')).rejects.toThrow(
-                'Error counting grouped card search results for "Test"'
+                'Database error'
             );
         });
     });
@@ -392,7 +392,7 @@ describe('CardService', () => {
             mockPriceHistoryRepository.findByCardId.mockRejectedValue(new Error('Database error'));
 
             await expect(service.findPriceHistory('test-card-id')).rejects.toThrow(
-                'Error finding price history for card test-card-id'
+                'Database error'
             );
         });
     });
@@ -434,7 +434,7 @@ describe('CardService', () => {
             );
 
             await expect(service.findCurrentBuylist('test-card-id')).rejects.toThrow(
-                'Error finding buylist for card test-card-id'
+                'Database error'
             );
         });
     });

--- a/test/core/set/set.service.spec.ts
+++ b/test/core/set/set.service.spec.ts
@@ -240,7 +240,7 @@ describe('SetService', () => {
             repository.totalInSet.mockRejectedValue(new Error('Database error'));
 
             await expect(service.totalCardsInSet(mockSetCode, mockQueryOptions)).rejects.toThrow(
-                `Error counting cards in set ${mockSetCode}`
+                'Database error'
             );
         });
     });
@@ -285,7 +285,7 @@ describe('SetService', () => {
 
             await expect(
                 service.totalValueForSet(mockSetCode, false, mockQueryOptions)
-            ).rejects.toThrow(`Error getting total value of non-foil cards for set ${mockSetCode}`);
+            ).rejects.toThrow('Database error');
         });
 
         it('should throw error when repository fails (with foil)', async () => {
@@ -293,7 +293,7 @@ describe('SetService', () => {
 
             await expect(
                 service.totalValueForSet(mockSetCode, true, mockQueryOptions)
-            ).rejects.toThrow(`Error getting total value of cards for set ${mockSetCode}`);
+            ).rejects.toThrow('Database error');
         });
     });
 
@@ -338,7 +338,7 @@ describe('SetService', () => {
             repository.searchSets.mockRejectedValue(new Error('Database error'));
 
             await expect(service.searchSets('Test', mockQueryOptions)).rejects.toThrow(
-                'Error searching sets for "Test"'
+                'Database error'
             );
         });
     });
@@ -365,7 +365,7 @@ describe('SetService', () => {
             repository.totalSearchSets.mockRejectedValue(new Error('Database error'));
 
             await expect(service.totalSearchSets('Test')).rejects.toThrow(
-                'Error counting set search results for "Test"'
+                'Database error'
             );
         });
     });
@@ -422,7 +422,7 @@ describe('SetService', () => {
             priceHistoryRepository.findBySetCode.mockRejectedValue(new Error('Database error'));
 
             await expect(service.findSetPriceHistory('SET')).rejects.toThrow(
-                'Error finding set price history for set SET'
+                'Database error'
             );
         });
     });


### PR DESCRIPTION
Part 2 of the W1 error-handling overhaul. Part 1 (#579) is merged; this branch has been rebased onto `main` (base = `main`, conflicts resolved).

## What changed
- **A2 — remove catch-wrap-rethrow.** `card.service` (14 methods) and `set.service` (5) wrapped every repo call in `try { … } catch (e) { throw new Error('Error …: ' + e.message) }`, which destroyed the original stack + type and added ~6 lines of noise per method. Deleted the try/catch; internal failures now propagate to an honest 500 with the real stack. Specs assert the underlying error instead of the wrapper string.
- **A1 — one convention (Domain\*Error).** Migrated the domain conditions that were plain `Error`:
  - `transaction.service` (12): invalid quantity/price/type + over-sell/over-reduce/over-delete checks → `DomainValidationError`; missing/not-owned → `DomainNotFoundError` (keeps 404 resource-hiding).
  - `validation.util` (`validateInit`), `user.service` ("Password must be updated separately"), `set-checklist.service` ("Set not found") → `Domain*Error`.

## Behavior notes
- Transaction invalid-input cases (`quantity must be positive`, `type must be BUY or SELL`, …) were **500s** before (no keyword match) and are now **400s** via the domain mapping — a correctness improvement. No e2e asserted the old 500.
- **The transitional keyword fallback in `toHttpException` stays.** The HBS orchestrators/presenters still throw plain keyword-significant `Error`s (e.g. `Set with code X not found`, `Published deck N not found`), so deleting the fallback now would regress their statuses to 500. Migrating the http layer + deleting the fallback is **W1 part 3**. No regression here: the Domain mapping runs before the fallback.

## Tests
Full suite green (**115 suites / 1378 tests**), `tsc --noEmit` clean, touched files lint-clean.

Refs #569