### PR TITLE
refactor: migrate HBS not-found throws to domain errors + delete keyword fallback (W1 part 3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -262,9 +262,9 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 - Per-repo findings with file/line refs: [`docs/codebase-analyses-2026-07/`](docs/codebase-analyses-2026-07/) — `web.md`, `scry.md`, `mcp.md`, `mobile.md`.
 - Cross-repo dependencies + sequencing rationale + the work-package → issue mapping: [`docs/cross-repo-analysis-plan-2026-07.md`](docs/cross-repo-analysis-plan-2026-07.md).
 
-**Done so far:** W9 ([#577](https://github.com/matthewdtowles/i-want-my-mtg/issues/577), ON DELETE CASCADE migration, PR #578), S1 ([scry#35](https://github.com/matthewdtowles/scry/issues/35), post-ingest-prune foreignness), and — 2026-07-09 — MB1 ([#63](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63), mobile PR #70) + MB2 ([#64](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64), mobile PR #71). 24 issues remain.
+**Done so far:** W9 ([#577](https://github.com/matthewdtowles/i-want-my-mtg/issues/577), ON DELETE CASCADE migration, PR #578), S1 ([scry#35](https://github.com/matthewdtowles/scry/issues/35), post-ingest-prune foreignness), W1 ([#569](https://github.com/matthewdtowles/i-want-my-mtg/issues/569), error-handling overhaul, PRs #579 + #580 + part 3), and — 2026-07-09 — MB1 ([#63](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/63), mobile PR #70) + MB2 ([#64](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/64), mobile PR #71). 23 issues remain.
 
-**In flight (2026-07-09):** W1 is being delivered in three parts — **part 1** (PR #579): the boundary + convention (B1/B9/A1/A9); **part 2** (stacked PR): remove A2 catch-wrap-rethrow + migrate the core services (card/set/transaction/user/validation/set-checklist) to `Domain*Error`; **part 3** (remaining): migrate the HBS orchestrators/presenters off plain keyword-significant Errors, then delete the transitional keyword fallback in `toHttpException`. #569 stays open until part 3 lands.
+**W1 landed (2026-07-09), delivered in three parts:** **part 1** (PR #579) — the boundary + convention (B1/B9/A1/A9); **part 2** (PR #580) — removed A2 catch-wrap-rethrow + migrated the core services (card/set/transaction/user/validation/set-checklist) to `Domain*Error`; **part 3** — migrated the HBS orchestrators' user-facing "not found" throws (card/set/deck/published-deck) to `DomainNotFoundError` and deleted the transitional keyword fallback in `toHttpException`, so unmapped plain Errors are now honest 500s (internal presenter invariants included). Next: **X6** verification (MCP `extractApiMessage` + mobile `errMessage` against the new error bodies).
 
 ### Cross-repo hard orderings (everything else is repo-local and parallelizable)
 
@@ -282,7 +282,7 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 |---|---|---|---|
 | ~~MB1~~ | mobile | Clear query cache on sign-out (cross-account data leak) | ✅ **done** (PR #70) |
 | ~~MB2~~ | mobile | Decouple CI spec-drift check from PR gating | ✅ **done** (PR #71); unblocked W8 (X3/X4) |
-| [W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569) | web | Error handling overhaul: domain errors end to end | Foundational; X6 verifies after — **parts 1 (#579) + 2 in PRs**, part 3 (http-layer + fallback removal) to follow |
+| ~~[W1](https://github.com/matthewdtowles/i-want-my-mtg/issues/569)~~ | web | Error handling overhaul: domain errors end to end | **Done** (PRs #579 + #580 + part 3); X6 verifies the new error bodies next |
 | [W2](https://github.com/matthewdtowles/i-want-my-mtg/issues/570) | web | Inventory/ledger integrity: transactional writes, fix silent failures | |
 | [S2](https://github.com/matthewdtowles/scry/issues/36) | scry | Delete/reset FK coverage; remove fake CASCADE | Unblocked by W9 (X1) |
 | [S3](https://github.com/matthewdtowles/scry/issues/37) | scry | Ingest robustness: stream failures, non-TTY prompts, batch/mapping bugs | |

--- a/src/http/hbs/card/card.orchestrator.ts
+++ b/src/http/hbs/card/card.orchestrator.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Card } from 'src/core/card/card.entity';
+import { DomainNotFoundError } from 'src/core/errors/domain.errors';
 import { CardImgType } from 'src/core/card/card.img.type.enum';
 import { CardService } from 'src/core/card/card.service';
 import { Inventory } from 'src/core/inventory/inventory.entity';
@@ -50,7 +51,9 @@ export class CardOrchestrator {
                 setNumber
             );
             if (!coreCard) {
-                throw new Error(`Card with set code ${setCode} and number ${setNumber} not found`);
+                throw new DomainNotFoundError(
+                    `Card with set code ${setCode} and number ${setNumber} not found`
+                );
             }
             const inventory: Inventory[] =
                 userId > 0 ? await this.inventoryService.findForUser(userId, coreCard.id) : [];

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Format } from 'src/core/card/format.enum';
+import { DomainNotFoundError } from 'src/core/errors/domain.errors';
 import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
 import { DeckCard } from 'src/core/deck/deck-card.entity';
 import { DeckCardGap, DeckGapSummary } from 'src/core/deck/deck-gap.policy';
@@ -131,7 +132,7 @@ export class DeckPageOrchestrator {
             HttpErrorHandler.validateAuthenticatedRequest(req);
             const deck = await this.deckService.getDeck(deckId, req.user.id);
             if (!deck) {
-                throw new Error(`Deck ${deckId} not found.`);
+                throw new DomainNotFoundError(`Deck ${deckId} not found.`);
             }
             const cards = deck.cards ?? [];
             const main = cards.filter((c) => !c.isSideboard);

--- a/src/http/hbs/published-deck/published-deck.orchestrator.ts
+++ b/src/http/hbs/published-deck/published-deck.orchestrator.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
+import { DomainNotFoundError } from 'src/core/errors/domain.errors';
 import { DeckCard } from 'src/core/deck/deck-card.entity';
 import { DeckGapPolicy, DeckCardGap } from 'src/core/deck/deck-gap.policy';
 import { DeckService } from 'src/core/deck/deck.service';
@@ -124,7 +125,7 @@ export class PublishedDeckOrchestrator {
         try {
             const deck = await this.publishedDeckService.get(id);
             if (!deck) {
-                throw new Error(`Published deck ${id} not found.`);
+                throw new DomainNotFoundError(`Published deck ${id} not found.`);
             }
             const cards = deck.cards ?? [];
             const main = cards.filter((c) => !c.isSideboard);
@@ -182,7 +183,7 @@ export class PublishedDeckOrchestrator {
         HttpErrorHandler.validateAuthenticatedRequest(req);
         const source = await this.publishedDeckService.get(id);
         if (!source) {
-            throw new Error(`Published deck ${id} not found.`);
+            throw new DomainNotFoundError(`Published deck ${id} not found.`);
         }
         const deck = await this.deckService.createDeck(req.user.id, this.deckTitle(source));
         const entries = (source.cards ?? []).map((c) => ({
@@ -199,7 +200,7 @@ export class PublishedDeckOrchestrator {
         HttpErrorHandler.validateAuthenticatedRequest(req);
         const deck = await this.publishedDeckService.get(id);
         if (!deck) {
-            throw new Error(`Published deck ${id} not found.`);
+            throw new DomainNotFoundError(`Published deck ${id} not found.`);
         }
         return this.buildabilityService.addMissingToBuyList(deck.cards ?? [], req.user.id);
     }

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { CardImgType } from 'src/core/card/card.img.type.enum';
+import { DomainNotFoundError } from 'src/core/errors/domain.errors';
 import { CardService } from 'src/core/card/card.service';
 import { InventoryImportService } from 'src/core/inventory/import/inventory-import.service';
 import { SetImportRow } from 'src/core/inventory/import/inventory-import.types';
@@ -189,7 +190,7 @@ export class SetOrchestrator {
         try {
             const set = await this.setService.findByCode(setCode);
             if (!set) {
-                throw new Error(`Set with code ${setCode} not found`);
+                throw new DomainNotFoundError(`Set with code ${setCode} not found`);
             }
 
             const forceShowAll = !set.isMain;

--- a/src/http/http.error.handler.ts
+++ b/src/http/http.error.handler.ts
@@ -48,8 +48,11 @@ export class HttpErrorHandler {
      * @param context the context in which the error occurred, used for logging
      * @returns never — always throws
      */
-    static toHttpException(error: Error, context: string): never {
-        this.LOGGER.error(`Error in ${context}: ${error.message}`, error.stack);
+    static toHttpException(error: unknown, context: string): never {
+        // Catch vars are `any` here (strictNullChecks off), so a non-Error value
+        // can reach us at runtime — normalize before touching .message/.stack.
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.LOGGER.error(`Error in ${context}: ${err.message}`, err.stack);
         // An existing HttpException (e.g. an auth guard's UnauthorizedException)
         // or a Domain*Error maps directly (HttpException passthrough first, so a
         // 401 "User not found in request" is not re-mapped to a 404 — W1/B1).

--- a/src/http/http.error.handler.ts
+++ b/src/http/http.error.handler.ts
@@ -43,8 +43,7 @@ export class HttpErrorHandler {
 
     /**
      * Logs the error and throws the standardized HTTP exception for it: an
-     * existing HttpException or a mapped Domain*Error, else a keyword fallback
-     * (transitional), else a generic 500.
+     * existing HttpException or a mapped Domain*Error, else a generic 500.
      * @param error the error that occurred
      * @param context the context in which the error occurred, used for logging
      * @returns never — always throws
@@ -52,30 +51,13 @@ export class HttpErrorHandler {
     static toHttpException(error: Error, context: string): never {
         this.LOGGER.error(`Error in ${context}: ${error.message}`, error.stack);
         // An existing HttpException (e.g. an auth guard's UnauthorizedException)
-        // or a Domain*Error maps directly. HttpException passthrough must come
-        // first: without it the keyword fallback below re-mapped a 401 "User not
-        // found in request" to a 404 (W1/B1).
+        // or a Domain*Error maps directly (HttpException passthrough first, so a
+        // 401 "User not found in request" is not re-mapped to a 404 — W1/B1).
+        // Anything else is a genuinely unexpected error: a generic 500 that never
+        // leaks the underlying message.
         const mapped = domainErrorToHttpException(error);
         if (mapped) {
             throw mapped;
-        }
-        // Transitional fallback for callers still throwing plain Error with
-        // keyword-significant messages: the HBS orchestrators/presenters (e.g.
-        // "Set with code X not found") plus a few defensive core guards
-        // (auth.service.login's "User not found"). W1 part 2 migrated the core
-        // domain conditions; this block is deleted in part 3 once those remaining
-        // throws move to Domain*Error, so unmapped errors become an honest 500.
-        if (error.message.includes('not found')) {
-            throw new NotFoundException(error.message);
-        }
-        if (error.message.includes('unauthorized') || error.message.includes('not logged in')) {
-            throw new UnauthorizedException(error.message);
-        }
-        if (error.message.includes('forbidden') || error.message.includes('not allowed')) {
-            throw new ForbiddenException(error.message);
-        }
-        if (error.message.includes('invalid') || error.message.includes('required')) {
-            throw new BadRequestException(error.message);
         }
         throw new InternalServerErrorException('An unexpected error occurred');
     }

--- a/test/http/http.error.handler.spec.ts
+++ b/test/http/http.error.handler.spec.ts
@@ -64,4 +64,19 @@ describe('HttpErrorHandler.toHttpException', () => {
             expect((e as HttpException).message).toBe('An unexpected error occurred');
         }
     });
+
+    // W1 part 3: the transitional keyword fallback is gone. A plain Error whose
+    // message happens to contain "not found" (or any other former keyword) is now
+    // an honest 500, not a 404 — callers must throw a Domain*Error to signal a
+    // non-500 status. Guards against the fallback silently coming back.
+    it('does not map a plain Error with a keyword-significant message', () => {
+        try {
+            HttpErrorHandler.toHttpException(new Error('Set with code BAD not found'), 'test');
+            fail('expected throw');
+        } catch (e) {
+            expect(e).toBeInstanceOf(InternalServerErrorException);
+            expect(e).not.toBeInstanceOf(NotFoundException);
+            expect((e as HttpException).message).toBe('An unexpected error occurred');
+        }
+    });
 });

--- a/test/http/http.error.handler.spec.ts
+++ b/test/http/http.error.handler.spec.ts
@@ -65,6 +65,17 @@ describe('HttpErrorHandler.toHttpException', () => {
         }
     });
 
+    // Callers pass the raw `catch (error)` value (typed `any` here), so a
+    // non-Error can reach us at runtime. It must be normalized for logging and
+    // mapped to a 500, never crash on `.message`/`.stack` access.
+    it('normalizes a non-Error thrown value to a 500', () => {
+        for (const thrown of ['just a string', { code: 42 }, null, undefined]) {
+            expect(() =>
+                HttpErrorHandler.toHttpException(thrown as unknown as Error, 'test')
+            ).toThrow(InternalServerErrorException);
+        }
+    });
+
     // W1 part 3: the transitional keyword fallback is gone. A plain Error whose
     // message happens to contain "not found" (or any other former keyword) is now
     // an honest 500, not a 404 — callers must throw a Domain*Error to signal a


### PR DESCRIPTION
Final part of the **W1** error-handling overhaul (#569). Parts 1 (#579) and 2 (#580) are merged.

## What
- Migrate the user-facing **"not found"** throws in the HBS orchestrators to `DomainNotFoundError`:
  - `card.orchestrator` (set-card lookup), `set.orchestrator` (set by code), `deck-page.orchestrator` (deck detail), `published-deck.orchestrator` (detail view + `cloneToUserDeck` + `addMissingToBuyList`).
- **Delete the transitional keyword fallback** in `HttpErrorHandler.toHttpException`. It now maps `HttpException` passthrough + `Domain*Error`, and everything else becomes a generic 500 that never leaks the underlying message.

## Behavior
- The four "not found" sites keep their **404** (message preserved through `DomainNotFoundError` → `NotFoundException`). Two published-deck sites (`cloneToUserDeck`, `addMissingToBuyList`) that previously reached the global filter as plain Errors improve from **500 → 404**.
- Internal-invariant guards left as plain `Error` (presenter "Card/Inventory is required", "Invalid rarity value") are now **honest 500s** instead of being re-mapped by message substring (was 400). These are unreachable programmer-error guards, not user-facing conditions.
- Throws caught locally (auth orchestrator/service → `AuthResult`) and already-500 paths (billing `loadUser`, user signup) are unchanged.

## Tests
- Added a regression test locking in that a plain `Error('...not found')` now maps to 500, not 404 (guards against the fallback silently returning).
- Full suite green: 1379 passing. Lint + `tsc --noEmit` clean.

## Next
- **X6**: verify MCP `extractApiMessage` + mobile `errMessage` against the new API error bodies (verification only).

Closes #569