### PR TITLE
fix: make inventory CSV import atomic (W2/B4 follow-up)

### DIFF
--- a/src/core/inventory/import/inventory-import.service.ts
+++ b/src/core/inventory/import/inventory-import.service.ts
@@ -6,6 +6,7 @@ import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { Set } from 'src/core/set/set.entity';
 import { SetRepositoryPort } from 'src/core/set/ports/set.repository.port';
 import { CardRepositoryPort } from 'src/core/card/ports/card.repository.port';
+import { TransactionRunnerPort } from 'src/core/transaction-runner.port';
 import { getLogger } from 'src/logger/global-app-logger';
 import { InventoryRepositoryPort } from '../ports/inventory.repository.port';
 import { CardImportRow, SetImportRow } from './inventory-import.types';
@@ -22,7 +23,9 @@ export class InventoryImportService {
         @Inject(SetRepositoryPort)
         private readonly setRepository: SetRepositoryPort,
         @Inject(CardImportResolver)
-        private readonly cardResolver: CardImportResolver
+        private readonly cardResolver: CardImportResolver,
+        @Inject(TransactionRunnerPort)
+        private readonly txRunner: TransactionRunnerPort
     ) {}
 
     async importCards(rows: CardImportRow[], userId: number): Promise<ImportResult> {
@@ -106,43 +109,41 @@ export class InventoryImportService {
             }
         }
 
-        // Execute deletions - track successes and failures separately
-        let deleted = 0;
-        for (const item of toDelete) {
-            try {
+        // Apply the deletes, exact saves, and ensure-at-least-one as one unit
+        // of work (W2/B4): if any phase fails the whole import rolls back rather
+        // than leaving rows deleted-but-not-saved. Row *resolution* errors
+        // gathered above are pre-write and returned regardless; only the DB
+        // writes are transactional. (A single transaction can't tolerate a
+        // mid-batch delete failure — the first error poisons it — so a failed
+        // delete now aborts the import instead of being skipped.)
+        const { deleted, exactSaved, ensureResult } = await this.txRunner.run(async () => {
+            for (const item of toDelete) {
                 await this.inventoryRepository.delete(item.userId, item.cardId, item.isFoil);
-                deleted++;
-            } catch (e) {
-                this.LOGGER.error(`Failed to delete inventory: ${e.message}`);
-                errors.push({
-                    row: 0,
-                    error: `Failed to delete card ${item.cardId}: ${e.message}`,
-                });
             }
-        }
 
-        // Execute exact saves
-        let exactSaved = 0;
-        if (toSave.length > 0) {
-            const { Inventory } = await import('../inventory.entity');
-            const inventoryItems = toSave.map(
-                (item) =>
-                    new Inventory({
-                        cardId: item.cardId,
-                        userId: item.userId,
-                        isFoil: item.isFoil,
-                        quantity: item.quantity,
-                    })
-            );
-            const saved = await this.inventoryRepository.save(inventoryItems);
-            exactSaved = saved.length;
-        }
+            let exactSaved = 0;
+            if (toSave.length > 0) {
+                const { Inventory } = await import('../inventory.entity');
+                const inventoryItems = toSave.map(
+                    (item) =>
+                        new Inventory({
+                            cardId: item.cardId,
+                            userId: item.userId,
+                            isFoil: item.isFoil,
+                            quantity: item.quantity,
+                        })
+                );
+                const saved = await this.inventoryRepository.save(inventoryItems);
+                exactSaved = saved.length;
+            }
 
-        // Execute ensure-at-least-one
-        let ensureResult = { saved: 0, skipped: 0 };
-        if (toEnsure.length > 0) {
-            ensureResult = await this.inventoryRepository.ensureAtLeastOne(toEnsure);
-        }
+            let ensureResult = { saved: 0, skipped: 0 };
+            if (toEnsure.length > 0) {
+                ensureResult = await this.inventoryRepository.ensureAtLeastOne(toEnsure);
+            }
+
+            return { deleted: toDelete.length, exactSaved, ensureResult };
+        });
 
         const totalSaved = exactSaved + ensureResult.saved;
         this.LOGGER.debug(

--- a/src/database/inventory/inventory.repository.ts
+++ b/src/database/inventory/inventory.repository.ts
@@ -280,7 +280,7 @@ export class InventoryRepository
         // RETURNING makes query() resolve to one row per *actually inserted*
         // row; ON CONFLICT DO NOTHING omits conflicting rows. The raw result is
         // a rows array with no rowCount, so count its length (W2/B2).
-        const result = await this.repository.query(
+        const result = await this.repo().query(
             `INSERT INTO inventory (card_id, user_id, foil, quantity)
              VALUES ${values}
              ON CONFLICT (card_id, user_id, foil) DO NOTHING

--- a/test/core/inventory/import/inventory-import.service.spec.ts
+++ b/test/core/inventory/import/inventory-import.service.spec.ts
@@ -85,7 +85,11 @@ describe('InventoryImportService', () => {
                 { provide: CardRepositoryPort, useValue: mockCardRepo },
                 { provide: SetRepositoryPort, useValue: mockSetRepo },
                 // Pass-through runner: execute the write phases inline (W2/B4).
-                { provide: TransactionRunnerPort, useValue: { run: (work: () => unknown) => work() } },
+                // Signature mirrors the port so the mock catches call-site drift.
+                {
+                    provide: TransactionRunnerPort,
+                    useValue: { run: <T>(work: () => Promise<T>): Promise<T> => work() },
+                },
             ],
         }).compile();
 

--- a/test/core/inventory/import/inventory-import.service.spec.ts
+++ b/test/core/inventory/import/inventory-import.service.spec.ts
@@ -5,6 +5,7 @@ import { CardRepositoryPort } from 'src/core/card/ports/card.repository.port';
 import { CardImportResolver } from 'src/core/import/card-import-resolver';
 import { InventoryImportService } from 'src/core/inventory/import/inventory-import.service';
 import { InventoryRepositoryPort } from 'src/core/inventory/ports/inventory.repository.port';
+import { TransactionRunnerPort } from 'src/core/transaction-runner.port';
 import { Set } from 'src/core/set/set.entity';
 import { SetRepositoryPort } from 'src/core/set/ports/set.repository.port';
 
@@ -83,6 +84,8 @@ describe('InventoryImportService', () => {
                 { provide: InventoryRepositoryPort, useValue: mockInventoryRepo },
                 { provide: CardRepositoryPort, useValue: mockCardRepo },
                 { provide: SetRepositoryPort, useValue: mockSetRepo },
+                // Pass-through runner: execute the write phases inline (W2/B4).
+                { provide: TransactionRunnerPort, useValue: { run: (work: () => unknown) => work() } },
             ],
         }).compile();
 
@@ -147,16 +150,17 @@ describe('InventoryImportService', () => {
             expect(result.errors).toHaveLength(0);
         });
 
-        it('reports failed deletion as an error', async () => {
+        it('aborts the whole import when a write fails (transactional)', async () => {
+            // W2/B4: the delete/save/ensure phases run inside one unit of work,
+            // so a failed write rolls the transaction back and propagates rather
+            // than being swallowed as a per-row error.
             const card = makeCard();
             mockCardRepo.findById.mockResolvedValue(card);
             mockInventoryRepo.delete.mockRejectedValue(new Error('DB constraint'));
 
-            const result = await service.importCards([{ id: card.id, quantity: '0' }], 1);
-
-            expect(result.deleted).toBe(0);
-            expect(result.errors).toHaveLength(1);
-            expect(result.errors[0].error).toMatch(/DB constraint/);
+            await expect(service.importCards([{ id: card.id, quantity: '0' }], 1)).rejects.toThrow(
+                /DB constraint/
+            );
         });
 
         it('errors on card not found by id', async () => {


### PR DESCRIPTION
## Summary

Follow-up to #584. That PR wrapped the transaction/ledger and deck-import money paths in a unit of work but **intentionally left `InventoryImportService.importCards` multi-step**. This closes that gap.

The delete / exact-save / ensure-at-least-one write phases of `importCards` now run inside `txRunner.run()`, so a mid-import write failure rolls the whole batch back instead of leaving rows deleted-but-not-saved.

## Changes

- **`inventory-import.service.ts`** — wrap the three write phases in `txRunner.run()`. Per-row *resolution* errors are still gathered pre-write and returned as before; only the DB writes are transactional. A failed write now aborts the import (throws) instead of being swallowed as a per-row error.
- **`inventory.repository.ts`** — route the `ensureAtLeastOne` bulk `INSERT` through `repo()` so it joins the ambient transaction. The other 5 raw `query()` sites are read/aggregate paths and stay on the base repository.
- **spec** — pass-through runner mock; the failed-delete case now asserts the import aborts transactionally.

## Testing

- `inventory-import.service` unit suite: 18/18 pass
- `tsc --noEmit`: clean