### PR TITLE
fix: query/input hardening - filter charset, limit caps, pool config (W3)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -298,7 +298,7 @@ The four codebase analyses run **2026-07-07** produced 29 work-package issues sp
 | Issue | Repo | Title | Notes |
 |---|---|---|---|
 | [W8](https://github.com/matthewdtowles/i-want-my-mtg/issues/576) | web | OpenAPI spec fixes + delta-quantity endpoint | After MB2 (X3/X4); triggers M3 + mobile regen |
-| [W3](https://github.com/matthewdtowles/i-want-my-mtg/issues/571) | web | Query/input hardening: filter charset, limit caps, pool config | |
+| ~~[W3](https://github.com/matthewdtowles/i-want-my-mtg/issues/571)~~ | web | Query/input hardening: filter charset, limit caps, pool config | ✅ **done** (PR #587) |
 | [W4](https://github.com/matthewdtowles/i-want-my-mtg/issues/572) | web | Security hardening: error leaks, enumeration, token hashing, Stripe sync | |
 | [W5](https://github.com/matthewdtowles/i-want-my-mtg/issues/573) | web | Performance: set page, batched imports, Promise.all, latest-price helper | |
 | [S5](https://github.com/matthewdtowles/scry/issues/39) | scry | Remove no-op concurrency + dead granular parsing; fix misleading counts | |

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,54 +14,45 @@ import { getLogger } from './logger/global-app-logger';
             imports: [ConfigModule],
             inject: [ConfigService],
             useFactory: (configService: ConfigService) => {
-                const databaseUrl = configService.get<string>('DATABASE_URL');
+                const isProduction = configService.get('NODE_ENV') === 'production';
+                // The two connection styles differ only in how the server is
+                // addressed; everything else (ssl, logging, pool) is shared.
+                const shared = {
+                    type: 'postgres' as const,
+                    autoLoadEntities: true,
+                    synchronize: false,
+                    dropSchema: false,
+                    migrationsRun: false,
+                    logging: (!isProduction ? ['error', 'warn'] : ['error']) as (
+                        | 'error'
+                        | 'warn'
+                    )[],
+                    ...(isProduction && { ssl: { rejectUnauthorized: false } }),
+                    // pg.Pool options (the previous connectionLimit/queueLimit/
+                    // waitForConnections were mysql2 keys that pg silently ignored).
+                    extra: {
+                        max: 10,
+                        idleTimeoutMillis: 30000,
+                        connectionTimeoutMillis: 10000,
+                    },
+                };
 
+                const databaseUrl = configService.get<string>('DATABASE_URL');
                 if (databaseUrl) {
                     // Remove sslmode from URL - pg treats 'require' as 'verify-full'
                     // which rejects AWS managed DB certs. We handle SSL via TypeORM config instead.
                     const url = new URL(databaseUrl);
                     url.searchParams.delete('sslmode');
-                    const isProduction = configService.get('NODE_ENV') === 'production';
-                    return {
-                        type: 'postgres',
-                        url: url.toString(),
-                        autoLoadEntities: true,
-                        synchronize: false,
-                        dropSchema: false,
-                        migrationsRun: false,
-                        logging: !isProduction ? ['error', 'warn'] : ['error'],
-                        ...(isProduction && {
-                            ssl: { rejectUnauthorized: false },
-                        }),
-                        extra: {
-                            connectionLimit: 10,
-                            queueLimit: 0,
-                            waitForConnections: true,
-                        },
-                    };
-                } else {
-                    return {
-                        type: 'postgres',
-                        host: configService.get<string>('DB_HOST'),
-                        port: configService.get<number>('DB_PORT'),
-                        username: configService.get<string>('DB_USERNAME'),
-                        password: configService.get<string>('DB_PASSWORD'),
-                        database: configService.get<string>('DB_NAME'),
-                        autoLoadEntities: true,
-                        synchronize: false,
-                        dropSchema: false,
-                        migrationsRun: false,
-                        logging:
-                            configService.get('NODE_ENV') !== 'production'
-                                ? ['error', 'warn']
-                                : ['error'],
-                        extra: {
-                            connectionLimit: 10,
-                            queueLimit: 0,
-                            waitForConnections: true,
-                        },
-                    };
+                    return { ...shared, url: url.toString() };
                 }
+                return {
+                    ...shared,
+                    host: configService.get<string>('DB_HOST'),
+                    port: configService.get<number>('DB_PORT'),
+                    username: configService.get<string>('DB_USERNAME'),
+                    password: configService.get<string>('DB_PASSWORD'),
+                    database: configService.get<string>('DB_NAME'),
+                };
             },
             dataSourceFactory: async (options) => {
                 try {

--- a/src/core/query/query.util.ts
+++ b/src/core/query/query.util.ts
@@ -6,11 +6,17 @@ import { SortOptions } from './sort-options.enum';
 // `string[]` at runtime. Each returns its default rather than calling a string
 // method on a non-string (which would throw and surface as a 500).
 
-export function sanitizeInt(value: unknown, defaultValue: number): number {
-    if (typeof value === 'number') return value < 1 ? defaultValue : value;
-    if (typeof value !== 'string') return defaultValue;
-    const parsed = parseInt(value, 10);
-    return isNaN(parsed) || parsed < 1 ? defaultValue : parsed;
+export function sanitizeInt(value: unknown, defaultValue: number, max?: number): number {
+    let n: number;
+    if (typeof value === 'number') {
+        n = value < 1 ? defaultValue : value;
+    } else if (typeof value !== 'string') {
+        n = defaultValue;
+    } else {
+        const parsed = parseInt(value, 10);
+        n = isNaN(parsed) || parsed < 1 ? defaultValue : parsed;
+    }
+    return max !== undefined ? Math.min(n, max) : n;
 }
 
 export function safeAlphaNumeric(value: unknown): string | undefined {

--- a/src/core/query/query.util.ts
+++ b/src/core/query/query.util.ts
@@ -9,7 +9,7 @@ import { SortOptions } from './sort-options.enum';
 export function sanitizeInt(value: unknown, defaultValue: number, max?: number): number {
     let n: number;
     if (typeof value === 'number') {
-        n = value < 1 ? defaultValue : value;
+        n = !Number.isFinite(value) || value < 1 ? defaultValue : Math.floor(value);
     } else if (typeof value !== 'string') {
         n = defaultValue;
     } else {

--- a/src/core/query/safe-query-options.dto.ts
+++ b/src/core/query/safe-query-options.dto.ts
@@ -1,8 +1,12 @@
 import { CardRarity } from 'src/core/card/card.rarity.enum';
 import { Format } from 'src/core/card/format.enum';
 import { LegalityStatus } from 'src/core/card/legality.status.enum';
-import { safeAlphaNumeric, safeBoolean, safeSort, sanitizeInt } from './query.util';
+import { safeAlphaNumeric, safeBoolean, safeSearchTerm, safeSort, sanitizeInt } from './query.util';
 import { SortOptions } from './sort-options.enum';
+
+// Upper bound on any list endpoint's page size. Without it a public request
+// (`?limit=1000000`) would build a giant join; a handful saturate Postgres.
+export const MAX_PAGE_LIMIT = 100;
 
 export const PUBLIC_RARITIES: ReadonlySet<CardRarity> = new Set([
     CardRarity.Common,
@@ -91,10 +95,10 @@ export class SafeQueryOptions implements QueryOptionsData {
         init = init || {};
         this.ascend = safeBoolean(init.ascend);
         this.baseOnly = safeBoolean(init.baseOnly);
-        this.filter = safeAlphaNumeric(init.filter);
+        this.filter = safeSearchTerm(init.filter);
         this.format = safeFormat(init.format);
         this.legality = safeLegality(init.legality, this.format);
-        this.limit = sanitizeInt(init.limit, 25);
+        this.limit = sanitizeInt(init.limit, 25, MAX_PAGE_LIMIT);
         this.page = sanitizeInt(init.page, 1);
         this.rarity = safeRarity(init.rarity);
         this.setCode = safeSetCode(init.setCode);

--- a/src/http/base/query.util.ts
+++ b/src/http/base/query.util.ts
@@ -1,10 +1,16 @@
+// Longest history window any UI control requests (the "1y" button). "All" sends
+// no `days`, so a caller asking for more than this is clamped rather than left
+// to scan with an unbounded window.
+export const MAX_HISTORY_DAYS = 365;
+
 /**
- * Parse a `days` query parameter string into a positive integer, or undefined.
+ * Parse a `days` query parameter string into a positive integer (capped at
+ * MAX_HISTORY_DAYS), or undefined.
  */
 export function parseDaysParam(days?: string): number | undefined {
     if (!days) return undefined;
     const parsed = parseInt(days, 10);
     if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
     if (String(parsed) !== days) return undefined;
-    return parsed;
+    return Math.min(parsed, MAX_HISTORY_DAYS);
 }

--- a/src/http/hbs/set/set.controller.ts
+++ b/src/http/hbs/set/set.controller.ts
@@ -19,6 +19,7 @@ import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
 import { OptionalAuthGuard } from 'src/http/auth/optional-auth.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { parseDaysParam } from 'src/http/base/query.util';
 import { SetListViewDto } from './dto/set-list.view.dto';
 import { SetPriceHistoryResponseDto } from './dto/set-price-history-response.dto';
 import { SetViewDto } from './dto/set.view.dto';
@@ -85,11 +86,7 @@ export class SetController {
         @Param('code') code: string,
         @Query('days') days?: string
     ): Promise<SetPriceHistoryResponseDto> {
-        const parsedDays = days ? parseInt(days, 10) : undefined;
-        return this.setOrchestrator.getSetPriceHistory(
-            code,
-            Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : undefined
-        );
+        return this.setOrchestrator.getSetPriceHistory(code, parseDaysParam(days));
     }
 
     @UseGuards(OptionalAuthGuard)

--- a/test/core/query/query.util.spec.ts
+++ b/test/core/query/query.util.spec.ts
@@ -1,5 +1,28 @@
-import { resolveSort } from 'src/core/query/query.util';
+import { resolveSort, sanitizeInt } from 'src/core/query/query.util';
 import { SortOptions, TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
+
+describe('sanitizeInt', () => {
+    it('parses a valid positive integer string', () => {
+        expect(sanitizeInt('42', 25)).toBe(42);
+    });
+
+    it('falls back to the default for non-numeric, zero, or negative input', () => {
+        expect(sanitizeInt('abc', 25)).toBe(25);
+        expect(sanitizeInt('0', 25)).toBe(25);
+        expect(sanitizeInt('-5', 25)).toBe(25);
+        expect(sanitizeInt(undefined, 25)).toBe(25);
+        expect(sanitizeInt(['a', 'b'] as never, 25)).toBe(25);
+    });
+
+    it('clamps to max when one is given', () => {
+        expect(sanitizeInt('1000000', 25, 100)).toBe(100);
+        expect(sanitizeInt('50', 25, 100)).toBe(50);
+    });
+
+    it('does not clamp when no max is given', () => {
+        expect(sanitizeInt('1000000', 25)).toBe(1000000);
+    });
+});
 
 describe('resolveSort', () => {
     it('returns the sort when it is in the allowed set', () => {

--- a/test/core/query/query.util.spec.ts
+++ b/test/core/query/query.util.spec.ts
@@ -22,6 +22,15 @@ describe('sanitizeInt', () => {
     it('does not clamp when no max is given', () => {
         expect(sanitizeInt('1000000', 25)).toBe(1000000);
     });
+
+    it('coerces a numeric input to an integer and rejects non-finite numbers', () => {
+        expect(sanitizeInt(2.7, 25)).toBe(2);
+        expect(sanitizeInt(NaN, 25)).toBe(25);
+        expect(sanitizeInt(NaN, 25, 100)).toBe(25);
+        expect(sanitizeInt(Infinity, 25)).toBe(25);
+        expect(sanitizeInt(0.5, 25)).toBe(25);
+        expect(sanitizeInt(50, 25)).toBe(50);
+    });
 });
 
 describe('resolveSort', () => {

--- a/test/core/query/safe-query-options.spec.ts
+++ b/test/core/query/safe-query-options.spec.ts
@@ -94,6 +94,37 @@ describe('SafeQueryOptions — public catalog filters', () => {
         });
     });
 
+    describe('filter', () => {
+        it('preserves apostrophes and commas so cards like "Urza\'s" are findable', () => {
+            const opts = new SafeQueryOptions({ filter: "Urza's, Tower" });
+            expect(opts.filter).toBe("Urza's, Tower");
+        });
+
+        it('strips characters outside the search charset', () => {
+            const opts = new SafeQueryOptions({ filter: 'name<script>' });
+            expect(opts.filter).toBe('namescript');
+        });
+
+        it('is undefined when blank after sanitizing', () => {
+            const opts = new SafeQueryOptions({ filter: '<<>>' });
+            expect(opts.filter).toBeUndefined();
+        });
+    });
+
+    describe('limit', () => {
+        it('defaults to 25 when absent', () => {
+            expect(new SafeQueryOptions({}).limit).toBe(25);
+        });
+
+        it('caps oversized page sizes at MAX_PAGE_LIMIT', () => {
+            expect(new SafeQueryOptions({ limit: '1000000' }).limit).toBe(100);
+        });
+
+        it('passes through a value under the cap', () => {
+            expect(new SafeQueryOptions({ limit: '50' }).limit).toBe(50);
+        });
+    });
+
     describe('format / legality', () => {
         it.each(Object.values(Format))('accepts format %s', (format) => {
             const opts = new SafeQueryOptions({ format });

--- a/test/http/base/query.util.spec.ts
+++ b/test/http/base/query.util.spec.ts
@@ -44,4 +44,9 @@ describe('parseDaysParam', () => {
     it('should handle large valid numbers', () => {
         expect(parseDaysParam('365')).toBe(365);
     });
+
+    it('should clamp values above the max window', () => {
+        expect(parseDaysParam('366')).toBe(365);
+        expect(parseDaysParam('1000000')).toBe(365);
+    });
 });


### PR DESCRIPTION
Closes #571. Work package **W3** from the July 2026 cross-repo analysis (Wave 2, P2).

## Changes

- **B7 — apostrophe/comma cards unfindable via filter.** `SafeQueryOptions.filter` now uses `safeSearchTerm`'s charset instead of `safeAlphaNumeric`, so filtering "Urza's" on a set page matches (it silently matched nothing before, while the search bar worked). The ILIKE queries are already parameterized, so the extra characters are safe.
- **B8 — unbounded page size.** `sanitizeInt` gained an optional `max`; `SafeQueryOptions` clamps `limit` at `MAX_PAGE_LIMIT` (100) in one place, so every list endpoint (sets, set cards, search, inventory, transactions, public card search) is covered instead of accepting `?limit=1000000`.
- **B14 (partial) — `days` clamp.** `parseDaysParam` clamps to `MAX_HISTORY_DAYS` (365, the largest window any UI control requests; "All" sends no `days`). The HBS set controller now routes through `parseDaysParam` instead of a raw `parseInt`.
- **B5 — inert pg pool config.** Replaced the mysql2 pool keys (`connectionLimit`/`queueLimit`/`waitForConnections`, which `pg.Pool` ignored) with real pg options (`max`, `idleTimeoutMillis`, `connectionTimeoutMillis`) and deduped the two TypeORM config branches into one shared block.

## Tests

- Unit: added `sanitizeInt` max-cap tests, `SafeQueryOptions` filter-charset + limit-cap tests, `parseDaysParam` clamp tests. Full suite 1407 pass.
- Integration: set suite (filter/days/pagination) passes against real Postgres, confirming the new pool config connects.