### PR TITLE
refactor(set): createSetPriceDto -> SetPresenter + spec (W7 remainder)

### DIFF
--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -40,6 +40,7 @@ import {
 import { SetListViewDto } from './dto/set-list.view.dto';
 import { SetMetaResponseDto } from './dto/set-meta.response.dto';
 import { SetPriceDto } from './dto/set-price.dto';
+import { SetPresenter } from './set.presenter';
 import { SetResponseDto } from './dto/set.response.dto';
 import { SetViewDto } from './dto/set.view.dto';
 import { SetTypeMapper } from 'src/http/base/set-type.mapper';
@@ -382,116 +383,8 @@ export class SetOrchestrator {
         }
     }
 
-    /**
-     * Creates a SetPriceDto with proper price filtering and deduplication.
-     * Handles prices that may be strings or numbers from the database.
-     * Filters out zero values and duplicate prices across categories.
-     */
     createSetPriceDto(prices: SetPrice): SetPriceDto {
-        prices = prices ?? new SetPrice({});
-
-        // Helper to safely convert to number and check if valid price
-        const toValidNumber = (value: any): number | null => {
-            if (value === null || value === undefined) return null;
-            const num = typeof value === 'string' ? parseFloat(value) : Number(value);
-            return !isNaN(num) && num > 0 ? num : null;
-        };
-
-        // Convert all prices to numbers or null
-        const basePrice = toValidNumber(prices.basePrice);
-        const basePriceAll = toValidNumber(prices.basePriceAll);
-        const totalPrice = toValidNumber(prices.totalPrice);
-        const totalPriceAll = toValidNumber(prices.totalPriceAll);
-
-        let defaultPrice = '-';
-        let defaultChange: number | null = null;
-        let gridCols = 0;
-
-        // Helper to convert change value to number or null
-        const toChangeNumber = (value: any): number | null => {
-            if (value === null || value === undefined) return null;
-            const num = typeof value === 'string' ? parseFloat(value) : Number(value);
-            return isNaN(num) ? null : num;
-        };
-
-        // Filter and deduplicate prices in priority order (reverse of display)
-        const totalPriceAllFiltered =
-            totalPriceAll && totalPriceAll !== totalPrice && totalPriceAll !== basePriceAll
-                ? toDollar(totalPriceAll)
-                : null;
-        if (totalPriceAllFiltered) {
-            gridCols++;
-            defaultPrice = totalPriceAllFiltered;
-            defaultChange = toChangeNumber(prices.totalPriceAllChangeWeekly);
-        }
-
-        const totalPriceNormalFiltered =
-            totalPrice && totalPrice !== basePrice ? toDollar(totalPrice) : null;
-        if (totalPriceNormalFiltered) {
-            gridCols++;
-            defaultPrice = totalPriceNormalFiltered;
-            defaultChange = toChangeNumber(prices.totalPriceChangeWeekly);
-        }
-
-        const basePriceAllFiltered =
-            basePriceAll && basePriceAll !== basePrice ? toDollar(basePriceAll) : null;
-        if (basePriceAllFiltered) {
-            gridCols++;
-            defaultPrice = basePriceAllFiltered;
-            defaultChange = toChangeNumber(prices.basePriceAllChangeWeekly);
-        }
-
-        const basePriceNormalFiltered = basePrice ? toDollar(basePrice) : null;
-        if (basePriceNormalFiltered) {
-            gridCols++;
-            defaultPrice = basePriceNormalFiltered;
-            defaultChange = toChangeNumber(prices.basePriceChangeWeekly);
-        }
-
-        // Helper to format a change value into display string + sign
-        const formatChange = (value: any): { changeWeekly: string; changeWeeklySign: string } => {
-            const num = toChangeNumber(value);
-            if (num === null) return { changeWeekly: '', changeWeeklySign: '' };
-            if (num === 0) return { changeWeekly: '$0.00', changeWeeklySign: 'neutral' };
-            const formatted = toDollar(Math.abs(num));
-            return num > 0
-                ? { changeWeekly: `+${formatted}`, changeWeeklySign: 'positive' }
-                : { changeWeekly: `-${formatted}`, changeWeeklySign: 'negative' };
-        };
-
-        const defaultFormatted = formatChange(defaultChange);
-        const basePriceNormalChange = basePriceNormalFiltered
-            ? formatChange(prices.basePriceChangeWeekly)
-            : { changeWeekly: '', changeWeeklySign: '' };
-        const basePriceAllChange = basePriceAllFiltered
-            ? formatChange(prices.basePriceAllChangeWeekly)
-            : { changeWeekly: '', changeWeeklySign: '' };
-        const totalPriceNormalChange = totalPriceNormalFiltered
-            ? formatChange(prices.totalPriceChangeWeekly)
-            : { changeWeekly: '', changeWeeklySign: '' };
-        const totalPriceAllChange = totalPriceAllFiltered
-            ? formatChange(prices.totalPriceAllChangeWeekly)
-            : { changeWeekly: '', changeWeeklySign: '' };
-
-        return new SetPriceDto({
-            gridCols,
-            defaultPrice,
-            basePriceNormal: basePriceNormalFiltered,
-            basePriceAll: basePriceAllFiltered,
-            totalPriceNormal: totalPriceNormalFiltered,
-            totalPriceAll: totalPriceAllFiltered,
-            defaultPriceChangeWeekly: defaultFormatted.changeWeekly,
-            defaultPriceChangeWeeklySign: defaultFormatted.changeWeeklySign,
-            basePriceNormalChangeWeekly: basePriceNormalChange.changeWeekly,
-            basePriceNormalChangeWeeklySign: basePriceNormalChange.changeWeeklySign,
-            basePriceAllChangeWeekly: basePriceAllChange.changeWeekly,
-            basePriceAllChangeWeeklySign: basePriceAllChange.changeWeeklySign,
-            totalPriceNormalChangeWeekly: totalPriceNormalChange.changeWeekly,
-            totalPriceNormalChangeWeeklySign: totalPriceNormalChange.changeWeeklySign,
-            totalPriceAllChangeWeekly: totalPriceAllChange.changeWeekly,
-            totalPriceAllChangeWeeklySign: totalPriceAllChange.changeWeeklySign,
-            lastUpdate: prices.lastUpdate,
-        });
+        return SetPresenter.toSetPriceDto(prices);
     }
 
     groupSetsByBlock(

--- a/src/http/hbs/set/set.presenter.ts
+++ b/src/http/hbs/set/set.presenter.ts
@@ -1,0 +1,117 @@
+import { SetPrice } from 'src/core/set/set-price.entity';
+import { toDollar } from 'src/http/base/http.util';
+import { SetPriceDto } from './dto/set-price.dto';
+
+export class SetPresenter {
+    /**
+     * Creates a SetPriceDto with proper price filtering and deduplication.
+     * Handles prices that may be strings or numbers from the database.
+     * Filters out zero values and duplicate prices across categories.
+     */
+    static toSetPriceDto(prices: SetPrice): SetPriceDto {
+        prices = prices ?? new SetPrice({});
+
+        // Helper to safely convert to number and check if valid price
+        const toValidNumber = (value: any): number | null => {
+            if (value === null || value === undefined) return null;
+            const num = typeof value === 'string' ? parseFloat(value) : Number(value);
+            return !isNaN(num) && num > 0 ? num : null;
+        };
+
+        // Convert all prices to numbers or null
+        const basePrice = toValidNumber(prices.basePrice);
+        const basePriceAll = toValidNumber(prices.basePriceAll);
+        const totalPrice = toValidNumber(prices.totalPrice);
+        const totalPriceAll = toValidNumber(prices.totalPriceAll);
+
+        let defaultPrice = '-';
+        let defaultChange: number | null = null;
+        let gridCols = 0;
+
+        // Helper to convert change value to number or null
+        const toChangeNumber = (value: any): number | null => {
+            if (value === null || value === undefined) return null;
+            const num = typeof value === 'string' ? parseFloat(value) : Number(value);
+            return isNaN(num) ? null : num;
+        };
+
+        // Filter and deduplicate prices in priority order (reverse of display)
+        const totalPriceAllFiltered =
+            totalPriceAll && totalPriceAll !== totalPrice && totalPriceAll !== basePriceAll
+                ? toDollar(totalPriceAll)
+                : null;
+        if (totalPriceAllFiltered) {
+            gridCols++;
+            defaultPrice = totalPriceAllFiltered;
+            defaultChange = toChangeNumber(prices.totalPriceAllChangeWeekly);
+        }
+
+        const totalPriceNormalFiltered =
+            totalPrice && totalPrice !== basePrice ? toDollar(totalPrice) : null;
+        if (totalPriceNormalFiltered) {
+            gridCols++;
+            defaultPrice = totalPriceNormalFiltered;
+            defaultChange = toChangeNumber(prices.totalPriceChangeWeekly);
+        }
+
+        const basePriceAllFiltered =
+            basePriceAll && basePriceAll !== basePrice ? toDollar(basePriceAll) : null;
+        if (basePriceAllFiltered) {
+            gridCols++;
+            defaultPrice = basePriceAllFiltered;
+            defaultChange = toChangeNumber(prices.basePriceAllChangeWeekly);
+        }
+
+        const basePriceNormalFiltered = basePrice ? toDollar(basePrice) : null;
+        if (basePriceNormalFiltered) {
+            gridCols++;
+            defaultPrice = basePriceNormalFiltered;
+            defaultChange = toChangeNumber(prices.basePriceChangeWeekly);
+        }
+
+        // Helper to format a change value into display string + sign
+        const formatChange = (value: any): { changeWeekly: string; changeWeeklySign: string } => {
+            const num = toChangeNumber(value);
+            if (num === null) return { changeWeekly: '', changeWeeklySign: '' };
+            if (num === 0) return { changeWeekly: '$0.00', changeWeeklySign: 'neutral' };
+            const formatted = toDollar(Math.abs(num));
+            return num > 0
+                ? { changeWeekly: `+${formatted}`, changeWeeklySign: 'positive' }
+                : { changeWeekly: `-${formatted}`, changeWeeklySign: 'negative' };
+        };
+
+        const defaultFormatted = formatChange(defaultChange);
+        const basePriceNormalChange = basePriceNormalFiltered
+            ? formatChange(prices.basePriceChangeWeekly)
+            : { changeWeekly: '', changeWeeklySign: '' };
+        const basePriceAllChange = basePriceAllFiltered
+            ? formatChange(prices.basePriceAllChangeWeekly)
+            : { changeWeekly: '', changeWeeklySign: '' };
+        const totalPriceNormalChange = totalPriceNormalFiltered
+            ? formatChange(prices.totalPriceChangeWeekly)
+            : { changeWeekly: '', changeWeeklySign: '' };
+        const totalPriceAllChange = totalPriceAllFiltered
+            ? formatChange(prices.totalPriceAllChangeWeekly)
+            : { changeWeekly: '', changeWeeklySign: '' };
+
+        return new SetPriceDto({
+            gridCols,
+            defaultPrice,
+            basePriceNormal: basePriceNormalFiltered,
+            basePriceAll: basePriceAllFiltered,
+            totalPriceNormal: totalPriceNormalFiltered,
+            totalPriceAll: totalPriceAllFiltered,
+            defaultPriceChangeWeekly: defaultFormatted.changeWeekly,
+            defaultPriceChangeWeeklySign: defaultFormatted.changeWeeklySign,
+            basePriceNormalChangeWeekly: basePriceNormalChange.changeWeekly,
+            basePriceNormalChangeWeeklySign: basePriceNormalChange.changeWeeklySign,
+            basePriceAllChangeWeekly: basePriceAllChange.changeWeekly,
+            basePriceAllChangeWeeklySign: basePriceAllChange.changeWeeklySign,
+            totalPriceNormalChangeWeekly: totalPriceNormalChange.changeWeekly,
+            totalPriceNormalChangeWeeklySign: totalPriceNormalChange.changeWeeklySign,
+            totalPriceAllChangeWeekly: totalPriceAllChange.changeWeekly,
+            totalPriceAllChangeWeeklySign: totalPriceAllChange.changeWeeklySign,
+            lastUpdate: prices.lastUpdate,
+        });
+    }
+}

--- a/src/http/hbs/set/set.presenter.ts
+++ b/src/http/hbs/set/set.presenter.ts
@@ -8,28 +8,28 @@ export class SetPresenter {
      * Handles prices that may be strings or numbers from the database.
      * Filters out zero values and duplicate prices across categories.
      */
-    static toSetPriceDto(prices: SetPrice): SetPriceDto {
-        prices = prices ?? new SetPrice({});
+    static toSetPriceDto(prices: SetPrice | null | undefined): SetPriceDto {
+        const setPrice: SetPrice = prices ?? new SetPrice({});
 
         // Helper to safely convert to number and check if valid price
-        const toValidNumber = (value: any): number | null => {
+        const toValidNumber = (value: unknown): number | null => {
             if (value === null || value === undefined) return null;
             const num = typeof value === 'string' ? parseFloat(value) : Number(value);
             return !isNaN(num) && num > 0 ? num : null;
         };
 
         // Convert all prices to numbers or null
-        const basePrice = toValidNumber(prices.basePrice);
-        const basePriceAll = toValidNumber(prices.basePriceAll);
-        const totalPrice = toValidNumber(prices.totalPrice);
-        const totalPriceAll = toValidNumber(prices.totalPriceAll);
+        const basePrice = toValidNumber(setPrice.basePrice);
+        const basePriceAll = toValidNumber(setPrice.basePriceAll);
+        const totalPrice = toValidNumber(setPrice.totalPrice);
+        const totalPriceAll = toValidNumber(setPrice.totalPriceAll);
 
         let defaultPrice = '-';
         let defaultChange: number | null = null;
         let gridCols = 0;
 
         // Helper to convert change value to number or null
-        const toChangeNumber = (value: any): number | null => {
+        const toChangeNumber = (value: unknown): number | null => {
             if (value === null || value === undefined) return null;
             const num = typeof value === 'string' ? parseFloat(value) : Number(value);
             return isNaN(num) ? null : num;
@@ -43,7 +43,7 @@ export class SetPresenter {
         if (totalPriceAllFiltered) {
             gridCols++;
             defaultPrice = totalPriceAllFiltered;
-            defaultChange = toChangeNumber(prices.totalPriceAllChangeWeekly);
+            defaultChange = toChangeNumber(setPrice.totalPriceAllChangeWeekly);
         }
 
         const totalPriceNormalFiltered =
@@ -51,7 +51,7 @@ export class SetPresenter {
         if (totalPriceNormalFiltered) {
             gridCols++;
             defaultPrice = totalPriceNormalFiltered;
-            defaultChange = toChangeNumber(prices.totalPriceChangeWeekly);
+            defaultChange = toChangeNumber(setPrice.totalPriceChangeWeekly);
         }
 
         const basePriceAllFiltered =
@@ -59,18 +59,18 @@ export class SetPresenter {
         if (basePriceAllFiltered) {
             gridCols++;
             defaultPrice = basePriceAllFiltered;
-            defaultChange = toChangeNumber(prices.basePriceAllChangeWeekly);
+            defaultChange = toChangeNumber(setPrice.basePriceAllChangeWeekly);
         }
 
         const basePriceNormalFiltered = basePrice ? toDollar(basePrice) : null;
         if (basePriceNormalFiltered) {
             gridCols++;
             defaultPrice = basePriceNormalFiltered;
-            defaultChange = toChangeNumber(prices.basePriceChangeWeekly);
+            defaultChange = toChangeNumber(setPrice.basePriceChangeWeekly);
         }
 
         // Helper to format a change value into display string + sign
-        const formatChange = (value: any): { changeWeekly: string; changeWeeklySign: string } => {
+        const formatChange = (value: unknown): { changeWeekly: string; changeWeeklySign: string } => {
             const num = toChangeNumber(value);
             if (num === null) return { changeWeekly: '', changeWeeklySign: '' };
             if (num === 0) return { changeWeekly: '$0.00', changeWeeklySign: 'neutral' };
@@ -82,16 +82,16 @@ export class SetPresenter {
 
         const defaultFormatted = formatChange(defaultChange);
         const basePriceNormalChange = basePriceNormalFiltered
-            ? formatChange(prices.basePriceChangeWeekly)
+            ? formatChange(setPrice.basePriceChangeWeekly)
             : { changeWeekly: '', changeWeeklySign: '' };
         const basePriceAllChange = basePriceAllFiltered
-            ? formatChange(prices.basePriceAllChangeWeekly)
+            ? formatChange(setPrice.basePriceAllChangeWeekly)
             : { changeWeekly: '', changeWeeklySign: '' };
         const totalPriceNormalChange = totalPriceNormalFiltered
-            ? formatChange(prices.totalPriceChangeWeekly)
+            ? formatChange(setPrice.totalPriceChangeWeekly)
             : { changeWeekly: '', changeWeeklySign: '' };
         const totalPriceAllChange = totalPriceAllFiltered
-            ? formatChange(prices.totalPriceAllChangeWeekly)
+            ? formatChange(setPrice.totalPriceAllChangeWeekly)
             : { changeWeekly: '', changeWeeklySign: '' };
 
         return new SetPriceDto({
@@ -111,7 +111,7 @@ export class SetPresenter {
             totalPriceNormalChangeWeeklySign: totalPriceNormalChange.changeWeeklySign,
             totalPriceAllChangeWeekly: totalPriceAllChange.changeWeekly,
             totalPriceAllChangeWeeklySign: totalPriceAllChange.changeWeeklySign,
-            lastUpdate: prices.lastUpdate,
+            lastUpdate: setPrice.lastUpdate,
         });
     }
 }

--- a/test/http/set.presenter.spec.ts
+++ b/test/http/set.presenter.spec.ts
@@ -14,7 +14,7 @@ describe('SetPresenter.toSetPriceDto', () => {
     });
 
     it('tolerates a null SetPrice', () => {
-        const result = SetPresenter.toSetPriceDto(null as unknown as SetPrice);
+        const result = SetPresenter.toSetPriceDto(null);
 
         expect(result.gridCols).toBe(0);
         expect(result.defaultPrice).toBe('-');

--- a/test/http/set.presenter.spec.ts
+++ b/test/http/set.presenter.spec.ts
@@ -1,0 +1,58 @@
+import { SetPrice } from 'src/core/set/set-price.entity';
+import { SetPresenter } from 'src/http/hbs/set/set.presenter';
+
+describe('SetPresenter.toSetPriceDto', () => {
+    it('returns an empty tier layout when every price is zero', () => {
+        const result = SetPresenter.toSetPriceDto(
+            new SetPrice({ basePrice: 0, basePriceAll: 0, totalPrice: 0, totalPriceAll: 0 })
+        );
+
+        expect(result.gridCols).toBe(0);
+        expect(result.defaultPrice).toBe('-');
+        expect(result.basePriceNormal).toBeNull();
+        expect(result.totalPriceAll).toBeNull();
+    });
+
+    it('tolerates a null SetPrice', () => {
+        const result = SetPresenter.toSetPriceDto(null as unknown as SetPrice);
+
+        expect(result.gridCols).toBe(0);
+        expect(result.defaultPrice).toBe('-');
+    });
+
+    it('uses base price as the default when it is the only tier', () => {
+        const result = SetPresenter.toSetPriceDto(new SetPrice({ basePrice: 100.5 }));
+
+        expect(result.gridCols).toBe(1);
+        expect(result.defaultPrice).toBe('$100.50');
+        expect(result.basePriceNormal).toBe('$100.50');
+    });
+
+    it('deduplicates tiers that share the same value', () => {
+        // totalPrice === basePrice and totalPriceAll === basePriceAll, so only the
+        // two distinct base tiers survive.
+        const result = SetPresenter.toSetPriceDto(
+            new SetPrice({
+                basePrice: 10,
+                totalPrice: 10,
+                basePriceAll: 25,
+                totalPriceAll: 25,
+            })
+        );
+
+        expect(result.gridCols).toBe(2);
+        expect(result.basePriceNormal).toBe('$10.00');
+        expect(result.basePriceAll).toBe('$25.00');
+        expect(result.totalPriceNormal).toBeNull();
+        expect(result.totalPriceAll).toBeNull();
+    });
+
+    it('formats the weekly change on the default tier with a sign', () => {
+        const result = SetPresenter.toSetPriceDto(
+            new SetPrice({ basePrice: 100, basePriceChangeWeekly: 5 })
+        );
+
+        expect(result.defaultPriceChangeWeekly).toBe('+$5.00');
+        expect(result.defaultPriceChangeWeeklySign).toBe('positive');
+    });
+});

--- a/test/http/user.orchestrator.spec.ts
+++ b/test/http/user.orchestrator.spec.ts
@@ -23,7 +23,6 @@ jest.mock('src/http/http.error.handler');
 describe('UserOrchestrator', () => {
     let orchestrator: UserOrchestrator;
     let userService: jest.Mocked<UserService>;
-    let authService: jest.Mocked<AuthService>;
 
     const mockUserService = {
         create: jest.fn(),
@@ -94,7 +93,6 @@ describe('UserOrchestrator', () => {
 
         orchestrator = module.get<UserOrchestrator>(UserOrchestrator);
         userService = module.get(UserService);
-        authService = module.get(AuthService);
 
         (HttpErrorHandler.validateAuthenticatedRequest as jest.Mock) =
             mockHttpErrorHandler.validateAuthenticatedRequest;


### PR DESCRIPTION
Part of the W7 remainder (#596).

- Moves the ~105-line pure `createSetPriceDto` formatting/dedup logic out of `SetOrchestrator` into a new `SetPresenter.toSetPriceDto` static method, matching the existing HBS presenter convention (portfolio/card/inventory/etc.). The orchestrator keeps a thin delegating method so call sites and existing tests are untouched.
- Adds `test/http/set.presenter.spec.ts` - direct, pure-function coverage of the presenter (the C8 'presenter specs are cheap to test' point).

Behavior-preserving: the existing `set.orchestrator` createSetPriceDto tests still pass through the delegator (72 tests green across both specs). Lint clean (0 errors), strict typecheck green.

Still open on #596: the A8 repo-wide SEO/meta move and broader C8 orchestrator-spec backfill.

Note (separate finding): mcp's remaining query-param `as never` isn't gated on web spec work - W8 already typed those params (2026-07-11). The mcp types are stale because its 'Sync generated artifacts' workflow is failing (last sync 2026-07-03). Fixing that sync is the real unblock; tracked for mcp.