### PR TITLE
refactor(hbs): move SEO/meta assembly into orchestrators (W7 A8)

### DIFF
--- a/src/http/hbs/billing/billing.orchestrator.ts
+++ b/src/http/hbs/billing/billing.orchestrator.ts
@@ -5,6 +5,7 @@ import { SubscriptionService } from 'src/core/billing/subscription.service';
 import { User } from 'src/core/user/user.entity';
 import { UserService } from 'src/core/user/user.service';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { isAuthenticated } from 'src/http/base/http.util';
 import { BillingViewDto, SubscriptionSummary } from './dto/billing.view.dto';
 
 @Injectable()
@@ -24,7 +25,7 @@ export class BillingOrchestrator {
         const subscription = await this.subscriptionService.getSubscriptionForUser(req.user.id);
         const summary = this.toSummary(subscription);
         return new BillingViewDto({
-            authenticated: req.isAuthenticated(),
+            authenticated: isAuthenticated(req),
             subscribed: !!summary?.isActive,
             breadcrumbs: this.breadCrumbs,
             indexable: false,

--- a/src/http/hbs/card/card.controller.ts
+++ b/src/http/hbs/card/card.controller.ts
@@ -1,9 +1,6 @@
 import { Controller, Get, Inject, Param, Query, Render, Req, UseGuards } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { OptionalAuthGuard } from 'src/http/auth/optional-auth.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
-import { buildCardUrl } from 'src/http/base/http.util';
-import { buildBreadcrumbJsonLd, buildCardJsonLd, buildJsonLd } from 'src/http/base/json-ld.util';
 import { parseDaysParam } from 'src/http/base/query.util';
 import { getLogger } from 'src/logger/global-app-logger';
 import { CardOrchestrator } from './card.orchestrator';
@@ -13,14 +10,10 @@ import { PriceHistoryResponseDto } from './dto/price-history-response.dto';
 @Controller('card')
 export class CardController {
     private readonly LOGGER = getLogger(CardController.name);
-    private readonly appUrl: string;
 
     constructor(
-        @Inject(CardOrchestrator) private readonly cardOrchestrator: CardOrchestrator,
-        private readonly configService: ConfigService
-    ) {
-        this.appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
-    }
+        @Inject(CardOrchestrator) private readonly cardOrchestrator: CardOrchestrator
+    ) {}
 
     @Get(':cardId/price-history')
     async getPriceHistory(
@@ -42,19 +35,6 @@ export class CardController {
         this.LOGGER.log(`Find set card ${setCode}/${setNumber}.`);
         const view = await this.cardOrchestrator.findSetCard(req, setCode, setNumber);
         this.LOGGER.log(`Found set card ${setCode}/${setNumber} -> ID: ${view?.card?.cardId}.`);
-        const cardName = view.card?.name || 'Card';
-        const setName = view.card?.setName || setCode.toUpperCase();
-        const cardUrl = buildCardUrl(setCode, setNumber);
-        view.title = `${cardName} (${setName}) - I Want My MTG`;
-        view.metaDescription = `${cardName} from ${setName} - prices, legalities, and other printings.`;
-        view.indexable = true;
-        view.lcpImageUrl = view.card?.imgSrc;
-        view.canonicalUrl = `${this.appUrl}${cardUrl}`;
-        view.ogImage = view.card?.imgSrc;
-        view.jsonLd = buildJsonLd(
-            buildCardJsonLd(this.appUrl, view.card, cardUrl),
-            buildBreadcrumbJsonLd(this.appUrl, view.breadcrumbs)
-        );
         return view;
     }
 }

--- a/src/http/hbs/card/card.orchestrator.ts
+++ b/src/http/hbs/card/card.orchestrator.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Card } from 'src/core/card/card.entity';
 import { DomainNotFoundError } from 'src/core/errors/domain.errors';
 import { CardImgType } from 'src/core/card/card.img.type.enum';
@@ -11,6 +12,11 @@ import { SortOptions } from 'src/core/query/sort-options.enum';
 import { TransactionService } from 'src/core/transaction/transaction.service';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { buildCardUrl, isAuthenticated, toStringRecord } from 'src/http/base/http.util';
+import {
+    buildBreadcrumbJsonLd,
+    buildCardJsonLd,
+    buildJsonLd,
+} from 'src/http/base/json-ld.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { InventoryPresenter } from 'src/http/hbs/inventory/inventory.presenter';
 import { FilterView } from 'src/http/hbs/list/filter.view';
@@ -28,13 +34,16 @@ import { SingleCardResponseDto } from './dto/single-card.response.dto';
 @Injectable()
 export class CardOrchestrator {
     private readonly LOGGER = getLogger(CardOrchestrator.name);
+    private readonly appUrl: string;
 
     constructor(
         @Inject(CardService) private readonly cardService: CardService,
         @Inject(InventoryService) private readonly inventoryService: InventoryService,
         @Inject(PriceAlertService) private readonly priceAlertService: PriceAlertService,
-        @Inject(TransactionService) private readonly transactionService: TransactionService
+        @Inject(TransactionService) private readonly transactionService: TransactionService,
+        private readonly configService: ConfigService
     ) {
+        this.appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
         this.LOGGER.debug(`Initialized`);
     }
 
@@ -167,14 +176,18 @@ export class CardOrchestrator {
                 printingHeaders.push(setCardSortHeader(options, SortOptions.PRICE_FOIL, ['pr-2']));
             }
 
+            const breadcrumbs = [
+                { label: 'Home', url: '/' },
+                { label: 'Sets', url: '/sets' },
+                { label: singleCard.setCode.toUpperCase(), url: `/sets/${singleCard.setCode}` },
+                { label: singleCard.name, url: baseUrl },
+            ];
+            const cardName = singleCard.name || 'Card';
+            const setName = singleCard.setName || setCode.toUpperCase();
+
             return new CardViewDto({
                 authenticated: isAuthenticated(req),
-                breadcrumbs: [
-                    { label: 'Home', url: '/' },
-                    { label: 'Sets', url: '/sets' },
-                    { label: singleCard.setCode.toUpperCase(), url: `/sets/${singleCard.setCode}` },
-                    { label: singleCard.name, url: baseUrl },
-                ],
+                breadcrumbs,
                 card: singleCard,
                 costBasis,
                 untrackedNormal,
@@ -187,6 +200,16 @@ export class CardOrchestrator {
                 pagination: new PaginationView(options, baseUrl, totalPrintings),
                 filter: new FilterView(options, baseUrl),
                 tableHeadersRow: new TableHeadersRowView(printingHeaders),
+                title: `${cardName} (${setName}) - I Want My MTG`,
+                metaDescription: `${cardName} from ${setName} - prices, legalities, and other printings.`,
+                indexable: true,
+                lcpImageUrl: singleCard.imgSrc,
+                canonicalUrl: `${this.appUrl}${baseUrl}`,
+                ogImage: singleCard.imgSrc,
+                jsonLd: buildJsonLd(
+                    buildCardJsonLd(this.appUrl, singleCard, baseUrl),
+                    buildBreadcrumbJsonLd(this.appUrl, breadcrumbs)
+                ),
             });
         } catch (error) {
             this.LOGGER.debug(`Error finding set card ${setCode}/${setNumber}: ${error?.message}`);

--- a/src/http/hbs/inventory/inventory.orchestrator.ts
+++ b/src/http/hbs/inventory/inventory.orchestrator.ts
@@ -20,7 +20,7 @@ import { TransactionService } from 'src/core/transaction/transaction.service';
 import { ActionStatus } from 'src/http/base/action-status.enum';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { Toast } from 'src/http/base/toast';
-import { completionRate, toDollar } from 'src/http/base/http.util';
+import { completionRate, isAuthenticated, toDollar } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { BaseOnlyToggleView } from 'src/http/hbs/list/base-only-toggle.view';
 import { FilterView } from 'src/http/hbs/list/filter.view';
@@ -94,7 +94,7 @@ export class InventoryOrchestrator {
             this.LOGGER.debug(`Found ${cards.length} inventory items for user ${userId}.`);
 
             return new InventoryViewDto({
-                authenticated: req.isAuthenticated(),
+                authenticated: isAuthenticated(req),
                 baseOnlyToggle: new BaseOnlyToggleView(
                     options,
                     baseUrl,

--- a/src/http/hbs/portfolio/portfolio.orchestrator.ts
+++ b/src/http/hbs/portfolio/portfolio.orchestrator.ts
@@ -25,7 +25,7 @@ import {
     ColorChipView,
 } from './dto/portfolio-breakdown.view.dto';
 import { PortfolioViewDto } from './dto/portfolio.view.dto';
-import { formatGain, gainSign } from 'src/http/base/http.util';
+import { formatGain, gainSign, isAuthenticated } from 'src/http/base/http.util';
 import {
     CardPerformanceViewData,
     PortfolioPresenter,
@@ -120,7 +120,7 @@ export class PortfolioOrchestrator {
             }
 
             return new PortfolioViewDto({
-                authenticated: req.isAuthenticated(),
+                authenticated: isAuthenticated(req),
                 subscribed,
                 breadcrumbs: [
                     { label: 'Home', url: '/' },

--- a/src/http/hbs/sealed-product/sealed-product.controller.ts
+++ b/src/http/hbs/sealed-product/sealed-product.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Get, Inject, Param, Render, Req, UseGuards } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { OptionalAuthGuard } from 'src/http/auth/optional-auth.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { SealedProductDetailViewDto } from './dto/sealed-product-view.dto';
@@ -7,15 +6,10 @@ import { SealedProductOrchestrator } from './sealed-product.orchestrator';
 
 @Controller('sealed-products')
 export class SealedProductController {
-    private readonly appUrl: string;
-
     constructor(
         @Inject(SealedProductOrchestrator)
-        private readonly orchestrator: SealedProductOrchestrator,
-        private readonly configService: ConfigService
-    ) {
-        this.appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
-    }
+        private readonly orchestrator: SealedProductOrchestrator
+    ) {}
 
     @UseGuards(OptionalAuthGuard)
     @Get(':uuid')
@@ -24,10 +18,6 @@ export class SealedProductController {
         @Param('uuid') uuid: string,
         @Req() req: AuthenticatedRequest
     ): Promise<SealedProductDetailViewDto> {
-        const view = await this.orchestrator.findByUuid(req, uuid);
-        view.title = `${view.product.name} - I Want My MTG`;
-        view.metaDescription = `${view.product.name} sealed product details and pricing.`;
-        view.canonicalUrl = `${this.appUrl}/sealed-products/${uuid}`;
-        return view;
+        return this.orchestrator.findByUuid(req, uuid);
     }
 }

--- a/src/http/hbs/sealed-product/sealed-product.orchestrator.ts
+++ b/src/http/hbs/sealed-product/sealed-product.orchestrator.ts
@@ -1,4 +1,5 @@
 import { HttpException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { SealedProductService } from 'src/core/sealed-product/sealed-product.service';
 import { SetService } from 'src/core/set/set.service';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
@@ -12,12 +13,16 @@ import { SealedProductHbsPresenter } from './sealed-product.presenter';
 @Injectable()
 export class SealedProductOrchestrator {
     private readonly LOGGER = getLogger(SealedProductOrchestrator.name);
+    private readonly appUrl: string;
 
     constructor(
         @Inject(SealedProductService)
         private readonly sealedProductService: SealedProductService,
-        @Inject(SetService) private readonly setService: SetService
-    ) {}
+        @Inject(SetService) private readonly setService: SetService,
+        private readonly configService: ConfigService
+    ) {
+        this.appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
+    }
 
     async findByUuid(
         req: AuthenticatedRequest,
@@ -56,6 +61,9 @@ export class SealedProductOrchestrator {
                 product: row,
                 setName: set?.name,
                 setKeyruneCode: set?.keyruneCode,
+                title: `${row.name} - I Want My MTG`,
+                metaDescription: `${row.name} sealed product details and pricing.`,
+                canonicalUrl: `${this.appUrl}/sealed-products/${uuid}`,
             });
         } catch (error) {
             if (error instanceof HttpException) throw error;

--- a/src/http/hbs/search/search.controller.ts
+++ b/src/http/hbs/search/search.controller.ts
@@ -27,9 +27,6 @@ export class SearchController {
         @Req() req: AuthenticatedRequest
     ): Promise<SearchViewDto> {
         const options = new SearchQueryOptions(query);
-        const view = await this.searchOrchestrator.search(req, options);
-        view.title = options.q ? `Search: ${options.q} - I Want My MTG` : 'Search - I Want My MTG';
-        view.metaDescription = 'Search for Magic: The Gathering cards and sets.';
-        return view;
+        return this.searchOrchestrator.search(req, options);
     }
 }

--- a/src/http/hbs/search/search.orchestrator.ts
+++ b/src/http/hbs/search/search.orchestrator.ts
@@ -51,6 +51,8 @@ export class SearchOrchestrator {
                         { label: 'Search', url: '/search' },
                     ],
                     query: '',
+                    title: 'Search - I Want My MTG',
+                    metaDescription: 'Search for Magic: The Gathering cards and sets.',
                 });
             }
 
@@ -71,6 +73,8 @@ export class SearchOrchestrator {
                 cardTotal: result.cardTotal,
                 setTotal: result.setTotal,
                 pagination: new PaginationView(options, baseUrl, paginationTotal),
+                title: `Search: ${term} - I Want My MTG`,
+                metaDescription: 'Search for Magic: The Gathering cards and sets.',
             });
         } catch (error) {
             this.LOGGER.debug(`Error searching for "${term}": ${error?.message}`);

--- a/src/http/hbs/set/set.controller.ts
+++ b/src/http/hbs/set/set.controller.ts
@@ -14,7 +14,6 @@ import {
     Res,
     UseGuards,
 } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { JwtAuthGuard } from 'src/http/auth/jwt.auth.guard';
 import { OptionalAuthGuard } from 'src/http/auth/optional-auth.guard';
@@ -31,14 +30,9 @@ const SAFE_SET_CODE_RE = /^[A-Za-z0-9_-]+$/;
 
 @Controller('sets')
 export class SetController {
-    private readonly appUrl: string;
-
     constructor(
-        @Inject(SetOrchestrator) private readonly setOrchestrator: SetOrchestrator,
-        private readonly configService: ConfigService
-    ) {
-        this.appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
-    }
+        @Inject(SetOrchestrator) private readonly setOrchestrator: SetOrchestrator
+    ) {}
 
     @UseGuards(OptionalAuthGuard)
     @Get()
@@ -50,7 +44,7 @@ export class SetController {
         const options = new SafeQueryOptions(query).withSetTypes(
             req.user?.includedSetTypes ?? null
         );
-        const view = await this.setOrchestrator.findSetList(
+        return this.setOrchestrator.findSetList(
             req,
             [
                 { label: 'Home', url: '/' },
@@ -58,13 +52,6 @@ export class SetController {
             ],
             options
         );
-        view.title = 'Sets - I Want My MTG';
-        view.metaDescription =
-            'Browse all Magic: The Gathering sets with prices, card lists, and collection tracking.';
-        view.indexable = true;
-        view.canonicalUrl = `${this.appUrl}/sets`;
-        view.ogImage = `${this.appUrl}/public/images/logo.webp`;
-        return view;
     }
 
     @UseGuards(JwtAuthGuard)
@@ -117,12 +104,6 @@ export class SetController {
         const options = new SafeQueryOptions(query).withSetTypes(
             req.user?.includedSetTypes ?? null
         );
-        const view = await this.setOrchestrator.findBySetCode(req, code, options);
-        view.title = `${view.set?.name || code.toUpperCase()} - I Want My MTG`;
-        view.metaDescription = `View cards, prices, and collection stats for ${view.set?.name || code.toUpperCase()}.`;
-        view.indexable = true;
-        view.canonicalUrl = `${this.appUrl}/sets/${code}`;
-        view.ogImage = `${this.appUrl}/public/images/logo.webp`;
-        return view;
+        return this.setOrchestrator.findBySetCode(req, code, options);
     }
 }

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Card } from 'src/core/card/card.entity';
 import { CardImgType } from 'src/core/card/card.img.type.enum';
 import { DomainNotFoundError } from 'src/core/errors/domain.errors';
@@ -48,6 +49,7 @@ import { SetTypeMapper } from 'src/http/base/set-type.mapper';
 @Injectable()
 export class SetOrchestrator {
     private readonly LOGGER = getLogger(SetOrchestrator.name);
+    private readonly appUrl: string;
 
     constructor(
         @Inject(SetService) private readonly setService: SetService,
@@ -57,8 +59,11 @@ export class SetOrchestrator {
         private readonly importService: InventoryImportService,
         @Inject(SetChecklistService) private readonly checklistService: SetChecklistService,
         @Inject(SealedProductService)
-        private readonly sealedProductService: SealedProductService
-    ) {}
+        private readonly sealedProductService: SealedProductService,
+        private readonly configService: ConfigService
+    ) {
+        this.appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
+    }
 
     async findSetList(
         req: AuthenticatedRequest,
@@ -69,10 +74,16 @@ export class SetOrchestrator {
         try {
             const userId = req.user?.id ?? 0;
 
-            if (options.sort) {
-                return await this.findFlatSetList(req, breadcrumbs, options, userId);
-            }
-            return await this.findBlockSetList(req, breadcrumbs, options, userId);
+            const view = options.sort
+                ? await this.findFlatSetList(req, breadcrumbs, options, userId)
+                : await this.findBlockSetList(req, breadcrumbs, options, userId);
+            view.title = 'Sets - I Want My MTG';
+            view.metaDescription =
+                'Browse all Magic: The Gathering sets with prices, card lists, and collection tracking.';
+            view.indexable = true;
+            view.canonicalUrl = `${this.appUrl}/sets`;
+            view.ogImage = `${this.appUrl}/public/images/logo.webp`;
+            return view;
         } catch (error) {
             this.LOGGER.debug(`Error finding list of sets: ${error?.message}`);
             HttpErrorHandler.toHttpException(error, 'findSetList');
@@ -177,6 +188,11 @@ export class SetOrchestrator {
                 authenticated: isAuthenticated(req),
                 breadcrumbs,
                 setList: await this.createSetMetaResponseDtos(userId, sets),
+                title: 'Upcoming Sets - I Want My MTG',
+                metaDescription:
+                    'Preview upcoming Magic: The Gathering sets before they release.',
+                indexable: true,
+                canonicalUrl: `${this.appUrl}/spoilers`,
             });
         } catch (error) {
             this.LOGGER.debug(`Error finding spoiler sets: ${error?.message}`);
@@ -259,6 +275,11 @@ export class SetOrchestrator {
                     hasAnyFoilPrice,
                     isAuthenticated(req)
                 ),
+                title: `${setResponse.name || setCode.toUpperCase()} - I Want My MTG`,
+                metaDescription: `View cards, prices, and collection stats for ${setResponse.name || setCode.toUpperCase()}.`,
+                indexable: true,
+                canonicalUrl: `${this.appUrl}/sets/${setCode}`,
+                ogImage: `${this.appUrl}/public/images/logo.webp`,
             });
         } catch (error) {
             this.LOGGER.debug(`Failed to find set ${setCode}: ${error?.message}.`);

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -278,7 +278,7 @@ export class SetOrchestrator {
                 title: `${setResponse.name || setCode.toUpperCase()} - I Want My MTG`,
                 metaDescription: `View cards, prices, and collection stats for ${setResponse.name || setCode.toUpperCase()}.`,
                 indexable: true,
-                canonicalUrl: `${this.appUrl}/sets/${setCode}`,
+                canonicalUrl: `${this.appUrl}/sets/${set.code.toLowerCase()}`,
                 ogImage: `${this.appUrl}/public/images/logo.webp`,
             });
         } catch (error) {

--- a/src/http/hbs/set/spoilers.controller.ts
+++ b/src/http/hbs/set/spoilers.controller.ts
@@ -1,5 +1,4 @@
 import { Controller, Get, Inject, Render, Req, UseGuards } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { OptionalAuthGuard } from 'src/http/auth/optional-auth.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { SetListViewDto } from './dto/set-list.view.dto';
@@ -7,28 +6,18 @@ import { SetOrchestrator } from './set.orchestrator';
 
 @Controller('spoilers')
 export class SpoilersController {
-    private readonly appUrl: string;
-
     constructor(
-        @Inject(SetOrchestrator) private readonly setOrchestrator: SetOrchestrator,
-        private readonly configService: ConfigService
-    ) {
-        this.appUrl = this.configService.get<string>('APP_URL', 'http://localhost:3000');
-    }
+        @Inject(SetOrchestrator) private readonly setOrchestrator: SetOrchestrator
+    ) {}
 
     @UseGuards(OptionalAuthGuard)
     @Get()
     @Render('spoilers')
     async findSpoilers(@Req() req: AuthenticatedRequest): Promise<SetListViewDto> {
-        const view = await this.setOrchestrator.findSpoilersList(req, [
+        return this.setOrchestrator.findSpoilersList(req, [
             { label: 'Home', url: '/' },
             { label: 'Sets', url: '/sets' },
             { label: 'Spoilers', url: '/spoilers' },
         ]);
-        view.title = 'Upcoming Sets - I Want My MTG';
-        view.metaDescription = 'Preview upcoming Magic: The Gathering sets before they release.';
-        view.indexable = true;
-        view.canonicalUrl = `${this.appUrl}/spoilers`;
-        return view;
     }
 }

--- a/src/http/hbs/user/user.orchestrator.ts
+++ b/src/http/hbs/user/user.orchestrator.ts
@@ -7,6 +7,7 @@ import { UserService } from 'src/core/user/user.service';
 import { ActionStatus } from 'src/http/base/action-status.enum';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { BaseViewDto } from 'src/http/base/base.view.dto';
+import { isAuthenticated } from 'src/http/base/http.util';
 import { Toast } from 'src/http/base/toast';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
@@ -213,7 +214,7 @@ export class UserOrchestrator {
                 req.query.action === 'login';
             this.LOGGER.debug(`User ${userId} login ${login ? 'success' : 'failed'}.`);
             return {
-                authenticated: req.isAuthenticated(),
+                authenticated: isAuthenticated(req),
                 breadcrumbs: this.breadCrumbs,
                 indexable: false,
                 title: 'My Account - I Want My MTG',
@@ -257,7 +258,7 @@ export class UserOrchestrator {
             if (req.user.email === userRequestDto.email && req.user.name === userRequestDto.name) {
                 this.LOGGER.debug(`No changes detected for user ${userId}.`);
                 return new UserViewDto({
-                    authenticated: req.isAuthenticated(),
+                    authenticated: isAuthenticated(req),
                     breadcrumbs: this.breadCrumbs,
                     toast: new Toast('No changes detected', ActionStatus.INFO),
                     user: null,
@@ -271,7 +272,7 @@ export class UserOrchestrator {
             const updatedUser: UserResponseDto = await this.userService.update(updateUser);
             this.LOGGER.debug(`User ${updatedUser.id} updated successfully.`);
             return new UserViewDto({
-                authenticated: req.isAuthenticated(),
+                authenticated: isAuthenticated(req),
                 breadcrumbs: this.breadCrumbs,
                 toast: new Toast(
                     `User ${updatedUser.name} updated successfully`,
@@ -301,7 +302,7 @@ export class UserOrchestrator {
                 `Password update for user ${userId}: ${pwdUpdated ? 'success' : 'failed'}.`
             );
             return new BaseViewDto({
-                authenticated: req.isAuthenticated(),
+                authenticated: isAuthenticated(req),
                 breadcrumbs: this.breadCrumbs,
                 toast: new Toast(
                     pwdUpdated ? 'Password updated' : 'Error updating password',

--- a/test/http/card.orchestrator.spec.ts
+++ b/test/http/card.orchestrator.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Card } from 'src/core/card/card.entity';
 import { CardRarity } from 'src/core/card/card.rarity.enum';
@@ -7,6 +8,7 @@ import { PriceAlertService } from 'src/core/price-alert/price-alert.service';
 import { TransactionService } from 'src/core/transaction/transaction.service';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { buildCardUrl } from 'src/http/base/http.util';
 import { CardOrchestrator } from 'src/http/hbs/card/card.orchestrator';
 import { CardViewDto } from 'src/http/hbs/card/dto/card.view.dto';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
@@ -120,6 +122,12 @@ describe('CardOrchestrator', () => {
                         getRemainingQuantity: jest.fn().mockResolvedValue(0),
                     },
                 },
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string, defaultValue: string) => defaultValue),
+                    },
+                },
             ],
         }).compile();
 
@@ -165,6 +173,20 @@ describe('CardOrchestrator', () => {
             expect(cardService.findBySetCodeAndNumber).toHaveBeenCalled();
             expect(cardService.findWithName).toHaveBeenCalled();
             expect(inventoryService.findForUser).toHaveBeenCalled();
+
+            // setName is absent on this fixture, so the orchestrator falls back to the
+            // upper-cased set code.
+            expect(result.title).toBe('Lightning Bolt (TST) - I Want My MTG');
+            expect(result.metaDescription).toBe(
+                'Lightning Bolt from TST - prices, legalities, and other printings.'
+            );
+            expect(result.indexable).toBe(true);
+            expect(result.canonicalUrl).toBe(
+                `http://localhost:3000${buildCardUrl(result.card.setCode, result.card.number)}`
+            );
+            expect(result.ogImage).toBe(result.card.imgSrc);
+            expect(result.lcpImageUrl).toBe(result.card.imgSrc);
+            expect(result.jsonLd).toBeTruthy();
         });
 
         it('should throw error when card not found', async () => {

--- a/test/http/sealed-product.orchestrator.spec.ts
+++ b/test/http/sealed-product.orchestrator.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { SealedProductInventory } from 'src/core/sealed-product/sealed-product-inventory.entity';
@@ -74,6 +75,12 @@ describe('SealedProductOrchestrator', () => {
                         findByCode: jest.fn(),
                     },
                 },
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string, defaultValue: string) => defaultValue),
+                    },
+                },
             ],
         }).compile();
 
@@ -108,6 +115,11 @@ describe('SealedProductOrchestrator', () => {
             expect(result.product.contentsSummary).toBe('36x Draft Booster Pack');
             expect(result.product.productSize).toBe(36);
             expect(result.product.cardCount).toBe(36);
+            expect(result.title).toBe('Draft Booster Box - I Want My MTG');
+            expect(result.metaDescription).toBe(
+                'Draft Booster Box sealed product details and pricing.'
+            );
+            expect(result.canonicalUrl).toBe('http://localhost:3000/sealed-products/sp-abc');
         });
 
         it('populates breadcrumbs with set and product links', async () => {

--- a/test/http/search/search.orchestrator.spec.ts
+++ b/test/http/search/search.orchestrator.spec.ts
@@ -73,6 +73,8 @@ describe('SearchOrchestrator', () => {
             expect(result.query).toBe('');
             expect(result.cards).toEqual([]);
             expect(result.sets).toEqual([]);
+            expect(result.title).toBe('Search - I Want My MTG');
+            expect(result.metaDescription).toBe('Search for Magic: The Gathering cards and sets.');
         });
 
         it('should return search results with mapped DTOs', async () => {
@@ -97,6 +99,8 @@ describe('SearchOrchestrator', () => {
             expect(result.sets[0].url).toBe('/sets/lea');
             expect(result.cardTotal).toBe(1);
             expect(result.setTotal).toBe(1);
+            expect(result.title).toBe('Search: bolt - I Want My MTG');
+            expect(result.metaDescription).toBe('Search for Magic: The Gathering cards and sets.');
         });
 
         it('should include breadcrumbs', async () => {

--- a/test/http/set.orchestrator.spec.ts
+++ b/test/http/set.orchestrator.spec.ts
@@ -279,7 +279,7 @@ describe('SetOrchestrator', () => {
                 'View cards, prices, and collection stats for Test Set.'
             );
             expect(result.indexable).toBe(true);
-            expect(result.canonicalUrl).toBe('http://localhost:3000/sets/TST');
+            expect(result.canonicalUrl).toBe('http://localhost:3000/sets/tst');
             expect(result.ogImage).toBe('http://localhost:3000/public/images/logo.webp');
         });
 

--- a/test/http/set.orchestrator.spec.ts
+++ b/test/http/set.orchestrator.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Card } from 'src/core/card/card.entity';
 import { CardRarity } from 'src/core/card/card.rarity.enum';
@@ -119,6 +120,12 @@ describe('SetOrchestrator', () => {
                         findInventoryQuantitiesForUser: jest.fn(),
                     },
                 },
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string, defaultValue: string) => defaultValue),
+                    },
+                },
             ],
         }).compile();
 
@@ -158,6 +165,10 @@ describe('SetOrchestrator', () => {
             expect(result.setList.length).toBe(1);
             expect(result.pagination.current).toBe(1);
             expect(result.toast).toBeUndefined();
+            expect(result.title).toBe('Sets - I Want My MTG');
+            expect(result.indexable).toBe(true);
+            expect(result.canonicalUrl).toBe('http://localhost:3000/sets');
+            expect(result.ogImage).toBe('http://localhost:3000/public/images/logo.webp');
         });
 
         it('returns error DTO on service failure', async () => {
@@ -222,6 +233,9 @@ describe('SetOrchestrator', () => {
             expect(result).toBeInstanceOf(SetListViewDto);
             expect(result.setList.length).toBe(1);
             expect(result.pagination).toBeUndefined();
+            expect(result.title).toBe('Upcoming Sets - I Want My MTG');
+            expect(result.indexable).toBe(true);
+            expect(result.canonicalUrl).toBe('http://localhost:3000/spoilers');
         });
 
         it('handles empty spoiler list', async () => {
@@ -260,6 +274,13 @@ describe('SetOrchestrator', () => {
             expect(result.set.cards.length).toBe(1);
             expect(result.pagination.current).toBe(1);
             expect(result.toast).toBeUndefined();
+            expect(result.title).toBe('Test Set - I Want My MTG');
+            expect(result.metaDescription).toBe(
+                'View cards, prices, and collection stats for Test Set.'
+            );
+            expect(result.indexable).toBe(true);
+            expect(result.canonicalUrl).toBe('http://localhost:3000/sets/TST');
+            expect(result.ogImage).toBe('http://localhost:3000/public/images/logo.webp');
         });
 
         it('returns error if set not found', async () => {


### PR DESCRIPTION
Part of #596 (W7 remainder). Addresses the **A8** SEO/meta move and the touched-file slice of **C8**.

## What
- Moves the SEO fields (`title`, `metaDescription`, `canonicalUrl`, `ogImage`, `indexable`, and the card page's `jsonLd`/`lcpImageUrl`) out of the **set**, **card**, **sealed-product**, **search**, and **spoilers** controllers and into their orchestrators, so view assembly lives in one layer instead of being mutated on the DTO after the orchestrator returns. Done repo-wide in one pass (the reason A8 was deferred - doing one controller would have broken cross-controller consistency).
- Unifies the remaining direct `req.isAuthenticated()` calls (billing, inventory, portfolio, user orchestrators) on the `isAuthenticated(req)` helper.
- Adds SEO assertions to the four touched orchestrator specs to lock in the relocated behavior (C8 for these files).

## Behavior
No behavior change. Verified end-to-end against a rebuilt container: `/sets`, `/sets/:code`, `/card/:set/:num`, `/sealed-products/:uuid`, `/spoilers`, and `/search` (with and without `q`) all emit byte-identical `<title>`, description, robots, canonical, og:image, and JSON-LD tags as before.

## Tests
- Full unit suite: 1421 passed.
- `lint:check`: 0 errors.

## Not in this PR (remaining on #596)
- Broad **C8** backfill: 8 orchestrators still lack specs (billing, pricing, buy-list-page, deck-page, notification-page, sell-optimizer, price-alert-page, published-deck).
- **C8 spec-response** OpenAPI coverage.