### PR TITLE
fix(migrations): stop 002 replay from locking card + add migration lock_timeout

### DIFF
--- a/migrations/002_add_card_layout.sql
+++ b/migrations/002_add_card_layout.sql
@@ -8,7 +8,7 @@ DO $$
 BEGIN
   IF EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_name = 'card' AND column_name = 'layout' AND is_nullable = 'YES'
+    WHERE table_schema = 'public' AND table_name = 'card' AND column_name = 'layout' AND is_nullable = 'YES'
   ) THEN
     UPDATE card SET layout = 'normal' WHERE layout IS NULL;
     ALTER TABLE card

--- a/migrations/002_add_card_layout.sql
+++ b/migrations/002_add_card_layout.sql
@@ -1,8 +1,18 @@
 ALTER TABLE card
   ADD COLUMN IF NOT EXISTS layout TEXT;
 
-UPDATE card SET layout = 'normal' WHERE layout IS NULL;
-
-ALTER TABLE card
-  ALTER COLUMN layout SET DEFAULT 'normal',
-  ALTER COLUMN layout SET NOT NULL;
+-- Only backfill + enforce NOT NULL while the column is still nullable. On every
+-- later replay the column is already NOT NULL, so this block is skipped and we
+-- avoid the whole-table rescan + ACCESS EXCLUSIVE lock that SET NOT NULL takes.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'card' AND column_name = 'layout' AND is_nullable = 'YES'
+  ) THEN
+    UPDATE card SET layout = 'normal' WHERE layout IS NULL;
+    ALTER TABLE card
+      ALTER COLUMN layout SET DEFAULT 'normal',
+      ALTER COLUMN layout SET NOT NULL;
+  END IF;
+END $$;

--- a/migrations/run_migrations.sh
+++ b/migrations/run_migrations.sh
@@ -20,6 +20,14 @@ else
   echo "Using POSTGRES_* vars for connection"
 fi
 
+# Fail fast if a migration can't acquire its locks (e.g. a stuck ingest holding
+# card in an idle-in-transaction session). Without this, a lock-blocked ALTER
+# queues an ACCESS EXCLUSIVE request in front of all live reads and takes the
+# site down until the deploy is killed. lock_timeout only aborts on lock
+# *acquisition*, so slow-but-running migrations (large index builds) still
+# complete.
+export PGOPTIONS="${PGOPTIONS:+$PGOPTIONS }-c lock_timeout=15000"
+
 MIGRATIONS_DIR="${MIGRATIONS_DIR:-/migrations}"
 echo "Running migrations from ${MIGRATIONS_DIR}"
 


### PR DESCRIPTION
## Problem

Deploys were hanging ~5 min on `002_add_card_layout.sql` and taking the live site down (504 Gateway Timeout).

Two root causes:

1. **run_migrations.sh replays every migration on every deploy** (by design - the set is intentionally idempotent). But **002 was the one file that wasn't replay-safe**: its final `ALTER COLUMN layout SET NOT NULL` re-scans the whole `card` table and takes an ACCESS EXCLUSIVE lock *every* replay.
2. **No lock_timeout.** When a deploy lands while a Scry ingest is holding `card` (tonight: an `idle in transaction` session stuck for 1h19m from an `INSERT INTO legality ... SELECT`), the ALTER queues its exclusive-lock request in front of all live reads. Every page query against `card` then blocks behind it -> 504 -> site down until the wedged backend is killed by hand.

## Fix

- **002**: wrap the backfill + `SET NOT NULL` in a `DO` block guarded on `is_nullable = 'YES'`. Fresh DBs still enforce NOT NULL once; replays skip the rescan + exclusive lock entirely.
- **run_migrations.sh**: export `PGOPTIONS=-c lock_timeout=15000`. A lock-blocked migration now aborts in 15s instead of stalling the site. `lock_timeout` only trips on lock *acquisition*, so slow-but-running migrations (index builds) still complete.

## Verification

- Ran 002 twice against local dev DB: second run is a no-op, column stays `NOT NULL` / default `'normal'`.
- Confirmed the session honors `lock_timeout = 15s` via `PGOPTIONS`.

## Not included

Deliberately did **not** add a `schema_migrations` tracking table. The migration set is intentionally replayable (see 047's comment); 002 was the only file violating that. Guarding it restores the design without a risky prod backfill. Moving to real migration tracking can be a separate change if desired.