### PR TITLE
test(http): unit specs for the 8 spec-less HBS orchestrators

### DIFF
--- a/test/http/billing/billing.orchestrator.spec.ts
+++ b/test/http/billing/billing.orchestrator.spec.ts
@@ -1,0 +1,142 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubscriptionPlan } from 'src/core/billing/subscription-plan.enum';
+import { SubscriptionStatus } from 'src/core/billing/subscription-status.enum';
+import { Subscription } from 'src/core/billing/subscription.entity';
+import { SubscriptionService } from 'src/core/billing/subscription.service';
+import { User } from 'src/core/user/user.entity';
+import { UserService } from 'src/core/user/user.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { BillingOrchestrator } from 'src/http/hbs/billing/billing.orchestrator';
+
+describe('BillingOrchestrator', () => {
+    let orchestrator: BillingOrchestrator;
+    let subscriptionService: jest.Mocked<SubscriptionService>;
+    let userService: jest.Mocked<UserService>;
+
+    const req = {
+        user: { id: 1, name: 'Test User', email: 'test@example.com' },
+        isAuthenticated: () => true,
+    } as AuthenticatedRequest;
+
+    const activeSub = new Subscription({
+        id: 10,
+        userId: 1,
+        stripeCustomerId: 'cus_1',
+        status: SubscriptionStatus.Active,
+        plan: SubscriptionPlan.Annual,
+        currentPeriodEnd: new Date('2026-03-05T00:00:00Z'),
+        cancelAtPeriodEnd: true,
+    });
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BillingOrchestrator,
+                {
+                    provide: SubscriptionService,
+                    useValue: {
+                        getSubscriptionForUser: jest.fn(),
+                        startCheckout: jest.fn(),
+                        startBillingPortal: jest.fn(),
+                        syncFromCheckoutSessionId: jest.fn(),
+                    },
+                },
+                { provide: UserService, useValue: { findById: jest.fn() } },
+            ],
+        }).compile();
+
+        orchestrator = module.get(BillingOrchestrator);
+        subscriptionService = module.get(SubscriptionService);
+        userService = module.get(UserService);
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    describe('getBillingView', () => {
+        it('summarizes an active subscription with a UTC-formatted period end', async () => {
+            subscriptionService.getSubscriptionForUser.mockResolvedValue(activeSub);
+
+            const view = await orchestrator.getBillingView(req);
+
+            expect(subscriptionService.getSubscriptionForUser).toHaveBeenCalledWith(1);
+            expect(view.subscribed).toBe(true);
+            expect(view.indexable).toBe(false);
+            expect(view.title).toBe('Subscription - I Want My MTG');
+            expect(view.subscription).toEqual({
+                status: SubscriptionStatus.Active,
+                plan: SubscriptionPlan.Annual,
+                currentPeriodEnd: 'March 5, 2026',
+                cancelAtPeriodEnd: true,
+                isActive: true,
+            });
+        });
+
+        it('returns a null summary when the user has no subscription', async () => {
+            subscriptionService.getSubscriptionForUser.mockResolvedValue(null);
+
+            const view = await orchestrator.getBillingView(req);
+
+            expect(view.subscription).toBeNull();
+            expect(view.subscribed).toBe(false);
+        });
+
+        it('reports not subscribed for a canceled subscription', async () => {
+            subscriptionService.getSubscriptionForUser.mockResolvedValue(
+                new Subscription({
+                    userId: 1,
+                    stripeCustomerId: 'cus_1',
+                    status: SubscriptionStatus.Canceled,
+                })
+            );
+
+            const view = await orchestrator.getBillingView(req);
+
+            expect(view.subscribed).toBe(false);
+            expect(view.subscription.isActive).toBe(false);
+            expect(view.subscription.currentPeriodEnd).toBeNull();
+        });
+    });
+
+    describe('checkout and portal', () => {
+        const user = { id: 1, email: 'test@example.com' } as User;
+
+        it('loads the user before starting checkout', async () => {
+            userService.findById.mockResolvedValue(user);
+            subscriptionService.startCheckout.mockResolvedValue({ url: 'https://checkout' });
+
+            await expect(
+                orchestrator.startCheckout(req, SubscriptionPlan.Monthly)
+            ).resolves.toEqual({ url: 'https://checkout' });
+            expect(subscriptionService.startCheckout).toHaveBeenCalledWith(
+                user,
+                SubscriptionPlan.Monthly
+            );
+        });
+
+        it('loads the user before starting the billing portal', async () => {
+            userService.findById.mockResolvedValue(user);
+            subscriptionService.startBillingPortal.mockResolvedValue({ url: 'https://portal' });
+
+            await expect(orchestrator.startBillingPortal(req)).resolves.toEqual({
+                url: 'https://portal',
+            });
+            expect(subscriptionService.startBillingPortal).toHaveBeenCalledWith(user);
+        });
+
+        it('throws when the request user no longer exists', async () => {
+            userService.findById.mockResolvedValue(null);
+
+            await expect(orchestrator.startCheckout(req, SubscriptionPlan.Monthly)).rejects.toThrow(
+                'User 1 not found.'
+            );
+            expect(subscriptionService.startCheckout).not.toHaveBeenCalled();
+        });
+    });
+
+    it('delegates checkout-session sync with the session id and user id', async () => {
+        subscriptionService.syncFromCheckoutSessionId.mockResolvedValue(true);
+
+        await expect(orchestrator.syncFromCheckoutSession(req, 'cs_123')).resolves.toBe(true);
+        expect(subscriptionService.syncFromCheckoutSessionId).toHaveBeenCalledWith('cs_123', 1);
+    });
+});

--- a/test/http/billing/pricing.orchestrator.spec.ts
+++ b/test/http/billing/pricing.orchestrator.spec.ts
@@ -1,0 +1,112 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubscriptionService } from 'src/core/billing/subscription.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { PricingOrchestrator } from 'src/http/hbs/billing/pricing.orchestrator';
+
+describe('PricingOrchestrator', () => {
+    let subscriptionService: jest.Mocked<SubscriptionService>;
+
+    const authedReq = { user: { id: 1 } } as AuthenticatedRequest;
+    const anonReq = { user: null } as unknown as AuthenticatedRequest;
+
+    /** Config values are read in the constructor, so each case builds its own instance. */
+    async function build(config: Record<string, string> = {}): Promise<PricingOrchestrator> {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PricingOrchestrator,
+                {
+                    provide: SubscriptionService,
+                    useValue: { isUserSubscribed: jest.fn().mockResolvedValue(false) },
+                },
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn((key: string, fallback?: string) => config[key] ?? fallback),
+                    },
+                },
+            ],
+        }).compile();
+
+        subscriptionService = module.get(SubscriptionService);
+        return module.get(PricingOrchestrator);
+    }
+
+    describe('getPricingView', () => {
+        it('builds an indexable view with a canonical URL from APP_URL', async () => {
+            const orchestrator = await build({ APP_URL: 'https://iwantmymtg.com' });
+
+            const view = await orchestrator.getPricingView(anonReq);
+
+            expect(view.authenticated).toBe(false);
+            expect(view.subscribed).toBe(false);
+            expect(view.indexable).toBe(true);
+            expect(view.title).toBe('Pricing - I Want My MTG');
+            expect(view.canonicalUrl).toBe('https://iwantmymtg.com/pricing');
+            expect(view.breadcrumbs).toEqual([
+                { label: 'Home', url: '/' },
+                { label: 'Pricing', url: '/pricing' },
+            ]);
+        });
+
+        it('does not check subscription status for an anonymous visitor', async () => {
+            const orchestrator = await build();
+
+            await orchestrator.getPricingView(anonReq);
+
+            expect(subscriptionService.isUserSubscribed).not.toHaveBeenCalled();
+        });
+
+        it('reflects the subscription status of a signed-in user', async () => {
+            const orchestrator = await build();
+            subscriptionService.isUserSubscribed.mockResolvedValue(true);
+
+            const view = await orchestrator.getPricingView(authedReq);
+
+            expect(subscriptionService.isUserSubscribed).toHaveBeenCalledWith(1);
+            expect(view.authenticated).toBe(true);
+            expect(view.subscribed).toBe(true);
+        });
+    });
+
+    describe('pricingDisplay', () => {
+        it('derives per-month and comparison figures from the configured amounts', async () => {
+            const orchestrator = await build({
+                STRIPE_DISPLAY_PRICE_MONTHLY: '$5.00',
+                STRIPE_DISPLAY_PRICE_ANNUAL: '$48.00',
+            });
+
+            expect(orchestrator.pricingDisplay()).toEqual({
+                monthly: { amount: '$5.00', label: 'per month', amountValue: '5.00' },
+                annual: {
+                    amount: '$48.00',
+                    label: 'per year',
+                    amountValue: '48.00',
+                    perMonth: '4.00',
+                    billedNote: 'Billed $48.00/year - save ~2 months',
+                },
+                annualMonthlyTotal: '60.00',
+            });
+        });
+
+        it('falls back to the default amounts when the config is unset', async () => {
+            const orchestrator = await build();
+
+            const pricing = orchestrator.pricingDisplay();
+
+            expect(pricing.monthly.amount).toBe('$3.99');
+            expect(pricing.annual.amount).toBe('$39.99');
+            expect(pricing.annual.perMonth).toBe('3.33');
+            expect(pricing.annualMonthlyTotal).toBe('47.88');
+        });
+
+        it('treats an unparseable amount as zero rather than NaN', async () => {
+            const orchestrator = await build({ STRIPE_DISPLAY_PRICE_ANNUAL: 'free' });
+
+            const pricing = orchestrator.pricingDisplay();
+
+            expect(pricing.annual.amountValue).toBe('0.00');
+            expect(pricing.annual.perMonth).toBe('0.00');
+        });
+    });
+});

--- a/test/http/buy-list/buy-list-page.orchestrator.spec.ts
+++ b/test/http/buy-list/buy-list-page.orchestrator.spec.ts
@@ -1,0 +1,63 @@
+import { InternalServerErrorException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BuyListService } from 'src/core/buy-list/buy-list.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { BuyListPageOrchestrator } from 'src/http/hbs/buy-list/buy-list-page.orchestrator';
+
+describe('BuyListPageOrchestrator', () => {
+    let orchestrator: BuyListPageOrchestrator;
+    let buyListService: jest.Mocked<BuyListService>;
+
+    const authedReq = { user: { id: 1 } } as AuthenticatedRequest;
+    const anonReq = { user: null } as unknown as AuthenticatedRequest;
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BuyListPageOrchestrator,
+                { provide: BuyListService, useValue: { count: jest.fn() } },
+            ],
+        }).compile();
+
+        orchestrator = module.get(BuyListPageOrchestrator);
+        buyListService = module.get(BuyListService);
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('builds the view with hasItems true when the user has items', async () => {
+        buyListService.count.mockResolvedValue(3);
+
+        const view = await orchestrator.buildListView(authedReq);
+
+        expect(buyListService.count).toHaveBeenCalledWith(1);
+        expect(view.authenticated).toBe(true);
+        expect(view.hasItems).toBe(true);
+        expect(view.title).toBe('Buy List - I Want My MTG');
+        expect(view.breadcrumbs).toEqual([
+            { label: 'Home', url: '/' },
+            { label: 'Buy List', url: '/buy-list' },
+        ]);
+    });
+
+    it('sets hasItems false when the buy list is empty', async () => {
+        buyListService.count.mockResolvedValue(0);
+
+        const view = await orchestrator.buildListView(authedReq);
+
+        expect(view.hasItems).toBe(false);
+    });
+
+    it('throws Unauthorized for an unauthenticated request', async () => {
+        await expect(orchestrator.buildListView(anonReq)).rejects.toThrow(UnauthorizedException);
+        expect(buyListService.count).not.toHaveBeenCalled();
+    });
+
+    it('maps an unexpected service error to a 500', async () => {
+        buyListService.count.mockRejectedValue(new Error('db down'));
+
+        await expect(orchestrator.buildListView(authedReq)).rejects.toThrow(
+            InternalServerErrorException
+        );
+    });
+});

--- a/test/http/deck/deck-page.orchestrator.spec.ts
+++ b/test/http/deck/deck-page.orchestrator.spec.ts
@@ -1,0 +1,380 @@
+import {
+    InternalServerErrorException,
+    NotFoundException,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Format } from 'src/core/card/format.enum';
+import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckGapSummary } from 'src/core/deck/deck-gap.policy';
+import { DeckImportService } from 'src/core/deck/deck-import.service';
+import { Deck } from 'src/core/deck/deck.entity';
+import { DeckService } from 'src/core/deck/deck.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { DeckPageOrchestrator } from 'src/http/hbs/deck/deck-page.orchestrator';
+
+describe('DeckPageOrchestrator', () => {
+    let orchestrator: DeckPageOrchestrator;
+    let deckService: jest.Mocked<DeckService>;
+    let deckImportService: jest.Mocked<DeckImportService>;
+    let buildabilityService: jest.Mocked<DeckBuildabilityService>;
+
+    const authedReq = { user: { id: 1 } } as AuthenticatedRequest;
+    const anonReq = { user: null } as unknown as AuthenticatedRequest;
+
+    const emptyGap: DeckGapSummary = {
+        neededCount: 0,
+        ownedCount: 0,
+        missingCount: 0,
+        completeness: 100,
+        perCard: [],
+        missingByCard: [],
+    };
+
+    function deckCard(over: Record<string, any> = {}): DeckCard {
+        return new DeckCard({
+            cardId: 'c1',
+            quantity: 1,
+            isSideboard: false,
+            card: {
+                id: 'c1',
+                name: 'Lightning Bolt',
+                setCode: 'LEA',
+                number: '141',
+                type: 'Instant',
+                manaCost: '{R}',
+                legalities: [],
+                prices: [{ normal: 2.5, foil: null }],
+            },
+            ...over,
+        } as Partial<DeckCard>);
+    }
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                DeckPageOrchestrator,
+                {
+                    provide: DeckService,
+                    useValue: { listDecks: jest.fn(), getDeck: jest.fn() },
+                },
+                { provide: DeckImportService, useValue: { importDecklist: jest.fn() } },
+                {
+                    provide: DeckBuildabilityService,
+                    useValue: { summariesForDecks: jest.fn(), gapForDeck: jest.fn() },
+                },
+            ],
+        }).compile();
+
+        orchestrator = module.get(DeckPageOrchestrator);
+        deckService = module.get(DeckService);
+        deckImportService = module.get(DeckImportService);
+        buildabilityService = module.get(DeckBuildabilityService);
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    describe('buildImportView', () => {
+        it('offers every format plus a "No format" default selection', () => {
+            const view = orchestrator.buildImportView(authedReq);
+
+            expect(view.authenticated).toBe(true);
+            expect(view.formatOptions).toHaveLength(Object.values(Format).length + 1);
+            expect(view.formatOptions[0]).toEqual({
+                value: '',
+                label: 'No format',
+                selected: true,
+            });
+            expect(view.formatOptions.filter((o) => o.selected)).toHaveLength(1);
+        });
+
+        it('is public, pointing an anonymous visitor at tournament decks', () => {
+            const view = orchestrator.buildImportView(anonReq);
+
+            expect(view.authenticated).toBe(false);
+            expect(view.breadcrumbs[1]).toEqual({
+                label: 'Tournament decks',
+                url: '/published-decks',
+            });
+        });
+    });
+
+    describe('importDecklist', () => {
+        it('passes a known format through and reports the import result', async () => {
+            deckImportService.importDecklist.mockResolvedValue({
+                deckId: 9,
+                name: 'Burn',
+                saved: 60,
+                errors: [{ row: 3, name: 'Bogus Card', error: 'not found' }],
+            } as any);
+
+            const view = await orchestrator.importDecklist(authedReq, 'Burn', 'modern', '4 Bolt');
+
+            expect(deckImportService.importDecklist).toHaveBeenCalledWith(
+                1,
+                'Burn',
+                Format.Modern,
+                '4 Bolt'
+            );
+            expect(view.deckId).toBe(9);
+            expect(view.deckUrl).toBe('/decks/9');
+            expect(view.saved).toBe(60);
+            expect(view.errorCount).toBe(1);
+            expect(view.errors).toEqual([{ row: 3, name: 'Bogus Card', error: 'not found' }]);
+        });
+
+        it('treats an unrecognized format as no format', async () => {
+            deckImportService.importDecklist.mockResolvedValue({
+                deckId: 1,
+                name: 'D',
+                saved: 0,
+                errors: [],
+            } as any);
+
+            await orchestrator.importDecklist(authedReq, 'D', 'not-a-format', '');
+
+            expect(deckImportService.importDecklist).toHaveBeenCalledWith(1, 'D', null, '');
+        });
+
+        it('throws Unauthorized for an unauthenticated request', async () => {
+            await expect(orchestrator.importDecklist(anonReq, 'D', undefined, '')).rejects.toThrow(
+                UnauthorizedException
+            );
+            expect(deckImportService.importDecklist).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('buildListView', () => {
+        it('ranks the most-buildable deck first and marks it buildable', async () => {
+            const decks = [
+                new Deck({ id: 1, userId: 1, name: 'Half done', cards: [deckCard()] }),
+                new Deck({
+                    id: 2,
+                    userId: 1,
+                    name: 'Ready',
+                    format: Format.Modern,
+                    cards: [deckCard({ quantity: 4 })],
+                    updatedAt: new Date('2026-01-15T00:00:00Z'),
+                }),
+            ];
+            deckService.listDecks.mockResolvedValue(decks);
+            buildabilityService.summariesForDecks.mockResolvedValue(
+                new Map([
+                    [1, { ...emptyGap, completeness: 40, missingCount: 3 }],
+                    [2, { ...emptyGap, completeness: 100, missingCount: 0 }],
+                ])
+            );
+
+            const view = await orchestrator.buildListView(authedReq);
+
+            expect(view.hasDecks).toBe(true);
+            expect(view.decks.map((d) => d.id)).toEqual([2, 1]);
+            expect(view.decks[0]).toMatchObject({
+                name: 'Ready',
+                formatLabel: 'Modern',
+                cardCount: 4,
+                estimatedValue: '$10.00',
+                url: '/decks/2',
+                updatedAt: '1/15/2026',
+                buildable: true,
+            });
+            expect(view.decks[1]).toMatchObject({
+                formatLabel: 'No format',
+                missingCount: 3,
+                buildable: false,
+            });
+        });
+
+        it('defaults completeness to zero for a deck with no gap summary', async () => {
+            deckService.listDecks.mockResolvedValue([
+                new Deck({ id: 1, userId: 1, name: 'Empty', cards: [] }),
+            ]);
+            buildabilityService.summariesForDecks.mockResolvedValue(new Map());
+
+            const view = await orchestrator.buildListView(authedReq);
+
+            expect(view.decks[0]).toMatchObject({
+                completeness: 0,
+                updatedAt: '',
+                estimatedValue: '$0.00',
+                // No cards, so nothing to build even though nothing is missing.
+                buildable: false,
+            });
+        });
+
+        it('sets hasDecks false when the user has none', async () => {
+            deckService.listDecks.mockResolvedValue([]);
+            buildabilityService.summariesForDecks.mockResolvedValue(new Map());
+
+            const view = await orchestrator.buildListView(authedReq);
+
+            expect(view.hasDecks).toBe(false);
+            expect(view.decks).toEqual([]);
+        });
+
+        it('throws Unauthorized for an unauthenticated request', async () => {
+            await expect(orchestrator.buildListView(anonReq)).rejects.toThrow(
+                UnauthorizedException
+            );
+        });
+
+        it('maps an unexpected service error to a 500', async () => {
+            deckService.listDecks.mockRejectedValue(new Error('boom'));
+
+            await expect(orchestrator.buildListView(authedReq)).rejects.toThrow(
+                InternalServerErrorException
+            );
+        });
+    });
+
+    describe('buildDetailView', () => {
+        const bolt = deckCard({ cardId: 'bolt', quantity: 4 });
+        const forest = deckCard({
+            cardId: 'forest',
+            quantity: 2,
+            card: {
+                id: 'forest',
+                name: 'Forest',
+                setCode: 'LEA',
+                number: '294',
+                type: 'Basic Land — Forest',
+                legalities: [],
+                prices: [],
+            },
+        });
+        const sideBolt = deckCard({ cardId: 'bolt', quantity: 1, isSideboard: true });
+
+        it('groups the maindeck by type, keeps the sideboard separate, and totals value', async () => {
+            deckService.getDeck.mockResolvedValue(
+                new Deck({
+                    id: 5,
+                    userId: 1,
+                    name: 'Burn',
+                    format: Format.Modern,
+                    cards: [bolt, forest, sideBolt],
+                })
+            );
+            buildabilityService.gapForDeck.mockResolvedValue({
+                ...emptyGap,
+                neededCount: 5,
+                ownedCount: 3,
+                missingCount: 2,
+                completeness: 60,
+                perCard: [
+                    {
+                        cardId: 'bolt',
+                        isSideboard: false,
+                        need: 4,
+                        owned: 2,
+                        missing: 2,
+                        isBasic: false,
+                    },
+                    {
+                        cardId: 'forest',
+                        isSideboard: false,
+                        need: 2,
+                        owned: 2,
+                        missing: 0,
+                        isBasic: true,
+                    },
+                ],
+            } as DeckGapSummary);
+
+            const view = await orchestrator.buildDetailView(authedReq, 5);
+
+            expect(deckService.getDeck).toHaveBeenCalledWith(5, 1);
+            expect(view.title).toBe('Burn - Decks - I Want My MTG');
+            expect(view.formatLabel).toBe('Modern');
+            // TYPE_ORDER puts Instants ahead of Lands.
+            expect(view.mainGroups.map((g) => g.type)).toEqual(['Instants', 'Lands']);
+            expect(view.mainGroups[0].count).toBe(4);
+            expect(view.mainGroups[0].cards[0]).toMatchObject({
+                name: 'Lightning Bolt',
+                url: '/card/lea/141',
+                unitValue: 2.5,
+                lineValue: '$10.00',
+                owned: 2,
+                missing: 2,
+                isBasic: false,
+            });
+            expect(view.mainGroups[1].cards[0]).toMatchObject({ isBasic: true, missing: 0 });
+            expect(view.sideboard).toHaveLength(1);
+            expect(view.mainCount).toBe(6);
+            expect(view.sideCount).toBe(1);
+            expect(view.estimatedValue).toBe('$12.50');
+            expect(view.hasMissing).toBe(true);
+            expect(view.completeness).toBe(60);
+        });
+
+        it('counts cards illegal in the deck format', async () => {
+            const illegal = deckCard({
+                cardId: 'bolt',
+                quantity: 1,
+                card: {
+                    id: 'bolt',
+                    name: 'Lightning Bolt',
+                    setCode: 'LEA',
+                    number: '141',
+                    type: 'Instant',
+                    legalities: [{ format: Format.Standard, status: 'banned' }],
+                    prices: [],
+                },
+            });
+            deckService.getDeck.mockResolvedValue(
+                new Deck({
+                    id: 6,
+                    userId: 1,
+                    name: 'Std',
+                    format: Format.Standard,
+                    cards: [illegal],
+                })
+            );
+            buildabilityService.gapForDeck.mockResolvedValue(emptyGap);
+
+            const view = await orchestrator.buildDetailView(authedReq, 6);
+
+            expect(view.illegalCount).toBe(1);
+            expect(view.mainGroups[0].cards[0].illegal).toBe(true);
+        });
+
+        it('reports no illegal cards when the deck has no format', async () => {
+            deckService.getDeck.mockResolvedValue(
+                new Deck({ id: 7, userId: 1, name: 'Casual', cards: [bolt] })
+            );
+            buildabilityService.gapForDeck.mockResolvedValue(emptyGap);
+
+            const view = await orchestrator.buildDetailView(authedReq, 7);
+
+            expect(view.illegalCount).toBe(0);
+            expect(view.formatLabel).toBe('No format');
+            expect(view.format).toBeNull();
+        });
+
+        it('falls back to the deck card quantity when a row has no gap entry', async () => {
+            deckService.getDeck.mockResolvedValue(
+                new Deck({ id: 8, userId: 1, name: 'D', cards: [bolt] })
+            );
+            buildabilityService.gapForDeck.mockResolvedValue(emptyGap);
+
+            const view = await orchestrator.buildDetailView(authedReq, 8);
+
+            expect(view.mainGroups[0].cards[0]).toMatchObject({ owned: 4, missing: 0 });
+        });
+
+        it('throws Not Found when the deck does not exist for this user', async () => {
+            deckService.getDeck.mockResolvedValue(null);
+
+            await expect(orchestrator.buildDetailView(authedReq, 99)).rejects.toThrow(
+                NotFoundException
+            );
+        });
+
+        it('throws Unauthorized for an unauthenticated request', async () => {
+            await expect(orchestrator.buildDetailView(anonReq, 1)).rejects.toThrow(
+                UnauthorizedException
+            );
+            expect(deckService.getDeck).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/http/notification/notification-page.orchestrator.spec.ts
+++ b/test/http/notification/notification-page.orchestrator.spec.ts
@@ -1,0 +1,63 @@
+import { InternalServerErrorException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PriceNotificationService } from 'src/core/price-alert/price-notification.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { NotificationPageOrchestrator } from 'src/http/hbs/notification/notification-page.orchestrator';
+
+describe('NotificationPageOrchestrator', () => {
+    let orchestrator: NotificationPageOrchestrator;
+    let notificationService: jest.Mocked<PriceNotificationService>;
+
+    const authedReq = { user: { id: 7 } } as AuthenticatedRequest;
+    const anonReq = { user: null } as unknown as AuthenticatedRequest;
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                NotificationPageOrchestrator,
+                { provide: PriceNotificationService, useValue: { countByUser: jest.fn() } },
+            ],
+        }).compile();
+
+        orchestrator = module.get(NotificationPageOrchestrator);
+        notificationService = module.get(PriceNotificationService);
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('builds the view with hasNotifications true when the user has some', async () => {
+        notificationService.countByUser.mockResolvedValue(2);
+
+        const view = await orchestrator.buildListView(authedReq);
+
+        expect(notificationService.countByUser).toHaveBeenCalledWith(7);
+        expect(view.authenticated).toBe(true);
+        expect(view.hasNotifications).toBe(true);
+        expect(view.title).toBe('Notifications - I Want My MTG');
+        expect(view.breadcrumbs).toEqual([
+            { label: 'Home', url: '/' },
+            { label: 'Notifications', url: '/notifications' },
+        ]);
+    });
+
+    it('sets hasNotifications false when there are none', async () => {
+        notificationService.countByUser.mockResolvedValue(0);
+
+        const view = await orchestrator.buildListView(authedReq);
+
+        expect(view.hasNotifications).toBe(false);
+    });
+
+    it('throws Unauthorized for an unauthenticated request', async () => {
+        await expect(orchestrator.buildListView(anonReq)).rejects.toThrow(UnauthorizedException);
+        expect(notificationService.countByUser).not.toHaveBeenCalled();
+    });
+
+    it('maps an unexpected service error to a 500', async () => {
+        notificationService.countByUser.mockRejectedValue(new Error('db down'));
+
+        await expect(orchestrator.buildListView(authedReq)).rejects.toThrow(
+            InternalServerErrorException
+        );
+    });
+});

--- a/test/http/optimizer/sell-optimizer.orchestrator.spec.ts
+++ b/test/http/optimizer/sell-optimizer.orchestrator.spec.ts
@@ -1,0 +1,151 @@
+import { InternalServerErrorException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { OptimizerPlan } from 'src/core/optimizer/optimizer.types';
+import { SellOptimizerService } from 'src/core/optimizer/sell-optimizer.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { SellOptimizerOrchestrator } from 'src/http/hbs/optimizer/sell-optimizer.orchestrator';
+
+describe('SellOptimizerOrchestrator', () => {
+    let orchestrator: SellOptimizerOrchestrator;
+    let optimizerService: jest.Mocked<SellOptimizerService>;
+
+    const authedReq = { user: { id: 3 } } as AuthenticatedRequest;
+    const anonReq = { user: null } as unknown as AuthenticatedRequest;
+
+    const plan: OptimizerPlan = {
+        vendorKey: 'cardkingdom',
+        vendorName: 'Card Kingdom',
+        cashValue: 100,
+        sellItemCount: 4,
+        buyListRetail: 120,
+        buyLines: [
+            {
+                name: 'Lightning Bolt',
+                setCode: 'lea',
+                number: '141',
+                finish: 'normal',
+                quantity: 2,
+                unitPrice: 10,
+                lineTotal: 20,
+            },
+            {
+                // Comma in the name and a missing price: both need CSV handling.
+                name: 'Jace, the Mind Sculptor',
+                setCode: 'wwk',
+                number: '31',
+                finish: 'foil',
+                quantity: 1,
+                unitPrice: null,
+                lineTotal: null,
+            },
+        ],
+        itemsWithoutPrice: 1,
+        bonusPct: 0.3,
+        result: {
+            cashValue: 100,
+            buyListRetail: 120,
+            bonusPct: 0.3,
+            storeCredit: 130,
+            cashOutOfPocket: 20,
+            cashLeftover: 0,
+            creditOutOfPocket: 0,
+            lockedCredit: 10,
+            creditAdvantage: 20,
+            recommendCredit: true,
+        },
+    };
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SellOptimizerOrchestrator,
+                { provide: SellOptimizerService, useValue: { buildPlan: jest.fn() } },
+            ],
+        }).compile();
+
+        orchestrator = module.get(SellOptimizerOrchestrator);
+        optimizerService = module.get(SellOptimizerService);
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        optimizerService.buildPlan.mockResolvedValue(plan);
+    });
+
+    describe('buildView', () => {
+        it('maps the plan onto the view and echoes the parsed bonus', async () => {
+            const view = await orchestrator.buildView(authedReq, '0.25');
+
+            expect(optimizerService.buildPlan).toHaveBeenCalledWith(3, 0.25);
+            expect(view.authenticated).toBe(true);
+            expect(view.title).toBe('Cash vs. Store Credit - I Want My MTG');
+            expect(view.vendorName).toBe('Card Kingdom');
+            expect(view.sellItemCount).toBe(4);
+            expect(view.itemsWithoutPrice).toBe(1);
+            expect(view.defaultBonusPct).toBe(0.25);
+            expect(view.buyLines).toBe(plan.buyLines);
+            expect(view.result).toBe(plan.result);
+        });
+
+        it('falls back to the default bonus when the param is missing or invalid', async () => {
+            const fallback = SellOptimizerService.parseBonus(undefined);
+
+            await orchestrator.buildView(authedReq);
+            expect(optimizerService.buildPlan).toHaveBeenCalledWith(3, fallback);
+
+            await orchestrator.buildView(authedReq, 'abc');
+            expect(optimizerService.buildPlan).toHaveBeenLastCalledWith(3, fallback);
+        });
+
+        it('throws Unauthorized for an unauthenticated request', async () => {
+            await expect(orchestrator.buildView(anonReq)).rejects.toThrow(UnauthorizedException);
+            expect(optimizerService.buildPlan).not.toHaveBeenCalled();
+        });
+
+        it('maps an unexpected service error to a 500', async () => {
+            optimizerService.buildPlan.mockRejectedValue(new Error('boom'));
+
+            await expect(orchestrator.buildView(authedReq)).rejects.toThrow(
+                InternalServerErrorException
+            );
+        });
+    });
+
+    describe('buildCsv', () => {
+        it('emits a summary block followed by the buy-list rows', async () => {
+            const csv = await orchestrator.buildCsv(authedReq, '0.3');
+            const lines = csv.split('\n');
+
+            expect(lines[0]).toBe('section,field,value');
+            expect(lines).toContain('summary,vendor,Card Kingdom');
+            expect(lines).toContain('summary,store_credit_bonus_pct,30');
+            expect(lines).toContain('summary,recommendation,store_credit');
+            expect(lines).toContain(
+                'buy_list,name,set_code,number,finish,quantity,unit_retail,line_retail'
+            );
+            expect(lines).toContain('buy_list,Lightning Bolt,lea,141,normal,2,10,20');
+            expect(csv.endsWith('\n')).toBe(true);
+        });
+
+        it('quotes fields containing commas and leaves unpriced lines blank', async () => {
+            const csv = await orchestrator.buildCsv(authedReq);
+
+            expect(csv).toContain('buy_list,"Jace, the Mind Sculptor",wwk,31,foil,1,,');
+        });
+
+        it('reports cash when credit is not the better option', async () => {
+            optimizerService.buildPlan.mockResolvedValue({
+                ...plan,
+                result: { ...plan.result, recommendCredit: false },
+            });
+
+            const csv = await orchestrator.buildCsv(authedReq);
+
+            expect(csv).toContain('summary,recommendation,cash');
+        });
+
+        it('throws Unauthorized for an unauthenticated request', async () => {
+            await expect(orchestrator.buildCsv(anonReq)).rejects.toThrow(UnauthorizedException);
+        });
+    });
+});

--- a/test/http/price-alert/price-alert-page.orchestrator.spec.ts
+++ b/test/http/price-alert/price-alert-page.orchestrator.spec.ts
@@ -1,0 +1,63 @@
+import { InternalServerErrorException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PriceAlertService } from 'src/core/price-alert/price-alert.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { PriceAlertPageOrchestrator } from 'src/http/hbs/price-alert/price-alert-page.orchestrator';
+
+describe('PriceAlertPageOrchestrator', () => {
+    let orchestrator: PriceAlertPageOrchestrator;
+    let priceAlertService: jest.Mocked<PriceAlertService>;
+
+    const authedReq = { user: { id: 4 } } as AuthenticatedRequest;
+    const anonReq = { user: null } as unknown as AuthenticatedRequest;
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PriceAlertPageOrchestrator,
+                { provide: PriceAlertService, useValue: { countByUser: jest.fn() } },
+            ],
+        }).compile();
+
+        orchestrator = module.get(PriceAlertPageOrchestrator);
+        priceAlertService = module.get(PriceAlertService);
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it('builds the view with hasAlerts true when the user has alerts', async () => {
+        priceAlertService.countByUser.mockResolvedValue(5);
+
+        const view = await orchestrator.buildListView(authedReq);
+
+        expect(priceAlertService.countByUser).toHaveBeenCalledWith(4);
+        expect(view.authenticated).toBe(true);
+        expect(view.hasAlerts).toBe(true);
+        expect(view.title).toBe('Price Alerts - I Want My MTG');
+        expect(view.breadcrumbs).toEqual([
+            { label: 'Home', url: '/' },
+            { label: 'Price Alerts', url: '/price-alerts' },
+        ]);
+    });
+
+    it('sets hasAlerts false when there are none', async () => {
+        priceAlertService.countByUser.mockResolvedValue(0);
+
+        const view = await orchestrator.buildListView(authedReq);
+
+        expect(view.hasAlerts).toBe(false);
+    });
+
+    it('throws Unauthorized for an unauthenticated request', async () => {
+        await expect(orchestrator.buildListView(anonReq)).rejects.toThrow(UnauthorizedException);
+        expect(priceAlertService.countByUser).not.toHaveBeenCalled();
+    });
+
+    it('maps an unexpected service error to a 500', async () => {
+        priceAlertService.countByUser.mockRejectedValue(new Error('db down'));
+
+        await expect(orchestrator.buildListView(authedReq)).rejects.toThrow(
+            InternalServerErrorException
+        );
+    });
+});

--- a/test/http/published-deck/published-deck.orchestrator.spec.ts
+++ b/test/http/published-deck/published-deck.orchestrator.spec.ts
@@ -1,0 +1,361 @@
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
+import { DomainNotFoundError } from 'src/core/errors/domain.errors';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckGapSummary } from 'src/core/deck/deck-gap.policy';
+import { Deck } from 'src/core/deck/deck.entity';
+import { DeckService } from 'src/core/deck/deck.service';
+import { PublishedDeck } from 'src/core/published-deck/published-deck.entity';
+import { PublishedDeckService } from 'src/core/published-deck/published-deck.service';
+import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
+import { PublishedDeckOrchestrator } from 'src/http/hbs/published-deck/published-deck.orchestrator';
+
+describe('PublishedDeckOrchestrator', () => {
+    let orchestrator: PublishedDeckOrchestrator;
+    let publishedDeckService: jest.Mocked<PublishedDeckService>;
+    let buildabilityService: jest.Mocked<DeckBuildabilityService>;
+    let deckService: jest.Mocked<DeckService>;
+
+    const authedReq = { user: { id: 1 } } as AuthenticatedRequest;
+    const anonReq = { user: null } as unknown as AuthenticatedRequest;
+
+    const emptyGap: DeckGapSummary = {
+        neededCount: 0,
+        ownedCount: 0,
+        missingCount: 0,
+        completeness: 100,
+        perCard: [],
+        missingByCard: [],
+    };
+
+    function deckCard(over: Record<string, any> = {}): DeckCard {
+        return new DeckCard({
+            cardId: 'bolt',
+            quantity: 4,
+            isSideboard: false,
+            card: {
+                id: 'bolt',
+                name: 'Lightning Bolt',
+                setCode: 'LEA',
+                number: '141',
+                type: 'Instant',
+                manaCost: '{R}',
+                legalities: [],
+                prices: [{ normal: 2.5, foil: null }],
+            },
+            ...over,
+        } as Partial<DeckCard>);
+    }
+
+    function publishedDeck(over: Record<string, any> = {}): PublishedDeck {
+        return new PublishedDeck({
+            id: 1,
+            source: 'fbettega',
+            sourceUri: 'https://example.com/deck/1',
+            tournamentName: 'RC Atlanta',
+            tournamentDate: new Date('2026-02-10T00:00:00Z'),
+            format: 'modern',
+            archetype: 'Burn',
+            player: 'Alice',
+            result: '1st',
+            cards: [deckCard()],
+            ...over,
+        } as Partial<PublishedDeck>);
+    }
+
+    beforeAll(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                PublishedDeckOrchestrator,
+                {
+                    provide: PublishedDeckService,
+                    useValue: { formats: jest.fn(), rowPage: jest.fn(), get: jest.fn() },
+                },
+                {
+                    provide: DeckBuildabilityService,
+                    useValue: { gapForDeck: jest.fn(), addMissingToBuyList: jest.fn() },
+                },
+                {
+                    provide: DeckService,
+                    useValue: { createDeck: jest.fn(), addCards: jest.fn() },
+                },
+            ],
+        }).compile();
+
+        orchestrator = module.get(PublishedDeckOrchestrator);
+        publishedDeckService = module.get(PublishedDeckService);
+        buildabilityService = module.get(DeckBuildabilityService);
+        deckService = module.get(DeckService);
+    });
+
+    beforeEach(() => jest.clearAllMocks());
+
+    describe('buildListView', () => {
+        it('builds a row per primary format and hides the rest behind "view all"', async () => {
+            publishedDeckService.formats.mockResolvedValue([
+                'modern',
+                'standard',
+                'pauper',
+                'vintage',
+            ]);
+            publishedDeckService.rowPage.mockResolvedValue({
+                decks: [publishedDeck()],
+                hasMore: true,
+            });
+
+            const view = await orchestrator.buildListView(anonReq);
+
+            // Rows follow PRIMARY_FORMATS order, not the order the service returned.
+            expect(view.rows.map((r) => r.format)).toEqual(['standard', 'modern']);
+            expect(view.rows[0].label).toBe('Standard');
+            expect(view.rows[0].nextOffset).toBe(1);
+            expect(view.rows[0].hasMore).toBe(true);
+            expect(view.hasDecks).toBe(true);
+            expect(view.hasOtherFormats).toBe(true);
+            expect(view.otherFormats).toEqual([
+                { value: 'pauper', label: 'Pauper' },
+                { value: 'vintage', label: 'Vintage' },
+            ]);
+            expect(view.indexable).toBe(true);
+            expect(view.authenticated).toBe(false);
+        });
+
+        it('shows every present format as a row when none are primary', async () => {
+            publishedDeckService.formats.mockResolvedValue(['pauper']);
+            publishedDeckService.rowPage.mockResolvedValue({ decks: [], hasMore: false });
+
+            const view = await orchestrator.buildListView(anonReq);
+
+            expect(view.rows.map((r) => r.format)).toEqual(['pauper']);
+            expect(view.hasOtherFormats).toBe(false);
+        });
+
+        it('sets hasDecks false when the catalog is empty', async () => {
+            publishedDeckService.formats.mockResolvedValue([]);
+
+            const view = await orchestrator.buildListView(anonReq);
+
+            expect(view.hasDecks).toBe(false);
+            expect(view.rows).toEqual([]);
+        });
+
+        it('maps a list item with its title, counts, and value', async () => {
+            publishedDeckService.formats.mockResolvedValue(['modern']);
+            publishedDeckService.rowPage.mockResolvedValue({
+                decks: [publishedDeck()],
+                hasMore: false,
+            });
+
+            const view = await orchestrator.buildListView(anonReq);
+
+            expect(view.rows[0].decks[0]).toMatchObject({
+                id: 1,
+                title: 'Burn',
+                formatLabel: 'Modern',
+                tournamentName: 'RC Atlanta',
+                date: '2/10/2026',
+                result: '1st',
+                cardCount: 4,
+                estimatedValue: '$10.00',
+                url: '/published-decks/1',
+            });
+        });
+    });
+
+    describe('buildRow', () => {
+        it('pages with the requested offset and limit', async () => {
+            publishedDeckService.rowPage.mockResolvedValue({
+                decks: [publishedDeck()],
+                hasMore: true,
+            });
+
+            const page = await orchestrator.buildRow('modern', 24, 10);
+
+            expect(publishedDeckService.rowPage).toHaveBeenCalledWith('modern', 10, 24);
+            expect(page.items).toHaveLength(1);
+            expect(page.nextOffset).toBe(25);
+            expect(page.hasMore).toBe(true);
+        });
+
+        it('returns an empty page when no format is given', async () => {
+            const page = await orchestrator.buildRow(undefined, 0, 12);
+
+            expect(page).toEqual({ items: [], nextOffset: 0, hasMore: false });
+            expect(publishedDeckService.rowPage).not.toHaveBeenCalled();
+        });
+
+        it('clamps a negative offset and an oversized limit', async () => {
+            publishedDeckService.rowPage.mockResolvedValue({ decks: [], hasMore: false });
+
+            await orchestrator.buildRow('modern', -5, 1000);
+
+            expect(publishedDeckService.rowPage).toHaveBeenCalledWith('modern', 48, 0);
+        });
+
+        it('falls back to the default row size for a non-numeric limit', async () => {
+            publishedDeckService.rowPage.mockResolvedValue({ decks: [], hasMore: false });
+
+            await orchestrator.buildRow('modern', NaN, NaN);
+
+            expect(publishedDeckService.rowPage).toHaveBeenCalledWith('modern', 12, 0);
+        });
+    });
+
+    describe('buildDetailView', () => {
+        it('shows the gap for a signed-in user', async () => {
+            publishedDeckService.get.mockResolvedValue(
+                publishedDeck({
+                    cards: [deckCard(), deckCard({ quantity: 1, isSideboard: true })],
+                })
+            );
+            buildabilityService.gapForDeck.mockResolvedValue({
+                ...emptyGap,
+                neededCount: 4,
+                ownedCount: 1,
+                missingCount: 3,
+                completeness: 25,
+                perCard: [
+                    {
+                        cardId: 'bolt',
+                        isSideboard: false,
+                        need: 4,
+                        owned: 1,
+                        missing: 3,
+                        isBasic: false,
+                    },
+                ],
+            } as DeckGapSummary);
+
+            const view = await orchestrator.buildDetailView(authedReq, 1);
+
+            expect(buildabilityService.gapForDeck).toHaveBeenCalledWith(expect.any(Array), 1);
+            expect(view.showGap).toBe(true);
+            expect(view.completeness).toBe(25);
+            expect(view.hasMissing).toBe(true);
+            expect(view.deckTitle).toBe('Burn');
+            expect(view.title).toBe('Burn - Tournament decks - I Want My MTG');
+            expect(view.mainGroups[0].type).toBe('Instants');
+            expect(view.mainGroups[0].cards[0]).toMatchObject({
+                name: 'Lightning Bolt',
+                url: '/card/lea/141',
+                lineValue: '$10.00',
+                owned: 1,
+                missing: 3,
+            });
+            expect(view.sideboard).toHaveLength(1);
+            expect(view.mainCount).toBe(4);
+            expect(view.sideCount).toBe(1);
+            expect(view.estimatedValue).toBe('$12.50');
+        });
+
+        it('skips the gap entirely for an anonymous visitor', async () => {
+            publishedDeckService.get.mockResolvedValue(publishedDeck());
+
+            const view = await orchestrator.buildDetailView(anonReq, 1);
+
+            expect(buildabilityService.gapForDeck).not.toHaveBeenCalled();
+            expect(view.showGap).toBe(false);
+            expect(view.authenticated).toBe(false);
+            expect(view.mainGroups[0].cards[0]).toMatchObject({ owned: 0, missing: 0 });
+        });
+
+        it('drops a non-http source URI so it cannot become a javascript: href', async () => {
+            publishedDeckService.get.mockResolvedValue(
+                publishedDeck({ sourceUri: 'javascript:alert(1)' })
+            );
+
+            const view = await orchestrator.buildDetailView(anonReq, 1);
+
+            expect(view.sourceUri).toBe('');
+        });
+
+        it('drops an unparseable source URI', async () => {
+            publishedDeckService.get.mockResolvedValue(publishedDeck({ sourceUri: 'not a url' }));
+
+            const view = await orchestrator.buildDetailView(anonReq, 1);
+
+            expect(view.sourceUri).toBe('');
+        });
+
+        it('falls back through archetype, player, then tournament name for the title', async () => {
+            publishedDeckService.get.mockResolvedValue(
+                publishedDeck({ archetype: null, player: null, format: null })
+            );
+
+            const view = await orchestrator.buildDetailView(anonReq, 1);
+
+            expect(view.deckTitle).toBe('RC Atlanta');
+            expect(view.formatLabel).toBe('Unknown format');
+            expect(view.date).toBe('2/10/2026');
+        });
+
+        it('throws Not Found for an unknown deck', async () => {
+            publishedDeckService.get.mockResolvedValue(null);
+
+            await expect(orchestrator.buildDetailView(anonReq, 99)).rejects.toThrow(
+                NotFoundException
+            );
+        });
+    });
+
+    describe('cloneToUserDeck', () => {
+        it('creates a deck titled after the source and copies every card', async () => {
+            const source = publishedDeck({
+                cards: [deckCard(), deckCard({ cardId: 'forest', quantity: 2, isSideboard: true })],
+            });
+            publishedDeckService.get.mockResolvedValue(source);
+            deckService.createDeck.mockResolvedValue(new Deck({ id: 42, userId: 1, name: 'Burn' }));
+
+            await expect(orchestrator.cloneToUserDeck(authedReq, 1)).resolves.toBe(42);
+            expect(deckService.createDeck).toHaveBeenCalledWith(1, 'Burn');
+            expect(deckService.addCards).toHaveBeenCalledWith(42, 1, [
+                { cardId: 'bolt', isSideboard: false, quantity: 4 },
+                { cardId: 'forest', isSideboard: true, quantity: 2 },
+            ]);
+        });
+
+        // No try/catch here: the domain error escapes raw and the global
+        // HttpExceptionFilter maps it to a 404.
+        it('throws Not Found for an unknown deck', async () => {
+            publishedDeckService.get.mockResolvedValue(null);
+
+            await expect(orchestrator.cloneToUserDeck(authedReq, 99)).rejects.toThrow(
+                DomainNotFoundError
+            );
+            expect(deckService.createDeck).not.toHaveBeenCalled();
+        });
+
+        it('throws Unauthorized for an unauthenticated request', async () => {
+            await expect(orchestrator.cloneToUserDeck(anonReq, 1)).rejects.toThrow(
+                UnauthorizedException
+            );
+            expect(publishedDeckService.get).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('addMissingToBuyList', () => {
+        it('seeds the buy list from the deck cards and returns the count added', async () => {
+            const deck = publishedDeck();
+            publishedDeckService.get.mockResolvedValue(deck);
+            buildabilityService.addMissingToBuyList.mockResolvedValue(3);
+
+            await expect(orchestrator.addMissingToBuyList(authedReq, 1)).resolves.toBe(3);
+            expect(buildabilityService.addMissingToBuyList).toHaveBeenCalledWith(deck.cards, 1);
+        });
+
+        it('throws Not Found for an unknown deck', async () => {
+            publishedDeckService.get.mockResolvedValue(null);
+
+            await expect(orchestrator.addMissingToBuyList(authedReq, 99)).rejects.toThrow(
+                DomainNotFoundError
+            );
+        });
+
+        it('throws Unauthorized for an unauthenticated request', async () => {
+            await expect(orchestrator.addMissingToBuyList(anonReq, 1)).rejects.toThrow(
+                UnauthorizedException
+            );
+        });
+    });
+});


### PR DESCRIPTION
Closes the last open item on #596 (analysis-doc C8: orchestrator test-coverage skew).

Adds unit specs for the 8 HBS orchestrators that had none:

| Orchestrator | Covered |
|---|---|
| `BillingOrchestrator` | subscription summary + date formatting, checkout/portal user load, missing-user error, session sync |
| `PricingOrchestrator` | canonical URL, anonymous vs signed-in, price display math + fallbacks + unparseable amount |
| `BuyListPageOrchestrator` | empty/non-empty, auth, 500 mapping |
| `NotificationPageOrchestrator` | same |
| `PriceAlertPageOrchestrator` | same |
| `SellOptimizerOrchestrator` | plan -> view mapping, bonus parsing fallback, CSV shape/quoting/unpriced lines, cash vs credit recommendation |
| `DeckPageOrchestrator` | import view + format parsing, list ranking by buildability, detail grouping/legality/gap fallbacks, 404/401 |
| `PublishedDeckOrchestrator` | primary-format rows + "view all", row paging clamps, gap shown only when signed in, `javascript:` source-URI stripping, clone, add-missing-to-buy-list |

No source changes - `npm test` is 1490 passing across 126 suites.