### PR TITLE
fix(price-alert): strip tier steering from API error messages (App Store 3.1.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,17 @@ The orchestrator layer sits between controllers and services. It handles present
 - **`PriceCalculationPolicy`** (`src/core/pricing/`) — All pricing logic: card value calculation (normal price with foil fallback), inventory valuation, set price tiers (base_price, total_price, base_price_all, total_price_all)
 - **`AffiliateLinkPolicy`** (`src/core/affiliate/`) — Wraps TCGPlayer product URLs in our Impact partner shortlink (hardcoded constant `TCGPLAYER_AFFILIATE_BASE`). Same value is used in all environments since the shortlink is public (visible in every buy button's href) and doesn't differ between dev and prod. Called from card + sealed-product presenters. Raw product IDs come from Scry (MTGJSON `tcgplayerProductId` / `tcgplayerEtchedProductId`); URLs are never stored in affiliate-wrapped form.
 
+### API error strings are an App Store surface (Guideline 3.1.1)
+
+The iOS app renders `/api/v1` error messages verbatim as native alerts, so a
+`4xx` body written here becomes on-screen text in a submitted app. **No
+`/api/v1` error message may contain "Premium", "Upgrade", "Free plan", a tier
+name, or a pricing URL** — state the limit neutrally (see
+`price-alert.service.ts`) and let each client present it. The web frontend does
+its own upgrade steering through its own UI; `src/mcp/` is exempt (separate
+developer product, never shipped through an app store). Violating this got the
+iOS app rejected four times; details in the mobile repo's `GO-LIVE.md` §3H.
+
 ### Authentication
 
 JWT-based auth using Passport.js. Guards: `JwtAuthGuard`, `LocalAuthGuard`, `OptionalJwtAuthGuard`. Tokens stored in HTTP cookies. New user registration uses a `pending_user` table for email verification with expiring tokens.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,13 +181,21 @@ The orchestrator layer sits between controllers and services. It handles present
 ### API error strings are an App Store surface (Guideline 3.1.1)
 
 The iOS app renders `/api/v1` error messages verbatim as native alerts, so a
-`4xx` body written here becomes on-screen text in a submitted app. **No
-`/api/v1` error message may contain "Premium", "Upgrade", "Free plan", a tier
-name, or a pricing URL** — state the limit neutrally (see
+`4xx` body written here becomes on-screen text in a submitted app. **No error
+body on a path the mobile app can reach may contain "Premium", "Upgrade",
+"Free plan", a tier name, or a pricing URL** — state the limit neutrally (see
 `price-alert.service.ts`) and let each client present it. The web frontend does
-its own upgrade steering through its own UI; `src/mcp/` is exempt (separate
-developer product, never shipped through an app store). Violating this got the
-iOS app rejected four times; details in the mobile repo's `GO-LIVE.md` §3H.
+its own upgrade steering through its own UI. Violating this got the iOS app
+rejected four times; details in the mobile repo's `GO-LIVE.md` §3H.
+
+Exempt, because the mobile app cannot reach them:
+
+- **API-key (developer-tier) traffic.** `ApiRateLimitGuard.checkApiKeyTier`
+  returns a 429 naming the tier and an `upgrade: '/developer/pricing'` field.
+  That branch requires `isApiKeyAuth`; the app authenticates with a bearer JWT
+  and falls through to `checkBurst`, which has no tier wording. Keep the
+  developer-facing message as-is — it is the right UX for that audience.
+- **`src/mcp/`** — separate developer product, never shipped through an app store.
 
 ### Authentication
 

--- a/src/core/price-alert/price-alert.service.ts
+++ b/src/core/price-alert/price-alert.service.ts
@@ -66,13 +66,13 @@ export class PriceAlertService {
         if (!subscribed) {
             if (alert.increasePct != null && alert.decreasePct != null) {
                 throw new DomainValidationError(
-                    'Multi-threshold alerts (increase AND decrease on the same card) are a Premium feature. Upgrade at /pricing to enable.'
+                    'Only one threshold direction (increase or decrease) can be set per alert on this account.'
                 );
             }
             const existingCount = await this.alertRepo.countActiveByUser(alert.userId);
             if (existingCount >= FREE_ALERT_LIMIT) {
                 throw new DomainValidationError(
-                    `Free plan is limited to ${FREE_ALERT_LIMIT} active price alerts. Upgrade at /pricing for unlimited alerts.`
+                    `This account is limited to ${FREE_ALERT_LIMIT} active price alerts.`
                 );
             }
         }
@@ -131,7 +131,7 @@ export class PriceAlertService {
             const subscribed = await this.subscriptionService.isUserSubscribed(userId);
             if (!subscribed) {
                 throw new DomainValidationError(
-                    'Multi-threshold alerts (increase AND decrease on the same card) are a Premium feature. Upgrade at /pricing to enable.'
+                    'Only one threshold direction (increase or decrease) can be set per alert on this account.'
                 );
             }
         }

--- a/test/core/price-alert/price-alert.service.spec.ts
+++ b/test/core/price-alert/price-alert.service.spec.ts
@@ -138,7 +138,7 @@ describe('PriceAlertService', () => {
                 increasePct: 10,
                 decreasePct: 10,
             });
-            await expect(service.create(alert)).rejects.toThrow(/Premium/);
+            await expect(service.create(alert)).rejects.toThrow(/Only one threshold direction/);
         });
 
         it('should allow multi-threshold alert for subscribed user', async () => {
@@ -158,7 +158,7 @@ describe('PriceAlertService', () => {
             mockSubscriptionService.isUserSubscribed.mockResolvedValue(false);
             alertRepo.countActiveByUser.mockResolvedValue(FREE_ALERT_LIMIT);
             const alert = new PriceAlert({ userId: 1, cardId: 'card-1', increasePct: 10 });
-            await expect(service.create(alert)).rejects.toThrow(/Free plan is limited/);
+            await expect(service.create(alert)).rejects.toThrow(/limited to 5 active price alerts/);
             expect(alertRepo.create).not.toHaveBeenCalled();
         });
 
@@ -225,7 +225,7 @@ describe('PriceAlertService', () => {
             alertRepo.findById.mockResolvedValue(existing);
             await expect(
                 service.update(1, 1, { decreasePct: 10 })
-            ).rejects.toThrow(/Premium/);
+            ).rejects.toThrow(/Only one threshold direction/);
         });
     });
 

--- a/test/integration/freemium-gates.e2e-spec.ts
+++ b/test/integration/freemium-gates.e2e-spec.ts
@@ -237,7 +237,7 @@ describe('Freemium gates (e2e)', () => {
                 .send({ cardId: TEST_CARD_ID, increasePct: 10, decreasePct: 10 });
 
             expect(res.status).toBe(400);
-            expect(String(res.body.error || '')).toMatch(/Premium/);
+            expect(String(res.body.error || '')).toMatch(/Only one threshold direction/);
         });
 
         it('rejects the 6th alert for free users', async () => {
@@ -268,7 +268,7 @@ describe('Freemium gates (e2e)', () => {
                     .send({ cardId: sixthCardId, increasePct: 15 });
 
                 expect(res.status).toBe(400);
-                expect(String(res.body.error || '')).toMatch(/Free plan is limited|5/);
+                expect(String(res.body.error || '')).toMatch(/limited to 5 active price alerts/);
             } finally {
                 await ds.query('DELETE FROM price_alert WHERE user_id = $1 AND card_id = $2', [
                     userId,


### PR DESCRIPTION
## Why

The App Store submission has been rejected **four times** under Guideline 3.1.1 ("accesses digital content purchased outside the app, such as premium…"). Root cause is here, not in the mobile app.

The iOS app renders `/api/v1` error bodies verbatim as native alerts (`lib/api/envelope.ts` → `errMessage`). Three messages in `price-alert.service.ts` named the paid tier and pointed at a pricing page:

> "Multi-threshold alerts … are a **Premium** feature. **Upgrade at /pricing** to enable."
> "**Free plan** is limited to 5 active price alerts. **Upgrade at /pricing** for unlimited alerts."

The mobile alert form (`components/CardPriceAlert.tsx`) shows Rise % and Fall % side by side, so a reviewer testing price alerts — a headline feature in the App Store description — filled in both and got an iOS alert containing the word *Premium* and a pricing URL. Textbook external-purchase steering.

## What changed

- All three messages made tier-neutral. **The limits themselves are unchanged** — only the wording.
- `CLAUDE.md`: records the standing rule that **the API is a shipping surface of the iOS app** — no `/api/v1` error message may contain "Premium", "Upgrade", "Free plan", a tier name, or a pricing URL.
- Specs + `freemium-gates` e2e assertions updated to the new literals.

The web frontend keeps steering through its own UI. `src/mcp/` is deliberately untouched — separate developer product, never shipped through an app store, and noted as exempt in CLAUDE.md.

## Verification

- `npx jest test/core test/http` — **1437 passed**, 120 suites.
- Full sweep of `src/core` + `src/http/api` confirms no remaining tier language or pricing URL on any path the iOS app can reach.
- `freemium-gates.e2e-spec.ts` not run locally (needs a DB); the changes are regex swaps matching the new literals exactly.

## Sequencing

Merge and deploy this **before** the mobile PR ships a build — the mobile repo regenerates `schema.ts` from the deployed spec, and the new build must be built against a backend that no longer emits the old strings.

Mobile counterpart: matthewdtowles/i-want-my-mtg-mobile#83