### PR TITLE
fix(migrations): guard 014's is_main backfill against replay

### DIFF
--- a/.github/scripts/setup-cron.sh
+++ b/.github/scripts/setup-cron.sh
@@ -53,7 +53,7 @@ sudo chmod 755 /opt/scripts/scry
 
 # Set log directory and file permissions
 sudo chown ubuntu:ubuntu /var/log/i-want-my-mtg
-sudo touch /var/log/i-want-my-mtg/ingestion.log /var/log/i-want-my-mtg/retention.log /var/log/i-want-my-mtg/cleanup.log /var/log/i-want-my-mtg/portfolio.log /var/log/i-want-my-mtg/price-alerts.log
+sudo touch /var/log/i-want-my-mtg/ingestion.log /var/log/i-want-my-mtg/retention.log /var/log/i-want-my-mtg/cleanup.log /var/log/i-want-my-mtg/portfolio.log /var/log/i-want-my-mtg/price-alerts.log /var/log/i-want-my-mtg/health.log
 sudo chown ubuntu:ubuntu /var/log/i-want-my-mtg/*.log
 
 log_info "Cron jobs installed successfully."

--- a/cron/i-want-my-mtg
+++ b/cron/i-want-my-mtg
@@ -3,6 +3,11 @@ SHELL=/bin/bash
 HOME=/home/ubuntu
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# Where cron mails job output. Every job below redirects stdout to its own log,
+# so the only thing that ever reaches this address is a job writing to stderr -
+# i.e. a failure. Requires a working local MTA.
+MAILTO=legal@iwantmymtg.net
+
 # Scryfall data ingestion (daily at 2 AM)
 0 2 * * * ubuntu /opt/scripts/scry.sh >> /var/log/i-want-my-mtg/ingestion.log 2>&1
 
@@ -17,6 +22,14 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Portfolio summary refresh (daily at 2:30 AM, 30 min after ingestion)
 30 2 * * * ubuntu /opt/scripts/scry.sh portfolio-summary >> /var/log/i-want-my-mtg/portfolio.log 2>&1
+
+# Data freshness check (daily at 6 AM, well after the ingest window).
+# `scry health` exits non-zero when the newest price row is more than a day
+# old, which is the only signal that an ingest silently stopped completing.
+# Note the missing `2>&1`: the report goes to health.log, but scry writes its
+# failure to stderr, so a stale catalog - and only a stale catalog - reaches
+# MAILTO.
+0 6 * * * ubuntu /opt/scripts/scry.sh health >> /var/log/i-want-my-mtg/health.log
 
 # Log cleanup (weekly, Sunday at 4 AM)
 0 4 * * 0 ubuntu /opt/scripts/clean_logs.sh >> /var/log/i-want-my-mtg/cleanup.log 2>&1

--- a/cron/i-want-my-mtg
+++ b/cron/i-want-my-mtg
@@ -25,7 +25,7 @@ MAILTO=legal@iwantmymtg.net
 30 3 * * * ubuntu /opt/scripts/scry.sh ingest-decks --days 2 >> /var/log/i-want-my-mtg/decks.log
 
 # Price alert processing (daily at 2:15 AM, after ingestion completes)
-15 2 * * * ubuntu curl -Sf -X POST -H "x-api-key: $(grep '^INTERNAL_API_KEY=' /home/ubuntu/.env | cut -d= -f2- | sed 's/^"//;s/"$//')" http://localhost/api/v1/price-alerts/process >> /var/log/i-want-my-mtg/price-alerts.log
+15 2 * * * ubuntu curl -sSf -X POST -H "x-api-key: $(grep '^INTERNAL_API_KEY=' /home/ubuntu/.env | cut -d= -f2- | sed 's/^"//;s/"$//')" http://localhost/api/v1/price-alerts/process >> /var/log/i-want-my-mtg/price-alerts.log
 
 # Portfolio summary refresh (daily at 2:30 AM, 30 min after ingestion)
 30 2 * * * ubuntu /opt/scripts/scry.sh portfolio-summary >> /var/log/i-want-my-mtg/portfolio.log

--- a/cron/i-want-my-mtg
+++ b/cron/i-want-my-mtg
@@ -3,34 +3,39 @@ SHELL=/bin/bash
 HOME=/home/ubuntu
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-# Where cron mails job output. Every job below redirects stdout to its own log,
-# so the only thing that ever reaches this address is a job writing to stderr -
-# i.e. a failure. Requires a working local MTA.
+# Where cron mails job output.
+#
+# Every job below redirects stdout - and only stdout - to its own log. scry
+# sends its whole report there via tracing and writes command failures to
+# stderr, so the only thing that ever reaches this address is a failure: a
+# non-zero exit, a run killed by its timeout, or a run skipped because the
+# previous one is still holding the lock. Successful runs mail nothing.
+#
+# Do not add `2>&1` to these lines - that is what silenced two days of failed
+# ingests. Requires a working local MTA.
 MAILTO=legal@iwantmymtg.net
 
 # Scryfall data ingestion (daily at 2 AM)
-0 2 * * * ubuntu /opt/scripts/scry.sh >> /var/log/i-want-my-mtg/ingestion.log 2>&1
+0 2 * * * ubuntu /opt/scripts/scry.sh >> /var/log/i-want-my-mtg/ingestion.log
 
 # Price history retention cleanup (weekly, Sunday at 3 AM)
-0 3 * * 0 ubuntu /opt/scripts/scry.sh retention >> /var/log/i-want-my-mtg/retention.log 2>&1
+0 3 * * 0 ubuntu /opt/scripts/scry.sh retention >> /var/log/i-want-my-mtg/retention.log
 
 # Published tournament-deck ingest (daily at 3:30 AM; fetches the prior 2 days)
-30 3 * * * ubuntu /opt/scripts/scry.sh ingest-decks --days 2 >> /var/log/i-want-my-mtg/decks.log 2>&1
+30 3 * * * ubuntu /opt/scripts/scry.sh ingest-decks --days 2 >> /var/log/i-want-my-mtg/decks.log
 
 # Price alert processing (daily at 2:15 AM, after ingestion completes)
-15 2 * * * ubuntu curl -Sf -X POST -H "x-api-key: $(grep '^INTERNAL_API_KEY=' /home/ubuntu/.env | cut -d= -f2- | sed 's/^"//;s/"$//')" http://localhost/api/v1/price-alerts/process >> /var/log/i-want-my-mtg/price-alerts.log 2>&1
+15 2 * * * ubuntu curl -Sf -X POST -H "x-api-key: $(grep '^INTERNAL_API_KEY=' /home/ubuntu/.env | cut -d= -f2- | sed 's/^"//;s/"$//')" http://localhost/api/v1/price-alerts/process >> /var/log/i-want-my-mtg/price-alerts.log
 
 # Portfolio summary refresh (daily at 2:30 AM, 30 min after ingestion)
-30 2 * * * ubuntu /opt/scripts/scry.sh portfolio-summary >> /var/log/i-want-my-mtg/portfolio.log 2>&1
+30 2 * * * ubuntu /opt/scripts/scry.sh portfolio-summary >> /var/log/i-want-my-mtg/portfolio.log
 
 # Data freshness check (daily at 6 AM, well after the ingest window).
 # `scry health` exits non-zero when the newest price row is more than a day
-# old, which is the only signal that an ingest silently stopped completing.
-# Note the missing `2>&1`: the report goes to health.log, but scry writes its
-# failure to stderr, so a stale catalog - and only a stale catalog - reaches
-# MAILTO.
+# old. Prices carry MTGJSON's file date, not the ingest date, so a healthy
+# catalog checked at 06:00 is one day old - two days means a run was missed.
 0 6 * * * ubuntu /opt/scripts/scry.sh health >> /var/log/i-want-my-mtg/health.log
 
 # Log cleanup (weekly, Sunday at 4 AM)
-0 4 * * 0 ubuntu /opt/scripts/clean_logs.sh >> /var/log/i-want-my-mtg/cleanup.log 2>&1
+0 4 * * 0 ubuntu /opt/scripts/clean_logs.sh >> /var/log/i-want-my-mtg/cleanup.log
 

--- a/cron/scry.sh
+++ b/cron/scry.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
+# A wedged run must not go unnoticed, and must not let the next one pile up on
+# top of it. On 2026-07-21 an ingest deadlocked inside scry - futex_wait, an
+# idle DB connection, no CPU - after zeroing set.base_size and before
+# post-ingest could restore it; an ingest from 2026-05-09 was still sitting
+# there too, 73 days on. Cron kept starting new ones and nothing said a word.
+#
+# `flock` skips a run whose predecessor is still going, and `timeout` turns a
+# wedged run into a failed one. Both report on stderr, which cron mails (see
+# MAILTO in cron/i-want-my-mtg) while stdout keeps going to the job's log.
+COMMAND="${1:-ingest}"
+# Locked per command, so ingest-decks is not blocked by a long ingest.
+LOCK_FILE="/var/lock/scry-${COMMAND//[^a-zA-Z0-9]/_}.lock"
+# A healthy full ingest finishes in well under 10 minutes.
+TIMEOUT_SECONDS="${SCRY_TIMEOUT_SECONDS:-3600}"
+
 echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) Starting scry.sh with args: ${*:-ingest}"
 
 echo "Sourcing .env..."
@@ -12,5 +27,22 @@ if [ -z "${DATABASE_URL:-}" ]; then
 fi
 echo "Environment variables validated."
 
+# The lock is held by this fd for as long as the script lives, and the child
+# inherits it - so it covers the whole run and releases on exit, however the
+# script ends.
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "ERROR: scry ${COMMAND} is already running (lock ${LOCK_FILE}); skipping this run" >&2
+    exit 1
+fi
+
 echo "Running: /opt/scripts/scry ${*:-ingest}"
-/opt/scripts/scry "${@:-ingest}"
+status=0
+timeout --signal=TERM --kill-after=60s "$TIMEOUT_SECONDS" /opt/scripts/scry "${@:-ingest}" || status=$?
+
+if [ "$status" -eq 124 ]; then
+    echo "ERROR: scry ${*:-ingest} exceeded ${TIMEOUT_SECONDS}s and was killed" >&2
+elif [ "$status" -ne 0 ]; then
+    echo "ERROR: scry ${*:-ingest} exited with status ${status}" >&2
+fi
+exit "$status"

--- a/migrations/014_add_set_is_main.sql
+++ b/migrations/014_add_set_is_main.sql
@@ -1,3 +1,8 @@
 ALTER TABLE "set" ADD COLUMN IF NOT EXISTS is_main BOOLEAN;
-UPDATE "set" SET is_main = (base_size > 0);
+-- Guarded: the migration set is replayed every deploy, and base_size is a
+-- derived column that scry zeroes on every set ingest and only restores in
+-- post-ingest. Unguarded, a deploy landing in that window re-derived
+-- is_main = false for every set and emptied the main-sets listing. After the
+-- first run the column is NOT NULL, so this is a clean no-op.
+UPDATE "set" SET is_main = (base_size > 0) WHERE is_main IS NULL;
 ALTER TABLE "set" ALTER COLUMN is_main SET DEFAULT true, ALTER COLUMN is_main SET NOT NULL;


### PR DESCRIPTION
## Problem

Every set in production has `is_main = false`, so `applyBaseFilter` (`src/database/set/set.repository.ts:225`) filters the default listing down to zero rows — no sets on web, API or mobile when showing main sets only.

`migrations/run_migrations.sh` replays every `.sql` on every deploy (no tracking table — `036` documents this explicitly), so each backfill has to be re-runnable. `014` held the only unguarded one left:

```sql
UPDATE "set" SET is_main = (base_size > 0);
```

`base_size` is derived: scry zeroes it on every set ingest and only restores it in post-ingest. An ingest run died in that window around 2026-07-20, leaving `base_size = 0` table-wide; the next deploy replayed this line and turned those zeros into `is_main = false` for all 686 sets.

Same line also clobbers the explicit `is_main` values in `test/integration/seed.sql` on any replay that follows seeding, and would flatten a fresh dev DB — `docker/postgres/init/001_complete_schema.sql:260` creates the column `NOT NULL DEFAULT true`.

## Change

Guard with `WHERE is_main IS NULL`, matching how `007` and `008` already guard theirs. The column is `NOT NULL` after the first run, so replays are a clean no-op and scry's `update_is_main` becomes the single writer of `is_main`.

The upstream half — scry's set upsert zeroing `base_size` on every re-ingest — is matthewdtowles/scry#62.

## Note

The guard means `014` can no longer *repair* `is_main` either, which is the correct ownership but does mean production needs one `scry post-ingest-updates` run to recompute `base_size` and `is_main`. Worth landing that before this deploys.

---

## Also here: alerting on a stale catalog

This incident ran unnoticed for two days. The ingests on 07-20 and 07-21 both stopped completing, prices stopped moving, and the only thing that surfaced it was someone noticing the empty set list.

Adds a 06:00 `scry health` job. `health` now exits non-zero when the newest `price` row is more than a day old (matthewdtowles/scry#62), and scry writes command failures to stderr via `eprintln!` while its report goes to stdout. So with stdout redirected to `health.log` and stderr left alone, the only thing that ever reaches `MAILTO` is a real failure — no daily success mail. `MAILTO=legal@iwantmymtg.net` applies to the whole file, so any other job writing to stderr surfaces too.

**Needs verifying on the box before this counts as working:** cron can only deliver through a local MTA, and AWS blocks outbound port 25 on Lightsail/EC2 by default. Worth a `echo test | mail -s test legal@iwantmymtg.net` before trusting it — if it doesn't land, routing through the SMTP provider the app already uses (`SMTP_HOST`/`SMTP_USER`/`SMTP_PASS`) via msmtp is the more reliable path.

---

## Root cause found, and the cron hardened around it

The 07-20 ingest **succeeded** (`Total set sizes updated: 168`, `Scry complete`). The reason no price row is dated 07-20 is that prices carry MTGJSON's file date, not the ingest date — that run wrote rows dated 07-19.

The 07-21 run is the incident. It deadlocked *inside* scry at `Processing cards for set: SLD`: stack in `futex_wait`, DB socket `ESTAB` with empty queues, no non-idle session in `pg_stat_activity`, 28s of CPU across 22 hours. It had already zeroed `base_size` via `update_sets` and never reached post-ingest. A second ingest had been wedged the same way since **05-09** — 73 days. Cron kept starting new ones on top.

So, in `cron/scry.sh`:
- **Per-command `flock`** — a run whose predecessor is still going is skipped, not stacked. Per-command so `ingest-decks` is not blocked by `ingest`.
- **`timeout` (1h)** — a wedged run dies instead of living for months. A healthy full ingest takes ~7 minutes.
- Both paths write one line to stderr.

And every cron line drops its `2>&1`. scry's report goes to stdout, its failures to stderr, so redirecting only stdout keeps the logs unchanged while failures reach `MAILTO`. That trailing `2>&1` is exactly what made two days of dead ingests invisible.

Verified in a `ubuntu:24.04` container across five cases: clean run (exit 0, silent), timeout (124 + message), non-zero exit (status preserved + message), concurrent same command (skipped with message), different command concurrently (unaffected).

The deadlock itself is not fixed here — this makes it loud and self-limiting. Worth a separate issue against scry; the suspect is the single-pass card+sealed tee (scry#60), which went onto the box on Jul 18 and had run clean on the 18th, 19th and 20th before hanging on the 21st.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

