### PR TITLE
feat(api): finish filter (normal/foil) on the inventory list

### DIFF
--- a/src/core/query/safe-query-options.dto.ts
+++ b/src/core/query/safe-query-options.dto.ts
@@ -39,6 +39,17 @@ export function safeFormat(value: unknown): Format | undefined {
     return Object.values(Format).includes(lower) ? lower : undefined;
 }
 
+// Card finish filter (inventory list). Exported like rarity/format so the API
+// validator and the OpenAPI enum document the same accepted values.
+export const FINISH_VALUES = ['normal', 'foil'] as const;
+export type Finish = (typeof FINISH_VALUES)[number];
+
+export function safeFinish(value: unknown): Finish | undefined {
+    if (typeof value !== 'string') return undefined;
+    const lower = value.toLowerCase() as Finish;
+    return FINISH_VALUES.includes(lower) ? lower : undefined;
+}
+
 function safeLegality(value: unknown, format: Format | undefined): LegalityStatus | undefined {
     if (!format) return undefined;
     if (typeof value !== 'string' || value === '') return LegalityStatus.Legal;
@@ -50,6 +61,7 @@ export interface RawQueryOptions {
     ascend?: string;
     baseOnly?: string;
     filter?: string;
+    finish?: string;
     format?: string;
     legality?: string;
     limit?: string;
@@ -65,6 +77,7 @@ export interface QueryOptionsData {
     readonly ascend?: boolean;
     readonly baseOnly: boolean;
     readonly filter?: string;
+    readonly finish?: Finish;
     readonly format?: Format;
     readonly includedSetTypes?: string[] | null;
     readonly legality?: LegalityStatus;
@@ -81,6 +94,7 @@ export class SafeQueryOptions implements QueryOptionsData {
     readonly ascend?: boolean;
     readonly baseOnly: boolean;
     readonly filter?: string;
+    readonly finish?: Finish;
     readonly format?: Format;
     readonly includedSetTypes?: string[] | null;
     readonly legality?: LegalityStatus;
@@ -96,6 +110,7 @@ export class SafeQueryOptions implements QueryOptionsData {
         this.ascend = safeBoolean(init.ascend);
         this.baseOnly = safeBoolean(init.baseOnly);
         this.filter = safeSearchTerm(init.filter);
+        this.finish = safeFinish(init.finish);
         this.format = safeFormat(init.format);
         this.legality = safeLegality(init.legality, this.format);
         this.limit = sanitizeInt(init.limit, 25, MAX_PAGE_LIMIT);
@@ -113,6 +128,7 @@ export class SafeQueryOptions implements QueryOptionsData {
                 ascend: this.ascend !== undefined ? String(this.ascend) : undefined,
                 baseOnly: String(baseOnly),
                 filter: this.filter,
+                finish: this.finish,
                 format: this.format,
                 legality: this.legality,
                 limit: String(this.limit),
@@ -132,6 +148,7 @@ export class SafeQueryOptions implements QueryOptionsData {
                 ascend: this.ascend !== undefined ? String(this.ascend) : undefined,
                 baseOnly: String(this.baseOnly),
                 filter: this.filter,
+                finish: this.finish,
                 format: this.format,
                 legality: this.legality,
                 limit: String(this.limit),

--- a/src/database/inventory/inventory.repository.ts
+++ b/src/database/inventory/inventory.repository.ts
@@ -116,6 +116,9 @@ export class InventoryRepository implements InventoryRepositoryPort {
         if (options.baseOnly) {
             qb.andWhere('card.inMain = :inMain', { inMain: true });
         }
+        if (options.finish) {
+            qb.andWhere(`${this.TABLE}.isFoil = :isFoil`, { isFoil: options.finish === 'foil' });
+        }
 
         this.queryHelper.applyOptions(qb, options);
         const results = await qb.getMany();
@@ -132,6 +135,10 @@ export class InventoryRepository implements InventoryRepositoryPort {
 
         if (options.baseOnly) {
             qb.andWhere('card.inMain = :inMain', { inMain: true });
+        }
+        // Mirror findByUser's finish clause so meta.total matches the rows served.
+        if (options.finish) {
+            qb.andWhere(`${this.TABLE}.isFoil = :isFoil`, { isFoil: options.finish === 'foil' });
         }
 
         this.queryHelper.applyFilters(qb, options.filter);

--- a/src/http/api/inventory/inventory-api.controller.ts
+++ b/src/http/api/inventory/inventory-api.controller.ts
@@ -33,7 +33,7 @@ import { InventoryImportService } from 'src/core/inventory/import/inventory-impo
 import { Inventory } from 'src/core/inventory/inventory.entity';
 import { InventoryService } from 'src/core/inventory/inventory.service';
 import { parseCardImport } from 'src/core/import/parsers/card-import-dispatch';
-import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
+import { FINISH_VALUES, SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { INVENTORY_SORTS } from 'src/core/query/sort-options.enum';
 import { JwtOrApiKeyGuard } from 'src/http/api/shared/jwt-or-api-key.guard';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
@@ -70,6 +70,12 @@ export class InventoryApiController {
     @ApiQuery({ name: 'sort', required: false, type: String })
     @ApiQuery({ name: 'ascend', required: false, type: Boolean })
     @ApiQuery({ name: 'filter', required: false, type: String })
+    @ApiQuery({
+        name: 'finish',
+        required: false,
+        enum: FINISH_VALUES,
+        description: 'Only holdings of this finish (normal or foil).',
+    })
     @ApiOkEnvelope(InventoryItemApiDto, { isArray: true, description: 'Inventory list' })
     @ApiResponse({
         status: 400,
@@ -80,7 +86,7 @@ export class InventoryApiController {
         @Query() query: Record<string, string>,
         @Req() req: AuthenticatedRequest
     ): Promise<ApiResponseDto<InventoryItemApiDto[]>> {
-        validateApiQuery(query, { sort: INVENTORY_SORTS });
+        validateApiQuery(query, { sort: INVENTORY_SORTS, finish: true });
         const options = new SafeQueryOptions(query);
         const [items, total] = await Promise.all([
             this.inventoryService.findAllForUser(req.user.id, options),

--- a/src/http/api/shared/query-validation.ts
+++ b/src/http/api/shared/query-validation.ts
@@ -1,7 +1,13 @@
 import { BadRequestException } from '@nestjs/common';
 import { Format } from 'src/core/card/format.enum';
 import { LegalityStatus } from 'src/core/card/legality.status.enum';
-import { PUBLIC_RARITIES, safeFormat, safeRarity } from 'src/core/query/safe-query-options.dto';
+import {
+    FINISH_VALUES,
+    PUBLIC_RARITIES,
+    safeFinish,
+    safeFormat,
+    safeRarity,
+} from 'src/core/query/safe-query-options.dto';
 import { SortOptions } from 'src/core/query/sort-options.enum';
 import { TRANSACTION_TYPES, parseTransactionType } from 'src/core/transaction/transaction.entity';
 
@@ -69,6 +75,8 @@ export interface StrictQueryFlags {
      */
     sort?: readonly SortOptions[];
     rarity?: boolean;
+    /** Validate `finish` against {@link FINISH_VALUES} (inventory list). */
+    finish?: boolean;
     format?: boolean;
     legality?: boolean;
     setCode?: boolean;
@@ -131,6 +139,12 @@ export function validateApiQuery(query: Record<string, unknown>, flags: StrictQu
         const value = readParam(query, 'rarity');
         if (value !== undefined && safeRarity(value) === undefined) {
             throw enumError('rarity', value, RARITY_VALUES);
+        }
+    }
+    if (flags.finish) {
+        const value = readParam(query, 'finish');
+        if (value !== undefined && safeFinish(value) === undefined) {
+            throw enumError('finish', value, FINISH_VALUES);
         }
     }
     if (flags.format) {

--- a/test/core/query/safe-query-options.spec.ts
+++ b/test/core/query/safe-query-options.spec.ts
@@ -111,6 +111,21 @@ describe('SafeQueryOptions — public catalog filters', () => {
         });
     });
 
+    describe('finish', () => {
+        it('accepts normal and foil, lowercasing input', () => {
+            expect(new SafeQueryOptions({ finish: 'foil' }).finish).toBe('foil');
+            expect(new SafeQueryOptions({ finish: 'Normal' }).finish).toBe('normal');
+        });
+
+        it('drops unknown values', () => {
+            expect(new SafeQueryOptions({ finish: 'etched' }).finish).toBeUndefined();
+        });
+
+        it('is undefined when not provided', () => {
+            expect(new SafeQueryOptions({}).finish).toBeUndefined();
+        });
+    });
+
     describe('limit', () => {
         it('defaults to 25 when absent', () => {
             expect(new SafeQueryOptions({}).limit).toBe(25);

--- a/test/http/api/shared/query-validation.spec.ts
+++ b/test/http/api/shared/query-validation.spec.ts
@@ -4,6 +4,7 @@ import { InvalidQueryParamException, validateApiQuery } from 'src/http/api/share
 const ALL_FLAGS = {
     sort: SET_CARD_SORTS,
     rarity: true,
+    finish: true,
     format: true,
     legality: true,
     setCode: true,
@@ -19,6 +20,7 @@ describe('validateApiQuery', () => {
                     {
                         sort: SortOptions.CARD,
                         rarity: 'rare',
+                        finish: 'foil',
                         format: 'modern',
                         legality: 'banned',
                         setCode: 'mh3',
@@ -44,6 +46,7 @@ describe('validateApiQuery', () => {
                 validateApiQuery(
                     {
                         rarity: 'COMMON',
+                        finish: 'Foil',
                         format: 'Standard',
                         legality: 'Legal',
                         type: 'sell',
@@ -71,6 +74,19 @@ describe('validateApiQuery', () => {
                 expect(err.allowedValues).toEqual(['common', 'uncommon', 'rare', 'mythic']);
                 expect(err.message).toContain("Invalid value 'foobar'");
                 expect(err.message).toContain('common, uncommon, rare, mythic');
+            }
+        });
+
+        it('rejects an unknown finish', () => {
+            try {
+                validateApiQuery({ finish: 'etched' }, ALL_FLAGS);
+                fail('expected throw');
+            } catch (e) {
+                expect(e).toBeInstanceOf(InvalidQueryParamException);
+                const err = e as InvalidQueryParamException;
+                expect(err.getStatus()).toBe(400);
+                expect(err.param).toBe('finish');
+                expect(err.allowedValues).toEqual(['normal', 'foil']);
             }
         });
 


### PR DESCRIPTION
Adds an optional `finish=normal|foil` query param to `GET /api/v1/inventory`, so clients can filter holdings by finish server-side.

## Why
The mobile app paginates inventory server-side (i-want-my-mtg-mobile#86); its All/Normal/Foil chips could only filter the pages already loaded. This makes the filter real: rows and `meta.total` both respect it.

## How
- `SafeQueryOptions`: new `finish` field with a `safeFinish` sanitizer (lenient lowercase/drop, like rarity/format); `FINISH_VALUES` exported as the single source for the validator and the OpenAPI enum.
- `validateApiQuery`: new `finish` flag — invalid values 400 with the allowed list, matching the strict-API convention.
- Inventory repository: `isFoil` where-clause applied in both `findByUser` and `totalInventoryCards` so the count matches the list.
- Controller: `@ApiQuery` enum documents the same values the validator enforces.

## Verification
- `npm test`: 1494/1494 pass (new specs for the sanitizer + validator).
- `npm run typecheck` clean; `npm run lint:check` 0 errors (warnings pre-existing).

Follow-up: the mobile app will switch its finish chips to this param (regenerating `lib/api/schema.ts` once this deploys).