### PR TITLE
style(charts): shade the area under the active price line

### DIFF
--- a/src/http/public/js/priceHistoryChart.js
+++ b/src/http/public/js/priceHistoryChart.js
@@ -16,15 +16,34 @@
         };
     }
 
+    /**
+     * A top-down fade of the line's own color, for the area under the curve.
+     * Scriptable because the chart area has no height until the first layout.
+     */
+    function areaGradient(color) {
+        return function (context) {
+            var area = context.chart.chartArea;
+            if (!area) return 'transparent';
+            var gradient = context.chart.ctx.createLinearGradient(0, area.top, 0, area.bottom);
+            gradient.addColorStop(0, color + '59');
+            gradient.addColorStop(1, color + '05');
+            return gradient;
+        };
+    }
+
+    // Only the active line is filled: stacking translucent areas for every
+    // series turns the plot to mud and hides the line the user is reading.
     function applyActiveDatasetStyles() {
         if (!chart) return;
         chart.data.datasets.forEach(function (d, j) {
             if (j === activeDatasetIndex) {
                 d.borderColor = d._fullColor;
                 d.borderWidth = 3;
+                d.fill = 'origin';
             } else {
                 d.borderColor = d._fullColor + '80';
                 d.borderWidth = 1.5;
+                d.fill = false;
             }
         });
     }
@@ -244,7 +263,7 @@
                 label: 'Normal',
                 data: normalPoints,
                 borderColor: colors.normal,
-                backgroundColor: colors.normal + '20',
+                backgroundColor: areaGradient(colors.normal),
                 borderWidth: 3,
                 pointRadius: pointRadius,
                 tension: 0.3,
@@ -256,7 +275,7 @@
                 label: 'Foil',
                 data: foilPoints,
                 borderColor: colors.foil + '80',
-                backgroundColor: colors.foil + '20',
+                backgroundColor: areaGradient(colors.foil),
                 borderWidth: 1.5,
                 pointRadius: pointRadius,
                 tension: 0.3,
@@ -271,9 +290,11 @@
             if (i === activeDatasetIndex) {
                 ds.borderColor = ds._fullColor;
                 ds.borderWidth = 3;
+                ds.fill = 'origin';
             } else {
                 ds.borderColor = ds._fullColor + '80';
                 ds.borderWidth = 1.5;
+                ds.fill = false;
             }
         });
 

--- a/src/http/public/js/setPriceHistoryChart.js
+++ b/src/http/public/js/setPriceHistoryChart.js
@@ -69,15 +69,34 @@
         });
     }
 
+    /**
+     * A top-down fade of the line's own color, for the area under the curve.
+     * Scriptable because the chart area has no height until the first layout.
+     */
+    function areaGradient(color) {
+        return function (context) {
+            var area = context.chart.chartArea;
+            if (!area) return 'transparent';
+            var gradient = context.chart.ctx.createLinearGradient(0, area.top, 0, area.bottom);
+            gradient.addColorStop(0, color + '59');
+            gradient.addColorStop(1, color + '05');
+            return gradient;
+        };
+    }
+
+    // Only the active line is filled: stacking translucent areas for every
+    // series turns the plot to mud and hides the line the user is reading.
     function applyActiveDatasetStyles() {
         if (!chart) return;
         chart.data.datasets.forEach(function (d, j) {
             if (j === activeDatasetIndex) {
                 d.borderColor = d._fullColor;
                 d.borderWidth = 3;
+                d.fill = 'origin';
             } else {
                 d.borderColor = d._fullColor + '80';
                 d.borderWidth = 1.5;
+                d.fill = false;
             }
         });
     }
@@ -431,7 +450,7 @@
                 label: 'Base Set',
                 data: basePricePoints,
                 borderColor: colors.basePrice,
-                backgroundColor: colors.basePrice + '20',
+                backgroundColor: areaGradient(colors.basePrice),
                 borderWidth: 3,
                 pointRadius: pointRadius,
                 tension: 0.3,
@@ -443,7 +462,7 @@
                 label: 'All Cards',
                 data: totalPricePoints,
                 borderColor: colors.totalPrice + '80',
-                backgroundColor: colors.totalPrice + '20',
+                backgroundColor: areaGradient(colors.totalPrice),
                 borderWidth: 1.5,
                 pointRadius: pointRadius,
                 tension: 0.3,
@@ -455,7 +474,7 @@
                 label: 'Base + Foils',
                 data: basePriceAllPoints,
                 borderColor: colors.basePriceAll + '80',
-                backgroundColor: colors.basePriceAll + '20',
+                backgroundColor: areaGradient(colors.basePriceAll),
                 borderWidth: 1.5,
                 pointRadius: pointRadius,
                 tension: 0.3,
@@ -471,7 +490,7 @@
                 label: 'All + Foils',
                 data: totalPriceAllPoints,
                 borderColor: colors.totalPriceAll + '80',
-                backgroundColor: colors.totalPriceAll + '20',
+                backgroundColor: areaGradient(colors.totalPriceAll),
                 borderWidth: 1.5,
                 pointRadius: pointRadius,
                 tension: 0.3,
@@ -495,9 +514,11 @@
             if (i === activeDatasetIndex) {
                 ds.borderColor = ds._fullColor;
                 ds.borderWidth = 3;
+                ds.fill = 'origin';
             } else {
                 ds.borderColor = ds._fullColor + '80';
                 ds.borderWidth = 1.5;
+                ds.fill = false;
             }
         });
 


### PR DESCRIPTION
The card and set price-history charts drew a bare line, so the size of a move had to be read off the axis rather than seen. This fills the active dataset to the origin with a top-down fade of its own color.

Only the **active** series is filled. Stacking translucent areas for all four set-price series (or both card finishes) turns the plot to mud and hides the line the user is actually reading — so `fill` follows the same active/inactive switch that `borderColor` and `borderWidth` already use, in `applyActiveDatasetStyles` and in the initial-styles pass.

The gradient is a scriptable `backgroundColor` because `chartArea` has no height until the first layout pass.

Files: `priceHistoryChart.js` (card), `setPriceHistoryChart.js` (set).

## Verification

`npm run test:frontend` (118 tests) passes; `npx prettier --check` clean on both files. Rendering not visually verified — worth a look on a card page and a set page before merge.

## Related

Mobile half of the same change (plus axis-label alignment): matthewdtowles/i-want-my-mtg-mobile#94