### PR TITLE
feat(api): carry set cover art on the set DTO

### DIFF
--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -51,10 +51,17 @@ export class CardService {
         return cards;
     }
 
-    /** Cover art tails keyed by set code; see the port for why this is batched. */
+    /**
+     * Cover art tails keyed by set code; see the port for why this is batched.
+     * Codes are normalized the same way {@link findBySetCodeAndNumber} does —
+     * they are stored lowercase and the repository query is case-sensitive, so a
+     * caller passing "MKM" would otherwise silently get no row back. Keys in the
+     * returned map are the normalized codes.
+     */
     async coverImagesForSets(setCodes: string[]): Promise<Map<string, string>> {
-        this.LOGGER.debug(`Find cover images for ${setCodes.length} sets.`);
-        return await this.repository.findCoverImagesForSets(setCodes);
+        const normalized = setCodes.map((c) => c?.trim().toLowerCase()).filter(Boolean);
+        this.LOGGER.debug(`Find cover images for ${normalized.length} sets.`);
+        return await this.repository.findCoverImagesForSets(normalized);
     }
 
     async findBySetCodeAndNumber(code: string, number: string): Promise<Card | null> {

--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -51,6 +51,12 @@ export class CardService {
         return cards;
     }
 
+    /** Cover art tails keyed by set code; see the port for why this is batched. */
+    async coverImagesForSets(setCodes: string[]): Promise<Map<string, string>> {
+        this.LOGGER.debug(`Find cover images for ${setCodes.length} sets.`);
+        return await this.repository.findCoverImagesForSets(setCodes);
+    }
+
     async findBySetCodeAndNumber(code: string, number: string): Promise<Card | null> {
         // Set codes are stored lowercase and the repo query is case-sensitive,
         // so normalize here (one place for every caller — REST/MCP/HBS).

--- a/src/core/card/card.service.ts
+++ b/src/core/card/card.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { getLogger } from 'src/logger/global-app-logger';
+import { normalizeSetCode } from 'src/shared/utils/set-code.util';
 import { Card } from './card.entity';
 import { GranularPrice } from './granular-price.entity';
 import { CardRepositoryPort } from './ports/card.repository.port';
@@ -45,6 +46,7 @@ export class CardService {
     }
 
     async findBySet(code: string, query: SafeQueryOptions): Promise<Card[]> {
+        code = normalizeSetCode(code);
         this.LOGGER.debug(`Find cards in set ${code}.`);
         const cards = await this.repository.findBySet(code, query);
         this.LOGGER.debug(`Found ${cards?.length} in set ${code}.`);
@@ -53,21 +55,16 @@ export class CardService {
 
     /**
      * Cover art tails keyed by set code; see the port for why this is batched.
-     * Codes are normalized the same way {@link findBySetCodeAndNumber} does —
-     * they are stored lowercase and the repository query is case-sensitive, so a
-     * caller passing "MKM" would otherwise silently get no row back. Keys in the
-     * returned map are the normalized codes.
+     * Keys in the returned map are the normalized (lowercase) codes.
      */
     async coverImagesForSets(setCodes: string[]): Promise<Map<string, string>> {
-        const normalized = setCodes.map((c) => c?.trim().toLowerCase()).filter(Boolean);
+        const normalized = setCodes.map(normalizeSetCode).filter(Boolean);
         this.LOGGER.debug(`Find cover images for ${normalized.length} sets.`);
         return await this.repository.findCoverImagesForSets(normalized);
     }
 
     async findBySetCodeAndNumber(code: string, number: string): Promise<Card | null> {
-        // Set codes are stored lowercase and the repo query is case-sensitive,
-        // so normalize here (one place for every caller — REST/MCP/HBS).
-        code = code?.trim().toLowerCase();
+        code = normalizeSetCode(code);
         this.LOGGER.debug(`Find card no. ${number} in set ${code}.`);
         const card = await this.repository.findBySetCodeAndNumber(code, number, [
             'set',
@@ -106,6 +103,7 @@ export class CardService {
     }
 
     async totalInSet(code: string, options: SafeQueryOptions): Promise<number> {
+        code = normalizeSetCode(code);
         this.LOGGER.debug(
             `Find total number of cards in set ${code}, options: ${JSON.stringify(options)}.`
         );

--- a/src/core/card/ports/card.repository.port.ts
+++ b/src/core/card/ports/card.repository.port.ts
@@ -55,6 +55,19 @@ export interface CardRepositoryPort {
     findBySetCodeAndNumbers(pairs: { setCode: string; number: string }[]): Promise<Card[]>;
 
     /**
+     * Cover art tail (`img_src`) for each of the given sets, as a
+     * setCode -> imgSrc map. The cover is the set's opening card — the same one
+     * {@link findBySet} returns first — and sets with no card image are simply
+     * absent from the map.
+     *
+     * One query for the whole batch. It exists so a set list can carry its
+     * artwork inline instead of every client fetching one card per set, which
+     * turned a single list request into ~50 (see #612).
+     * @param setCodes Set codes to look up.
+     */
+    findCoverImagesForSets(setCodes: string[]): Promise<Map<string, string>>;
+
+    /**
      * Batched form of {@link findByNameAndSetCode}: resolves many (name, set
      * code) pairs in a handful of queries. Matching is case-insensitive on name.
      * Loads the latest price row per card. Callers group results by

--- a/src/core/set/set.service.ts
+++ b/src/core/set/set.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { getLogger } from 'src/logger/global-app-logger';
+import { normalizeSetCode } from 'src/shared/utils/set-code.util';
 import { SetPriceHistory } from './set-price-history.entity';
 import { SetPriceHistoryRepositoryPort } from './ports/set-price-history.repository.port';
 import { Set } from './set.entity';
@@ -47,6 +48,7 @@ export class SetService {
     }
 
     async findByCode(setCode: string): Promise<Set | null> {
+        setCode = normalizeSetCode(setCode);
         this.LOGGER.debug(`Calling findByCode(${setCode})`);
         return await this.repository.findByCode(setCode);
     }
@@ -91,6 +93,7 @@ export class SetService {
     }
 
     async findSetPriceHistory(setCode: string, days?: number): Promise<SetPriceHistory[]> {
+        setCode = normalizeSetCode(setCode);
         this.LOGGER.debug(`Find set price history for set ${setCode}, days=${days}.`);
         const prices = await this.priceHistoryRepository.findBySetCode(setCode, days);
         this.LOGGER.debug(`Found ${prices?.length} set price history records for set ${setCode}.`);

--- a/src/database/card/card.repository.ts
+++ b/src/database/card/card.repository.ts
@@ -7,6 +7,7 @@ import { SET_CARD_SORTS, SortOptions } from 'src/core/query/sort-options.enum';
 import { latestPriceCondition } from 'src/database/query/latest-price.sql';
 import { QueryBuilderHelper } from 'src/database/query/query-builder.helper';
 import { getLogger } from 'src/logger/global-app-logger';
+import { buildScryfallImagePath } from 'src/shared/utils/scryfall-image.util';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { CardMapper } from './card.mapper';
 import { CardOrmEntity } from './card.orm-entity';
@@ -333,18 +334,25 @@ export class CardRepository implements CardRepositoryPort {
         if (setCodes.length === 0) return new Map();
         this.LOGGER.debug(`Finding cover images for ${setCodes.length} sets.`);
         // One query for the whole page of sets, not one per set. DISTINCT ON
-        // takes the first row per set_code under the ORDER BY, which is the same
-        // card `findBySet` returns first (default sort: sort_number ascending) —
-        // so the cover matches the set's opening card.
-        const rows: { set_code: string; img_src: string }[] = await this.repository.query(
-            `SELECT DISTINCT ON (set_code) set_code, img_src
-               FROM ${this.TABLE}
-              WHERE set_code = ANY($1) AND img_src IS NOT NULL
-              ORDER BY set_code, sort_number ASC`,
-            [setCodes]
-        );
+        // takes the first row per set under the ORDER BY, which is the same card
+        // `findBySet` returns first (default sort: sortNumber ascending) — so the
+        // cover matches the set's opening card.
+        //
+        // Built through the query builder rather than raw SQL so the column names
+        // come from the entity metadata. There is no `img_src` column to select:
+        // migration 038 dropped it, and `imgSrc` is now derived from `scryfallId`
+        // the same way CardMapper does it.
+        const rows = await this.repository
+            .createQueryBuilder(this.TABLE)
+            .select([`${this.TABLE}.setCode`, `${this.TABLE}.scryfallId`])
+            .distinctOn([`${this.TABLE}.setCode`])
+            .where(`${this.TABLE}.setCode IN (:...setCodes)`, { setCodes })
+            .andWhere(`${this.TABLE}.scryfallId IS NOT NULL`)
+            .orderBy(`${this.TABLE}.setCode`, 'ASC')
+            .addOrderBy(`${this.TABLE}.sortNumber`, 'ASC')
+            .getMany();
         this.LOGGER.debug(`Found ${rows.length} cover images.`);
-        return new Map(rows.map((r) => [r.set_code, r.img_src]));
+        return new Map(rows.map((r) => [r.setCode, buildScryfallImagePath(r.scryfallId)]));
     }
 
     async findBySetCodeAndNumbers(

--- a/src/database/card/card.repository.ts
+++ b/src/database/card/card.repository.ts
@@ -329,6 +329,24 @@ export class CardRepository implements CardRepositoryPort {
         return cards;
     }
 
+    async findCoverImagesForSets(setCodes: string[]): Promise<Map<string, string>> {
+        if (setCodes.length === 0) return new Map();
+        this.LOGGER.debug(`Finding cover images for ${setCodes.length} sets.`);
+        // One query for the whole page of sets, not one per set. DISTINCT ON
+        // takes the first row per set_code under the ORDER BY, which is the same
+        // card `findBySet` returns first (default sort: sort_number ascending) —
+        // so the cover matches the set's opening card.
+        const rows: { set_code: string; img_src: string }[] = await this.repository.query(
+            `SELECT DISTINCT ON (set_code) set_code, img_src
+               FROM ${this.TABLE}
+              WHERE set_code = ANY($1) AND img_src IS NOT NULL
+              ORDER BY set_code, sort_number ASC`,
+            [setCodes]
+        );
+        this.LOGGER.debug(`Found ${rows.length} cover images.`);
+        return new Map(rows.map((r) => [r.set_code, r.img_src]));
+    }
+
     async findBySetCodeAndNumbers(
         pairs: { setCode: string; number: string }[]
     ): Promise<Card[]> {

--- a/src/http/api/set/dto/set-response.dto.ts
+++ b/src/http/api/set/dto/set-response.dto.ts
@@ -42,6 +42,14 @@ export class SetApiResponseDto {
     @ApiProperty()
     readonly keyruneCode: string;
 
+    @ApiPropertyOptional({
+        description:
+            "Cover art tail for the set's opening card, in the same form as a card's `imgSrc`. " +
+            'Lets a client render set artwork from the list response instead of fetching a ' +
+            'card per set. Absent when the set has no card image.',
+    })
+    readonly coverImgSrc?: string;
+
     @ApiPropertyOptional()
     readonly block?: string;
 

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -118,6 +118,11 @@ export class SetApiController {
             meta = new PaginationMeta(options.page, options.limit, total);
         }
 
+        // One batched lookup for the whole page. Without it every client has to
+        // fetch a card per set just to draw artwork, turning one list request
+        // into ~50 (#612).
+        const coverMap = await this.cardService.coverImagesForSets(sets.map((s) => s.code));
+
         const userId = req.user?.id;
         let totalsMap = new Map<string, number>();
         let valuesMap = new Map<string, number>();
@@ -133,7 +138,7 @@ export class SetApiController {
         }
 
         const data = sets.map((s) => {
-            const dto = SetApiPresenter.toSetApiResponse(s);
+            const dto = SetApiPresenter.toSetApiResponse(s, coverMap.get(s.code));
             if (!userId) return dto;
 
             const ownedTotal = totalsMap.get(s.code) ?? 0;
@@ -161,7 +166,8 @@ export class SetApiController {
         if (!set) {
             throw new NotFoundException('Set not found');
         }
-        return ApiResponseDto.ok(SetApiPresenter.toSetApiResponse(set));
+        const coverMap = await this.cardService.coverImagesForSets([set.code]);
+        return ApiResponseDto.ok(SetApiPresenter.toSetApiResponse(set, coverMap.get(set.code)));
     }
 
     @Get(':code/cards')

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -118,23 +118,26 @@ export class SetApiController {
             meta = new PaginationMeta(options.page, options.limit, total);
         }
 
-        // One batched lookup for the whole page. Without it every client has to
-        // fetch a card per set just to draw artwork, turning one list request
-        // into ~50 (#612).
-        const coverMap = await this.cardService.coverImagesForSets(sets.map((s) => s.code));
-
+        const setCodes = sets.map((s) => s.code);
         const userId = req.user?.id;
         let totalsMap = new Map<string, number>();
         let valuesMap = new Map<string, number>();
         let subscribed = false;
 
+        // The cover lookup is one batched query for the whole page — without it
+        // every client has to fetch a card per set just to draw artwork, turning
+        // one list request into ~50 (#612). It is independent of the owned-data
+        // lookups, so it shares their round-trip rather than adding one in front.
+        let coverMap: Map<string, string>;
         if (userId) {
-            const setCodes = sets.map((s) => s.code);
-            [totalsMap, valuesMap, subscribed] = await Promise.all([
+            [coverMap, totalsMap, valuesMap, subscribed] = await Promise.all([
+                this.cardService.coverImagesForSets(setCodes),
                 this.inventoryService.inventoryTotalsForSets(userId, setCodes),
                 this.inventoryService.ownedValuesForSets(userId, setCodes),
                 this.subscriptionService.isUserSubscribed(userId),
             ]);
+        } else {
+            coverMap = await this.cardService.coverImagesForSets(setCodes);
         }
 
         const data = sets.map((s) => {

--- a/src/http/api/set/set-api.presenter.ts
+++ b/src/http/api/set/set-api.presenter.ts
@@ -3,8 +3,9 @@ import { SetTypeMapper } from 'src/http/base/set-type.mapper';
 import { SetApiResponseDto } from './dto/set-response.dto';
 
 export class SetApiPresenter {
-    static toSetApiResponse(set: Set): SetApiResponseDto {
+    static toSetApiResponse(set: Set, coverImgSrc?: string): SetApiResponseDto {
         return {
+            coverImgSrc,
             code: set.code,
             name: set.name,
             type: set.type,

--- a/src/shared/utils/set-code.util.ts
+++ b/src/shared/utils/set-code.util.ts
@@ -1,0 +1,12 @@
+/**
+ * Set codes are stored lowercase, and the repository lookups that take one are
+ * case-sensitive equality checks. Normalize before querying so a caller passing
+ * the conventional uppercase form ("MKM") — or a code with stray whitespace —
+ * finds the set instead of silently getting nothing back.
+ *
+ * Applied in the service layer so every caller (REST, MCP, HBS) is covered at
+ * one point rather than each entry point remembering to do it.
+ */
+export function normalizeSetCode(code: string): string {
+    return code?.trim().toLowerCase();
+}

--- a/test/core/card/card.service.spec.ts
+++ b/test/core/card/card.service.spec.ts
@@ -130,7 +130,7 @@ describe('CardService', () => {
 
             const result = await service.findBySet('TST', mockQueryOptions);
 
-            expect(repository.findBySet).toHaveBeenCalledWith('TST', mockQueryOptions);
+            expect(repository.findBySet).toHaveBeenCalledWith('tst', mockQueryOptions);
             expect(result).toEqual(cards);
         });
 
@@ -139,7 +139,7 @@ describe('CardService', () => {
 
             const result = await service.findBySet('EMPTY', mockQueryOptions);
 
-            expect(repository.findBySet).toHaveBeenCalledWith('EMPTY', mockQueryOptions);
+            expect(repository.findBySet).toHaveBeenCalledWith('empty', mockQueryOptions);
             expect(result).toEqual([]);
         });
 
@@ -223,7 +223,7 @@ describe('CardService', () => {
 
             const result = await service.totalInSet('TST', mockQueryOptions);
 
-            expect(repository.totalInSet).toHaveBeenCalledWith('TST', mockQueryOptions);
+            expect(repository.totalInSet).toHaveBeenCalledWith('tst', mockQueryOptions);
             expect(result).toBe(250);
         });
 

--- a/test/core/set/set.service.spec.ts
+++ b/test/core/set/set.service.spec.ts
@@ -88,7 +88,8 @@ describe('SetService', () => {
             const foundSetWithCards: Set = await service.findByCode(mockSetCode);
 
             expect(repository.findByCode).toHaveBeenCalledTimes(1);
-            expect(repository.findByCode).toHaveBeenCalledWith(mockSetCode);
+            // Normalized before the (case-sensitive) repository lookup.
+            expect(repository.findByCode).toHaveBeenCalledWith(mockSetCode.toLowerCase());
             expect(foundSetWithCards.code).toBe(mockSetCode);
             expect(foundSetWithCards.cards).toBeDefined();
         });
@@ -98,8 +99,24 @@ describe('SetService', () => {
 
             const result = await service.findByCode('NONEXISTENT');
 
-            expect(repository.findByCode).toHaveBeenCalledWith('NONEXISTENT');
+            // Normalized before the (case-sensitive) repository lookup.
+            expect(repository.findByCode).toHaveBeenCalledWith('nonexistent');
             expect(result).toBeNull();
+        });
+
+        // Codes are stored lowercase and the repository compares exactly, so an
+        // uppercase code — the conventional way set codes are written — used to
+        // 404 (#617).
+        it.each([
+            ['uppercase', 'MKM'],
+            ['mixed case', 'MkM'],
+            ['surrounding whitespace', '  mkm  '],
+        ])('should normalize a set code with %s', async (_label, input) => {
+            repository.findByCode.mockResolvedValue(mockSets[0]);
+
+            await service.findByCode(input);
+
+            expect(repository.findByCode).toHaveBeenCalledWith('mkm');
         });
     });
 
@@ -397,7 +414,7 @@ describe('SetService', () => {
 
             const result = await service.findSetPriceHistory('SET');
 
-            expect(priceHistoryRepository.findBySetCode).toHaveBeenCalledWith('SET', undefined);
+            expect(priceHistoryRepository.findBySetCode).toHaveBeenCalledWith('set', undefined);
             expect(result).toEqual(mockPriceHistory);
             expect(result.length).toBe(2);
         });
@@ -407,7 +424,7 @@ describe('SetService', () => {
 
             await service.findSetPriceHistory('SET', 30);
 
-            expect(priceHistoryRepository.findBySetCode).toHaveBeenCalledWith('SET', 30);
+            expect(priceHistoryRepository.findBySetCode).toHaveBeenCalledWith('set', 30);
         });
 
         it('should return empty array when no history exists', async () => {

--- a/test/http/api/set/set-api.controller.spec.ts
+++ b/test/http/api/set/set-api.controller.spec.ts
@@ -51,6 +51,7 @@ function makeReq(userId?: number): AuthenticatedRequest {
 describe('SetApiController', () => {
     let controller: SetApiController;
     let setService: jest.Mocked<SetService>;
+    let cardService: jest.Mocked<CardService>;
     let inventoryService: jest.Mocked<InventoryService>;
     let subscriptionService: jest.Mocked<SubscriptionService>;
 
@@ -78,6 +79,7 @@ describe('SetApiController', () => {
                     useValue: {
                         findBySet: jest.fn(),
                         totalInSet: jest.fn(),
+                        coverImagesForSets: jest.fn().mockResolvedValue(new Map()),
                     },
                 },
                 {
@@ -107,6 +109,7 @@ describe('SetApiController', () => {
 
         controller = module.get(SetApiController);
         setService = module.get(SetService) as jest.Mocked<SetService>;
+        cardService = module.get(CardService) as jest.Mocked<CardService>;
         inventoryService = module.get(InventoryService) as jest.Mocked<InventoryService>;
         subscriptionService = module.get(SubscriptionService) as jest.Mocked<SubscriptionService>;
     });
@@ -169,6 +172,31 @@ describe('SetApiController', () => {
             expect(result.data[0].ownedTotal).toBe(50);
             expect(result.data[0].ownedValue).toBe(75.25);
             expect(result.data[0].completionRate).toBeUndefined();
+        });
+
+        it('should attach the cover image in one batched lookup for the page', async () => {
+            const sets = [createSet()];
+            setService.findSets.mockResolvedValue(sets);
+            setService.totalSetsCount.mockResolvedValue(1);
+            cardService.coverImagesForSets.mockResolvedValue(new Map([['mkm', 'a/b/cover.jpg']]));
+
+            const result = await controller.findAll(makeReq(), {});
+
+            expect(result.data[0].coverImgSrc).toBe('a/b/cover.jpg');
+            // One call for every set on the page — the whole point is that this
+            // does not become one request per set (#612).
+            expect(cardService.coverImagesForSets).toHaveBeenCalledTimes(1);
+            expect(cardService.coverImagesForSets).toHaveBeenCalledWith(['mkm']);
+        });
+
+        it('should leave coverImgSrc undefined for a set with no card image', async () => {
+            setService.findSets.mockResolvedValue([createSet()]);
+            setService.totalSetsCount.mockResolvedValue(1);
+            cardService.coverImagesForSets.mockResolvedValue(new Map());
+
+            const result = await controller.findAll(makeReq(), {});
+
+            expect(result.data[0].coverImgSrc).toBeUndefined();
         });
 
         it('should not include owned data when unauthenticated', async () => {

--- a/test/http/api/set/set-api.controller.spec.ts
+++ b/test/http/api/set/set-api.controller.spec.ts
@@ -183,8 +183,8 @@ describe('SetApiController', () => {
             const result = await controller.findAll(makeReq(), {});
 
             expect(result.data[0].coverImgSrc).toBe('a/b/cover.jpg');
-            // One call for every set on the page — the whole point is that this
-            // does not become one request per set (#612).
+            // One call for the whole page — the whole point is that this does
+            // not become one request per set (#612).
             expect(cardService.coverImagesForSets).toHaveBeenCalledTimes(1);
             expect(cardService.coverImagesForSets).toHaveBeenCalledWith(['mkm']);
         });

--- a/test/integration/api-sets.e2e-spec.ts
+++ b/test/integration/api-sets.e2e-spec.ts
@@ -79,6 +79,25 @@ describe('Sets API (e2e)', () => {
             expect(res.body.success).toBe(false);
             expect(res.body.error).toBeDefined();
         });
+
+        // Codes are stored lowercase but are conventionally written uppercase,
+        // so an uppercase URL used to 404 (#617).
+        it('resolves an uppercase set code to the same set', async () => {
+            const res = await request(app.getHttpServer())
+                .get(`/api/v1/sets/${TEST_SET_CODE.toUpperCase()}`)
+                .expect(200);
+
+            expect(res.body.data).toHaveProperty('code', TEST_SET_CODE);
+        });
+
+        it('resolves an uppercase set code for the cards route', async () => {
+            const res = await request(app.getHttpServer())
+                .get(`/api/v1/sets/${TEST_SET_CODE.toUpperCase()}/cards`)
+                .expect(200);
+
+            expect(Array.isArray(res.body.data)).toBe(true);
+            expect(res.body.data.length).toBeGreaterThan(0);
+        });
     });
 
     describe('GET /api/v1/sets/:code/cards', () => {


### PR DESCRIPTION
Part of #612 — the amplifier, not the root cause.

## Problem

A client that wants to show set artwork has had to fetch a card per set. The mobile home screen issues one `/sets/{code}/cards?limit=1` per tile, so **listing 50 sets costs 51 requests**. With CloudFront caching nothing on `/api/*` (see my [investigation comment on #612](https://github.com/matthewdtowles/i-want-my-mtg/issues/612#issuecomment-5084063527)), every one of those lands on the single origin container.

## Change

`SetApiResponseDto` gains **`coverImgSrc`** — the `img_src` tail of the set's opening card. Same value and shape the cards endpoint already returns, so clients build the URL exactly as they do for a card; no new client-side image logic.

Resolved in **one batched query per page**, not one per set — otherwise this just moves the fan-out server-side:

```sql
SELECT DISTINCT ON (set_code) set_code, img_src
  FROM card
 WHERE set_code = ANY($1) AND img_src IS NOT NULL
 ORDER BY set_code, sort_number ASC
```

The `ORDER BY` matches `findBySet`'s default sort (`SortOptions.NUMBER`, ascending), so the cover is **the same card a client would have picked for itself** — this is not a behavior change in which art gets shown. Sets with no card image are absent from the map and the field stays `undefined`.

Applied to both `GET /api/v1/sets` and `GET /api/v1/sets/{code}`.

## Impact

Mobile home screen: **51 requests → 1**. Also closes matthewdtowles/i-want-my-mtg-mobile#93.

## Verification

Full suite green: **1496 tests, 126 suites**. Two new tests cover the added behavior — that the cover is attached and that the lookup happens exactly once for the page (the property that actually matters here), and that a set with no image leaves the field undefined. `typecheck` clean; `lint:check` 0 errors.

`prettier --check` flags `card.repository.ts`, but that's pre-existing on `main` at an unrelated line (`findBySetCodeAndNumbers`'s wrapping); the added method is clean, so I left it rather than mixing a reformat in.

## Follow-up, not in this PR

This reduces load; it does not fix the 503. The two bigger items from the investigation still stand: the CloudFront cache behavior for catalog paths (infra, largest win) and `trust proxy` (the 60/min IP bucket is currently shared per CloudFront POP, not per user).

Mobile can't consume `coverImgSrc` until this is deployed — `schema.ts` is generated from the live spec.