### PR TITLE
feat(deck): show deck cover art on the deck list

### DIFF
--- a/src/core/deck/deck-cover.policy.ts
+++ b/src/core/deck/deck-cover.policy.ts
@@ -97,14 +97,25 @@ export class DeckCoverPolicy {
         return best;
     }
 
-    /** Whole-word containment, so "dragon" does not match "dragons" mid-token. */
+    /**
+     * Whole-word containment, so "dragon" does not match "dragons" mid-token.
+     *
+     * Every occurrence is checked, not just the first: in "bring the ring" the
+     * leading hit is inside "bring", and stopping there would miss the real
+     * match at the end.
+     */
     private static containsWord(haystack: string, needle: string): boolean {
-        const index = haystack.indexOf(needle);
-        if (index === -1) return false;
-        const before = index === 0 ? ' ' : haystack[index - 1];
-        const after =
-            index + needle.length >= haystack.length ? ' ' : haystack[index + needle.length];
-        return !/[a-z0-9]/.test(before) && !/[a-z0-9]/.test(after);
+        for (
+            let index = haystack.indexOf(needle);
+            index !== -1;
+            index = haystack.indexOf(needle, index + 1)
+        ) {
+            const before = index === 0 ? ' ' : haystack[index - 1];
+            const after =
+                index + needle.length >= haystack.length ? ' ' : haystack[index + needle.length];
+            if (!/[a-z0-9]/.test(before) && !/[a-z0-9]/.test(after)) return true;
+        }
+        return false;
     }
 
     private static mostValuable(

--- a/src/core/deck/deck-cover.policy.ts
+++ b/src/core/deck/deck-cover.policy.ts
@@ -1,0 +1,123 @@
+import { Card } from 'src/core/card/card.entity';
+import { Format } from 'src/core/card/format.enum';
+import { DeckCard } from './deck-card.entity';
+import { DeckSummaryPolicy } from './deck-summary.policy';
+
+/** Formats built around a commander, where a legendary creature is the deck's face. */
+const COMMANDER_FORMATS: ReadonlySet<Format> = new Set([
+    Format.Commander,
+    Format.Brawl,
+    Format.Oathbreaker,
+]);
+
+/**
+ * Picks the card whose art represents a deck.
+ *
+ * There is no commander column on `deck_card` — entries carry only
+ * `isSideboard` — so the commander is inferred rather than stored. The order
+ * below runs most-intentional to most-mechanical, and each step falls through
+ * when it finds nothing:
+ *
+ *   1. The commander: a legendary creature, in a format that has one.
+ *   2. A card the deck is named after ("Atraxa Superfriends" -> Atraxa).
+ *   3. The most valuable creature — decks are usually pictured by a creature.
+ *   4. The most valuable card of any type.
+ *
+ * Ties within a step break on value, so the pick is deterministic. Cards with
+ * no art are never chosen; a deck of only art-less cards yields undefined and
+ * the caller renders its no-art fallback.
+ */
+export class DeckCoverPolicy {
+    static pick(
+        deck: { name?: string; format?: Format | null },
+        cards: DeckCard[] = []
+    ): Card | undefined {
+        // The sideboard is not what a deck looks like.
+        const candidates = DeckCoverPolicy.eligible(cards, false);
+        const pool = candidates.length > 0 ? candidates : DeckCoverPolicy.eligible(cards, true);
+        if (pool.length === 0) return undefined;
+
+        return (
+            DeckCoverPolicy.commander(pool, deck.format) ??
+            DeckCoverPolicy.namesake(pool, deck.name) ??
+            DeckCoverPolicy.mostValuable(pool, DeckCoverPolicy.isCreature) ??
+            DeckCoverPolicy.mostValuable(pool)
+        );
+    }
+
+    /** Main-deck cards that have art, or every carded entry when `includeSide`. */
+    private static eligible(cards: DeckCard[], includeSide: boolean): Card[] {
+        return cards
+            .filter((dc) => (includeSide || !dc.isSideboard) && dc.card?.imgSrc)
+            .map((dc) => dc.card);
+    }
+
+    private static isCreature(card: Card): boolean {
+        return (card.type ?? '').toLowerCase().includes('creature');
+    }
+
+    private static commander(pool: Card[], format?: Format | null): Card | undefined {
+        if (!format || !COMMANDER_FORMATS.has(format)) return undefined;
+        return DeckCoverPolicy.mostValuable(pool, (c) => {
+            const type = (c.type ?? '').toLowerCase();
+            return type.includes('legendary') && type.includes('creature');
+        });
+    }
+
+    /**
+     * A card the deck is named after. Matches on the card's name up to its first
+     * comma, because legendary names carry a title the deck name will not repeat
+     * ("Atraxa, Praetors' Voice" is shortened to "Atraxa"). The match must cover
+     * whole words so "Ur-Dragon" does not match a deck called "Dragons".
+     *
+     * Longest match wins — a deck named "Kenrith Group Hug" should pick Kenrith
+     * over a one-word card that also appears — then value.
+     */
+    private static namesake(pool: Card[], deckName?: string): Card | undefined {
+        const haystack = (deckName ?? '').toLowerCase().trim();
+        if (!haystack) return undefined;
+
+        let best: Card | undefined;
+        let bestLength = 0;
+        for (const card of pool) {
+            const needle = (card.name ?? '').split(',')[0].toLowerCase().trim();
+            // One-character names would match almost anything.
+            if (needle.length < 3) continue;
+            if (!DeckCoverPolicy.containsWord(haystack, needle)) continue;
+
+            const better =
+                needle.length > bestLength ||
+                (needle.length === bestLength &&
+                    DeckSummaryPolicy.cardValue(card) > DeckSummaryPolicy.cardValue(best));
+            if (better) {
+                best = card;
+                bestLength = needle.length;
+            }
+        }
+        return best;
+    }
+
+    /** Whole-word containment, so "dragon" does not match "dragons" mid-token. */
+    private static containsWord(haystack: string, needle: string): boolean {
+        const index = haystack.indexOf(needle);
+        if (index === -1) return false;
+        const before = index === 0 ? ' ' : haystack[index - 1];
+        const after =
+            index + needle.length >= haystack.length ? ' ' : haystack[index + needle.length];
+        return !/[a-z0-9]/.test(before) && !/[a-z0-9]/.test(after);
+    }
+
+    private static mostValuable(
+        pool: Card[],
+        predicate: (card: Card) => boolean = () => true
+    ): Card | undefined {
+        let best: Card | undefined;
+        for (const card of pool) {
+            if (!predicate(card)) continue;
+            if (!best || DeckSummaryPolicy.cardValue(card) > DeckSummaryPolicy.cardValue(best)) {
+                best = card;
+            }
+        }
+        return best;
+    }
+}

--- a/src/http/api/deck/deck-api.presenter.ts
+++ b/src/http/api/deck/deck-api.presenter.ts
@@ -1,5 +1,7 @@
 import { Format } from 'src/core/card/format.enum';
+import { CardImgType } from 'src/core/card/card.img.type.enum';
 import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckCoverPolicy } from 'src/core/deck/deck-cover.policy';
 import { DeckLegalityPolicy } from 'src/core/deck/deck-legality.policy';
 import { DeckSummaryPolicy } from 'src/core/deck/deck-summary.policy';
 import { Deck } from 'src/core/deck/deck.entity';
@@ -9,10 +11,15 @@ import { DeckCardApiDto, DeckDetailApiDto, DeckSummaryApiDto } from './dto/deck-
 export class DeckApiPresenter {
     static toSummary(deck: Deck): DeckSummaryApiDto {
         const cards = deck.cards ?? [];
+        const cover = DeckCoverPolicy.pick(deck, cards);
         return {
             id: deck.id!,
             name: deck.name,
             format: deck.format ?? null,
+            coverImgSrc: cover
+                ? `${BASE_IMAGE_URL}/${CardImgType.ART_CROP}/front/${cover.imgSrc}`
+                : undefined,
+            coverCardName: cover?.name,
             cardCount: DeckSummaryPolicy.cardCount(cards),
             estimatedValue: round2(DeckSummaryPolicy.estimatedValue(cards)),
             createdAt: deck.createdAt?.toISOString() ?? '',

--- a/src/http/api/deck/dto/deck-response.dto.ts
+++ b/src/http/api/deck/dto/deck-response.dto.ts
@@ -61,6 +61,17 @@ export class DeckSummaryApiDto {
     @ApiPropertyOptional({ nullable: true })
     readonly format?: string | null;
 
+    @ApiPropertyOptional({
+        description:
+            "Art-crop URL of the deck's representative card — its commander, the card it is " +
+            'named after, or its most valuable creature. Ready to render as-is. Absent for an ' +
+            'empty deck.',
+    })
+    readonly coverImgSrc?: string;
+
+    @ApiPropertyOptional({ description: "The cover card's name, for alt text." })
+    readonly coverCardName?: string;
+
     @ApiProperty({ description: 'Total card count (sum of quantities, main + side).' })
     readonly cardCount: number;
 

--- a/src/http/hbs/deck/deck-page.orchestrator.ts
+++ b/src/http/hbs/deck/deck-page.orchestrator.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { CardImgType } from 'src/core/card/card.img.type.enum';
 import { Format } from 'src/core/card/format.enum';
 import { DomainNotFoundError } from 'src/core/errors/domain.errors';
 import { DeckBuildabilityService } from 'src/core/deck/deck-buildability.service';
 import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckCoverPolicy } from 'src/core/deck/deck-cover.policy';
 import { DeckCardGap, DeckGapSummary } from 'src/core/deck/deck-gap.policy';
 import { DeckImportService } from 'src/core/deck/deck-import.service';
 import { DeckLegalityPolicy } from 'src/core/deck/deck-legality.policy';
@@ -10,7 +12,7 @@ import { DeckSummaryPolicy } from 'src/core/deck/deck-summary.policy';
 import { Deck } from 'src/core/deck/deck.entity';
 import { DeckService } from 'src/core/deck/deck.service';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
-import { buildCardUrl } from 'src/http/base/http.util';
+import { BASE_IMAGE_URL, buildCardUrl } from 'src/http/base/http.util';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { getLogger } from 'src/logger/global-app-logger';
 import { primaryType, TYPE_ORDER, TYPE_PLURAL } from './deck-grouping';
@@ -182,9 +184,16 @@ export class DeckPageOrchestrator {
 
     private toListItem(deck: Deck, gap?: DeckGapSummary) {
         const cards = deck.cards ?? [];
+        // Art crop of the deck's representative card (see DeckCoverPolicy).
+        // Undefined for an empty deck, which the template renders as a plain tile.
+        const cover = DeckCoverPolicy.pick(deck, cards);
         return {
             id: deck.id!,
             name: deck.name,
+            coverImgSrc: cover
+                ? `${BASE_IMAGE_URL}/${CardImgType.ART_CROP}/front/${cover.imgSrc}`
+                : undefined,
+            coverCardName: cover?.name,
             formatLabel: deck.format ? this.capitalize(deck.format) : 'No format',
             cardCount: DeckSummaryPolicy.cardCount(cards),
             estimatedValue: this.formatCurrency(DeckSummaryPolicy.estimatedValue(cards)),

--- a/src/http/hbs/deck/dto/deck.view.dto.ts
+++ b/src/http/hbs/deck/dto/deck.view.dto.ts
@@ -11,6 +11,10 @@ export interface FormatOptionView {
 export interface DeckListItemView {
     id: number;
     name: string;
+    /** Art-crop URL of the deck's representative card; absent for an empty deck. */
+    coverImgSrc?: string;
+    /** That card's name, for the image's alt text. */
+    coverCardName?: string;
     formatLabel: string;
     cardCount: number;
     estimatedValue: string;

--- a/src/http/views/decks.hbs
+++ b/src/http/views/decks.hbs
@@ -43,16 +43,27 @@
     {{#if hasDecks}}
         <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {{#each decks}}
-                <div class="section-container" data-deck-id="{{id}}">
-                    <div class="flex items-start justify-between gap-2">
-                        <a href="{{url}}" class="font-display font-semibold text-lg text-gray-900 dark:text-white hover:text-teal-600 dark:hover:text-teal-400">{{name}}</a>
+                <div class="section-container !p-0 overflow-hidden" data-deck-id="{{id}}">
+                    {{!-- Art band: the deck's representative card, name over a scrim. --}}
+                    <a href="{{url}}" class="relative block h-28 bg-gray-200 dark:bg-midnight-700 group">
+                        {{#if coverImgSrc}}
+                            <img src="{{coverImgSrc}}" alt="Art from {{coverCardName}}" loading="lazy" decoding="async"
+                                width="626" height="457"
+                                class="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105" />
+                        {{/if}}
+                        <div class="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent px-4 pt-8 pb-2">
+                            <span class="font-display font-semibold text-lg text-white drop-shadow">{{name}}</span>
+                        </div>
+                    </a>
+                    <div class="p-4">
+                    <div class="flex items-center justify-between gap-2">
+                        <div class="flex items-center gap-2">
+                            <span class="text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
+                            {{>deckColors colors=colors}}
+                        </div>
                         <button type="button" class="deck-delete-btn text-gray-400 hover:text-red-500" data-deck-id="{{id}}" data-deck-name="{{name}}" aria-label="Delete deck">
                             <i class="fas fa-trash" aria-hidden="true"></i>
                         </button>
-                    </div>
-                    <div class="mt-1 flex items-center gap-2">
-                        <span class="text-xs uppercase tracking-wider text-purple-600 dark:text-purple-400 font-semibold">{{formatLabel}}</span>
-                        {{>deckColors colors=colors}}
                     </div>
                     <div class="mt-3 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
                         <span>{{cardCount}} card{{#unless (eq cardCount 1)}}s{{/unless}}</span>
@@ -74,6 +85,7 @@
                     </div>
                     {{/if}}
                     <div class="mt-1 text-xs text-gray-400">Updated {{updatedAt}}</div>
+                    </div>
                 </div>
             {{/each}}
         </div>

--- a/test/core/deck/deck-cover.policy.spec.ts
+++ b/test/core/deck/deck-cover.policy.spec.ts
@@ -1,0 +1,177 @@
+import { Card } from 'src/core/card/card.entity';
+import { Format } from 'src/core/card/format.enum';
+import { CardRarity } from 'src/core/card/card.rarity.enum';
+import { Price } from 'src/core/card/price.entity';
+import { DeckCard } from 'src/core/deck/deck-card.entity';
+import { DeckCoverPolicy } from 'src/core/deck/deck-cover.policy';
+
+let seq = 0;
+
+function card(overrides: { name: string; type?: string; value?: number; imgSrc?: string }): Card {
+    seq += 1;
+    return new Card({
+        id: `card-${seq}`,
+        name: overrides.name,
+        type: overrides.type ?? 'Creature — Human',
+        imgSrc: overrides.imgSrc === undefined ? `a/b/${seq}.jpg` : overrides.imgSrc,
+        number: String(seq),
+        rarity: CardRarity.Rare,
+        setCode: 'tst',
+        sortNumber: String(seq),
+        legalities: [],
+        prices:
+            overrides.value === undefined
+                ? []
+                : [new Price({ cardId: `card-${seq}`, normal: overrides.value, date: new Date() })],
+    });
+}
+
+function entry(c: Card, isSideboard = false): DeckCard {
+    return new DeckCard({ cardId: c.id, quantity: 1, isSideboard, card: c });
+}
+
+describe('DeckCoverPolicy', () => {
+    it('prefers the commander in a commander-format deck', () => {
+        const commander = card({
+            name: 'Atraxa, Praetors’ Voice',
+            type: 'Legendary Creature — Phyrexian Angel Horror',
+            value: 5,
+        });
+        // Worth far more, but a commander deck is pictured by its commander.
+        const bomb = card({ name: 'Jeweled Lotus', type: 'Artifact', value: 300 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Superfriends', format: Format.Commander }, [
+            entry(bomb),
+            entry(commander),
+        ]);
+
+        expect(pick.name).toBe('Atraxa, Praetors’ Voice');
+    });
+
+    it('ignores the commander rule outside commander formats', () => {
+        const legend = card({ name: 'Thalia', type: 'Legendary Creature — Human', value: 5 });
+        const bomb = card({ name: 'Ragavan', type: 'Creature — Monkey Pirate', value: 60 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Aggro', format: Format.Modern }, [
+            entry(legend),
+            entry(bomb),
+        ]);
+
+        expect(pick.name).toBe('Ragavan');
+    });
+
+    it('picks the card the deck is named after, over a more valuable one', () => {
+        const namesake = card({ name: 'Kenrith, the Returned King', value: 2 });
+        const bomb = card({ name: 'Mana Crypt', type: 'Artifact', value: 200 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Kenrith Group Hug', format: Format.Modern }, [
+            entry(bomb),
+            entry(namesake),
+        ]);
+
+        expect(pick.name).toBe('Kenrith, the Returned King');
+    });
+
+    it('matches the deck name on whole words only', () => {
+        // "Dragons" must not match the card "Dragon".
+        const dragon = card({ name: 'Dragon', value: 1 });
+        const other = card({ name: 'Shivan Devastator', value: 9 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Dragons of Tarkir', format: Format.Modern }, [
+            entry(dragon),
+            entry(other),
+        ]);
+
+        expect(pick.name).toBe('Shivan Devastator');
+    });
+
+    it('prefers the longest namesake match', () => {
+        const short = card({ name: 'Ur-Dragon', value: 50 });
+        const long = card({ name: 'The Ur-Dragon, Hidden', value: 1 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'The Ur-Dragon Tribal', format: Format.Modern }, [
+            entry(short),
+            entry(long),
+        ]);
+
+        expect(pick.name).toBe('The Ur-Dragon, Hidden');
+    });
+
+    it('falls back to the most valuable creature', () => {
+        const cheapCreature = card({ name: 'Llanowar Elves', value: 1 });
+        const goodCreature = card({ name: 'Sheoldred', value: 90 });
+        const pricierNonCreature = card({ name: 'The One Ring', type: 'Artifact', value: 120 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Midrange', format: Format.Standard }, [
+            entry(cheapCreature),
+            entry(pricierNonCreature),
+            entry(goodCreature),
+        ]);
+
+        expect(pick.name).toBe('Sheoldred');
+    });
+
+    it('falls back to the most valuable card when the deck has no creatures', () => {
+        const cheap = card({ name: 'Opt', type: 'Instant', value: 1 });
+        const pricey = card({ name: 'Force of Will', type: 'Instant', value: 90 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Control', format: Format.Legacy }, [
+            entry(cheap),
+            entry(pricey),
+        ]);
+
+        expect(pick.name).toBe('Force of Will');
+    });
+
+    it('never picks a sideboard card when the maindeck has art', () => {
+        const main = card({ name: 'Opt', type: 'Instant', value: 1 });
+        const side = card({ name: 'Force of Will', type: 'Instant', value: 90 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Control', format: Format.Legacy }, [
+            entry(main),
+            entry(side, true),
+        ]);
+
+        expect(pick.name).toBe('Opt');
+    });
+
+    it('uses the sideboard when the maindeck is empty', () => {
+        const side = card({ name: 'Force of Will', type: 'Instant', value: 90 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Control', format: Format.Legacy }, [
+            entry(side, true),
+        ]);
+
+        expect(pick.name).toBe('Force of Will');
+    });
+
+    it('skips cards with no art', () => {
+        const artless = card({ name: 'Black Lotus', type: 'Artifact', value: 9999, imgSrc: '' });
+        const usable = card({ name: 'Opt', type: 'Instant', value: 1 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Vintage', format: Format.Vintage }, [
+            entry(artless),
+            entry(usable),
+        ]);
+
+        expect(pick.name).toBe('Opt');
+    });
+
+    it('returns undefined for an empty deck', () => {
+        expect(DeckCoverPolicy.pick({ name: 'New deck', format: null }, [])).toBeUndefined();
+    });
+
+    it('returns undefined when no card has art', () => {
+        const artless = card({ name: 'Opt', type: 'Instant', value: 1, imgSrc: '' });
+
+        expect(
+            DeckCoverPolicy.pick({ name: 'Control', format: Format.Legacy }, [entry(artless)])
+        ).toBeUndefined();
+    });
+
+    it('tolerates a deck with no name', () => {
+        const only = card({ name: 'Opt', type: 'Instant', value: 1 });
+
+        expect(DeckCoverPolicy.pick({ format: null }, [entry(only)]).name).toBe('Opt');
+    });
+});

--- a/test/core/deck/deck-cover.policy.spec.ts
+++ b/test/core/deck/deck-cover.policy.spec.ts
@@ -85,6 +85,20 @@ describe('DeckCoverPolicy', () => {
         expect(pick.name).toBe('Shivan Devastator');
     });
 
+    it('finds a namesake match after an earlier partial-token hit', () => {
+        // "ring" appears inside "Bring" first; scanning must continue to the
+        // real whole-word match at the end.
+        const ring = card({ name: 'Ring', type: 'Artifact', value: 1 });
+        const other = card({ name: 'Frodo Baggins', value: 40 });
+
+        const pick = DeckCoverPolicy.pick({ name: 'Bring the Ring', format: Format.Modern }, [
+            entry(other),
+            entry(ring),
+        ]);
+
+        expect(pick.name).toBe('Ring');
+    });
+
     it('prefers the longest namesake match', () => {
         const short = card({ name: 'Ur-Dragon', value: 50 });
         const long = card({ name: 'The Ur-Dragon, Hidden', value: 1 });

--- a/test/http/api/deck/deck-api.presenter.spec.ts
+++ b/test/http/api/deck/deck-api.presenter.spec.ts
@@ -71,3 +71,34 @@ describe('DeckApiPresenter.toDetail', () => {
         expect(dto.illegalCount).toBe(0);
     });
 });
+
+describe('DeckApiPresenter.toSummary cover art', () => {
+    function deckWith(cards: DeckCard[], format: Format | null = Format.Modern): Deck {
+        return new Deck({
+            id: 1,
+            userId: 7,
+            name: 'Sheoldred Midrange',
+            format,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            cards,
+        });
+    }
+
+    it('exposes the cover as a ready-to-render art crop', () => {
+        const cover = card('Sheoldred', 'Legendary Creature — Praetor', 90);
+        const summary = DeckApiPresenter.toSummary(
+            deckWith([new DeckCard({ cardId: 'Sheoldred', quantity: 1, isSideboard: false, card: cover })])
+        );
+
+        expect(summary.coverImgSrc).toBe('https://cards.scryfall.io/art_crop/front/a/b/c.jpg');
+        expect(summary.coverCardName).toBe('Sheoldred');
+    });
+
+    it('omits the cover for an empty deck', () => {
+        const summary = DeckApiPresenter.toSummary(deckWith([]));
+
+        expect(summary.coverImgSrc).toBeUndefined();
+        expect(summary.coverCardName).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Decks listed as text-only cards while the set list is art-backed. This gives each deck the art crop of a representative card — on the web deck list and on the JSON API the mobile app reads.

## Which card represents a deck

The interesting part. There is **no commander column** on `deck_card` — entries carry only `isSideboard` — so `DeckCoverPolicy` infers it, running most-intentional to most-mechanical and falling through when a step finds nothing:

1. **The commander** — a legendary creature, in a format that has one (commander / brawl / oathbreaker).
2. **A card the deck is named after** — "Atraxa Superfriends" → Atraxa. Matched on the card's name *up to its first comma*, since legendary names carry a title the deck name won't repeat, and on **whole words** so "Ur-Dragon" doesn't match a deck called "Dragons". Longest match wins.
3. **The most valuable creature** — decks are usually pictured by a creature.
4. **The most valuable card** of any type.

Ties break on value, so the pick is deterministic. The sideboard is not what a deck looks like, so it's only consulted when the maindeck has no art at all. Cards without art are never chosen, and a deck that yields none renders the plain tile it does today.

**Costs no extra query** — both deck read paths already load cards with prices to compute value and counts.

## Layout

Web tiles become an art band with the deck name over a scrim, with format, colors, value, and the completeness bar below. Deck cards carry far more detail than set tiles, and stacking it over artwork reads worse than giving it room.

```
┌────────────────────┐
│ [   art crop    ]  │
│ ░░░░░░░░░░░░░░░░░░ │
│ Mono-Red Aggro     │  <- name on scrim
├────────────────────┤
│ COMMANDER  ●●    🗑│
│ 60 cards    $124.50│
│ You own 82%        │
│ ████████░░ Buildable│
└────────────────────┘
```

The duplicated "Updated" line the old markup had at top and bottom is now shown once.

## API

`DeckSummaryApiDto` gains `coverImgSrc` (a ready-to-render art-crop URL, matching how this endpoint already returns full URLs for deck-card images) and `coverCardName` for alt text.

## Verification

1514 unit tests, 295 integration, all passing. 13 new tests cover the policy — each priority step, the whole-word and longest-match rules, sideboard fallback, art-less cards, and empty decks — plus 2 on the API presenter.

Not visually verified in a browser yet; worth a look at `/decks` before merge.

## Follow-up

The mobile half is a separate PR and **blocked on this deploying** — `schema.ts` is generated from the live spec, so the app can't type `coverImgSrc` until then. Same constraint as #615.