### PR TITLE
feat(api): list a card's printings by set code and number

### DIFF
--- a/RAPIDAPI.md
+++ b/RAPIDAPI.md
@@ -57,6 +57,7 @@ from the public surface.
 | `GET /api/v1/cards/{setCode}/{setNumber}` | `lea/161` (Lightning Bolt) |
 | `GET /api/v1/cards/{setCode}/{setNumber}/prices` | `lea/161` |
 | `GET /api/v1/cards/{setCode}/{setNumber}/price-history` | `lea/161` |
+| `GET /api/v1/cards/{setCode}/{setNumber}/printings` | `lea/161` (every printing of Lightning Bolt) |
 | `GET /api/v1/sets` | `?limit=10` |
 | `GET /api/v1/sets/{code}` | `lea` |
 | `GET /api/v1/sets/{code}/cards` | code `lea`, query `?limit=10` |

--- a/src/database/card/card.repository.ts
+++ b/src/database/card/card.repository.ts
@@ -105,6 +105,9 @@ export class CardRepository implements CardRepositoryPort {
                 'prices',
                 latestPriceCondition('prices', 'card')
             )
+            // The set is joined so callers can name the printing's set, not just
+            // its code — the API's printings list has no set context of its own.
+            .leftJoinAndSelect(`${this.TABLE}.set`, 'set')
             .where(`${this.TABLE}.name = :name`, { name });
 
         // Use price-desc helper for "other printings" sorted by value

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -272,9 +272,15 @@ export class CardApiController {
         if (!card) {
             throw new NotFoundException('Card not found');
         }
-        // Printings have a fixed price-desc order (findWithName ignores `sort`),
-        // so only page/limit are read off the query.
-        const options = new SafeQueryOptions(query);
+        // Only paging is taken from the query: `sort` and `ascend` are dropped so
+        // the price-desc order is the contract rather than a default a caller can
+        // flip. `ascend` has to be passed explicitly - SafeQueryOptions defaults
+        // it to true, which would order the cheapest printing first.
+        const options = new SafeQueryOptions({
+            page: query.page,
+            limit: query.limit,
+            ascend: 'false',
+        });
         const [printings, total] = await Promise.all([
             this.cardService.findWithName(card.name, options),
             this.cardService.totalWithName(card.name),

--- a/src/http/api/card/card-api.controller.ts
+++ b/src/http/api/card/card-api.controller.ts
@@ -10,6 +10,7 @@ import {
 import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ApiOkEnvelope } from '../shared/api-ok-envelope.decorator';
 import { CardService } from 'src/core/card/card.service';
+import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { SearchQueryOptions } from 'src/core/query/search-query-options.dto';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { parseDaysParam } from 'src/http/base/query.util';
@@ -247,6 +248,41 @@ export class CardApiController {
             throw new NotFoundException('Card not found');
         }
         return this.getPriceHistoryForCard(card.id, days);
+    }
+
+    @Get(':setCode/:setNumber/printings')
+    @ApiOperation({
+        operationId: 'getCardPrintings',
+        summary: 'List every printing of this card, most valuable first',
+    })
+    @ApiQuery({ name: 'page', required: false, type: Number })
+    @ApiQuery({ name: 'limit', required: false, type: Number })
+    @ApiOkEnvelope(CardApiResponseDto, {
+        isArray: true,
+        description:
+            'Printings of the card, including the one addressed by the path (clients that want "other printings" filter it out; the total counts every printing)',
+    })
+    @ApiResponse({ status: 404, description: 'Card not found' })
+    async getPrintings(
+        @Param('setCode') setCode: string,
+        @Param('setNumber') setNumber: string,
+        @Query() query: Record<string, string>
+    ): Promise<ApiResponseDto<CardApiResponseDto[]>> {
+        const card = await this.cardService.findBySetCodeAndNumber(setCode, setNumber);
+        if (!card) {
+            throw new NotFoundException('Card not found');
+        }
+        // Printings have a fixed price-desc order (findWithName ignores `sort`),
+        // so only page/limit are read off the query.
+        const options = new SafeQueryOptions(query);
+        const [printings, total] = await Promise.all([
+            this.cardService.findWithName(card.name, options),
+            this.cardService.totalWithName(card.name),
+        ]);
+        return ApiResponseDto.ok(
+            printings.map((c) => CardApiPresenter.toCardApiResponse(c)),
+            new PaginationMeta(options.page, options.limit, total)
+        );
     }
 
     @Get(':setCode/:setNumber')

--- a/src/http/api/openapi-public-spec.ts
+++ b/src/http/api/openapi-public-spec.ts
@@ -11,6 +11,7 @@ const PUBLIC_PATH_ALLOWLIST: ReadonlyArray<string> = Object.freeze([
     '/api/v1/cards/{setCode}/{setNumber}',
     '/api/v1/cards/{setCode}/{setNumber}/prices',
     '/api/v1/cards/{setCode}/{setNumber}/price-history',
+    '/api/v1/cards/{setCode}/{setNumber}/printings',
     '/api/v1/sets',
     '/api/v1/sets/{code}',
     '/api/v1/sets/{code}/cards',

--- a/src/mcp/tools/cards.tools.ts
+++ b/src/mcp/tools/cards.tools.ts
@@ -183,10 +183,12 @@ export class CardMcpTools {
         if (!card) {
             throw new NotFoundException('Card not found');
         }
-        // Only paging is read: findWithName has a fixed price-desc order, and
-        // setCode/setNumber are the card's address here, not filters on the list.
+        // Only paging is read: setCode/setNumber are the card's address here, not
+        // filters on the list. `ascend: false` pins the price-desc order the tool
+        // advertises - SearchQueryOptions defaults ascend to true, which would put
+        // the cheapest printing first.
         const { page, limit } = this.toQuery(args);
-        const options = new SearchQueryOptions({ page, limit });
+        const options = new SearchQueryOptions({ page, limit, ascend: 'false' });
         const [printings, total] = await Promise.all([
             this.cardService.findWithName(card.name, options),
             this.cardService.totalWithName(card.name),

--- a/src/mcp/tools/cards.tools.ts
+++ b/src/mcp/tools/cards.tools.ts
@@ -99,6 +99,25 @@ export class CardMcpTools {
                 annotations: READ_ONLY,
                 handler: async (args) => this.getCardPriceHistory(args),
             },
+            {
+                name: 'get_card_printings',
+                description:
+                    'List every printing of the card at this set code and collector number, most valuable first. Use this to compare what the same card costs across sets, or to find a cheaper printing. Prefer it over search_cards for that: search_cards matches names by substring, so it also returns unrelated cards whose names merely contain the term.',
+                inputSchema: z.object({
+                    ...cardKeySchema,
+                    page: z.number().int().min(1).optional().describe('1-based page index.'),
+                    limit: z
+                        .number()
+                        .int()
+                        .min(1)
+                        .max(100)
+                        .optional()
+                        .describe('Page size (max 100).'),
+                }),
+                requiresAuth: false,
+                annotations: READ_ONLY,
+                handler: async (args) => this.getCardPrintings(args),
+            },
         ];
     }
 
@@ -156,6 +175,26 @@ export class CardMcpTools {
         }
         const prices = await this.cardService.findPriceHistory(card.id, parseDaysParam(undefined));
         return ApiResponseDto.ok(prices.map(CardPresenter.toPriceHistoryPoint));
+    }
+
+    private async getCardPrintings(args: Record<string, unknown>): Promise<unknown> {
+        const setCode = String(args.setCode).trim().toLowerCase();
+        const card = await this.cardService.findBySetCodeAndNumber(setCode, String(args.setNumber));
+        if (!card) {
+            throw new NotFoundException('Card not found');
+        }
+        // Only paging is read: findWithName has a fixed price-desc order, and
+        // setCode/setNumber are the card's address here, not filters on the list.
+        const { page, limit } = this.toQuery(args);
+        const options = new SearchQueryOptions({ page, limit });
+        const [printings, total] = await Promise.all([
+            this.cardService.findWithName(card.name, options),
+            this.cardService.totalWithName(card.name),
+        ]);
+        return ApiResponseDto.ok(
+            printings.map((c) => CardApiPresenter.toCardApiResponse(c)),
+            new PaginationMeta(options.page, options.limit, total)
+        );
     }
 
     private toQuery(args: Record<string, unknown>): Record<string, string> {

--- a/src/mcp/tools/output-schemas.ts
+++ b/src/mcp/tools/output-schemas.ts
@@ -237,6 +237,7 @@ export const outputSchemaByName: Record<string, z.ZodTypeAny> = {
     get_card: ok(card),
     get_card_prices: ok(card),
     get_card_price_history: ok(z.array(pricePoint)),
+    get_card_printings: okPaginated(card),
     // sets
     search_sets: okPaginated(set),
     get_set: ok(set),

--- a/test/http/api/card/card-api.controller.spec.ts
+++ b/test/http/api/card/card-api.controller.spec.ts
@@ -240,6 +240,34 @@ describe('CardApiController', () => {
             expect(result.meta).toEqual({ page: 2, limit: 10, total: 42, totalPages: 5 });
         });
 
+        // The price-desc order is the endpoint's contract, so a caller must not be
+        // able to flip it. `ascend` is the sharp edge: SafeQueryOptions defaults it
+        // to true, so it has to be pinned false or the cheapest printing leads.
+        it('ignores caller sort/ascend and pins the price-desc order', async () => {
+            cardService.findBySetCodeAndNumber.mockResolvedValue(createCard());
+            cardService.findWithName.mockResolvedValue([createCard()]);
+            cardService.totalWithName.mockResolvedValue(1);
+
+            await controller.getPrintings('lea', '161', {
+                sort: 'card.name',
+                ascend: 'true',
+            });
+
+            const options = cardService.findWithName.mock.calls[0][1];
+            expect(options.sort).toBeUndefined();
+            expect(options.ascend).toBe(false);
+        });
+
+        it('pins the price-desc order when the query is empty too', async () => {
+            cardService.findBySetCodeAndNumber.mockResolvedValue(createCard());
+            cardService.findWithName.mockResolvedValue([createCard()]);
+            cardService.totalWithName.mockResolvedValue(1);
+
+            await controller.getPrintings('lea', '161', {});
+
+            expect(cardService.findWithName.mock.calls[0][1].ascend).toBe(false);
+        });
+
         // The addressed printing stays in the page so the total stays honest;
         // "other printings" is the caller's filter, not the API's.
         it('keeps the addressed printing in the results', async () => {

--- a/test/http/api/card/card-api.controller.spec.ts
+++ b/test/http/api/card/card-api.controller.spec.ts
@@ -55,6 +55,8 @@ describe('CardApiController', () => {
                         findByIdsWithPrices: jest.fn(),
                         findBySetCodeAndNumber: jest.fn(),
                         findPriceHistory: jest.fn(),
+                        findWithName: jest.fn(),
+                        totalWithName: jest.fn(),
                     },
                 },
                 {
@@ -214,6 +216,50 @@ describe('CardApiController', () => {
                 controller.getPriceHistoryBySetCodeAndNumber('lea', '999', '30')
             ).rejects.toBeInstanceOf(NotFoundException);
             expect(cardService.findPriceHistory).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getPrintings', () => {
+        it('pages every printing of the addressed card name', async () => {
+            cardService.findBySetCodeAndNumber.mockResolvedValue(createCard());
+            cardService.findWithName.mockResolvedValue([
+                createCard({ prices: [createPrice()] }),
+                createCard({ id: 'card-2', setCode: 'm10', number: '146' }),
+            ]);
+            cardService.totalWithName.mockResolvedValue(42);
+
+            const result = await controller.getPrintings('lea', '161', { page: '2', limit: '10' });
+
+            expect(cardService.findBySetCodeAndNumber).toHaveBeenCalledWith('lea', '161');
+            expect(cardService.findWithName).toHaveBeenCalledWith(
+                'Lightning Bolt',
+                expect.objectContaining({ page: 2, limit: 10 })
+            );
+            expect(cardService.totalWithName).toHaveBeenCalledWith('Lightning Bolt');
+            expect(result.data.map((c) => c.id)).toEqual(['card-1', 'card-2']);
+            expect(result.meta).toEqual({ page: 2, limit: 10, total: 42, totalPages: 5 });
+        });
+
+        // The addressed printing stays in the page so the total stays honest;
+        // "other printings" is the caller's filter, not the API's.
+        it('keeps the addressed printing in the results', async () => {
+            cardService.findBySetCodeAndNumber.mockResolvedValue(createCard());
+            cardService.findWithName.mockResolvedValue([createCard()]);
+            cardService.totalWithName.mockResolvedValue(1);
+
+            const result = await controller.getPrintings('lea', '161', {});
+
+            expect(result.data).toHaveLength(1);
+            expect(result.data[0].setCode).toBe('lea');
+        });
+
+        it('throws when the card cannot be found', async () => {
+            cardService.findBySetCodeAndNumber.mockResolvedValue(null);
+
+            await expect(controller.getPrintings('lea', '999', {})).rejects.toBeInstanceOf(
+                NotFoundException
+            );
+            expect(cardService.findWithName).not.toHaveBeenCalled();
         });
     });
 });

--- a/test/http/openapi-public-spec.spec.ts
+++ b/test/http/openapi-public-spec.spec.ts
@@ -20,6 +20,9 @@ function fakeDoc() {
             '/api/v1/cards/{setCode}/{setNumber}/price-history': {
                 get: { operationId: 'getCardPriceHistoryBySetAndNumber' },
             },
+            '/api/v1/cards/{setCode}/{setNumber}/printings': {
+                get: { operationId: 'getCardPrintings' },
+            },
             '/api/v1/sets': { get: { operationId: 'listSets' } },
             '/api/v1/sets/{code}': { get: { operationId: 'getSet' } },
             '/api/v1/sets/{code}/cards': { get: { operationId: 'getSetCards' } },

--- a/test/integration/api-cards.e2e-spec.ts
+++ b/test/integration/api-cards.e2e-spec.ts
@@ -359,4 +359,43 @@ describe('Cards API (e2e)', () => {
             expect(Array.isArray(res.body.data)).toBe(true);
         });
     });
+
+    describe('GET /api/v1/cards/:setCode/:setNumber/printings', () => {
+        // The seed has one printing per name, so these assert the contract and
+        // the routing - that the three-segment path resolves here and not to
+        // `:setCode/:setNumber`, which would 404 on a `printings` collector
+        // number.
+        it('returns the addressed printing with paging meta', async () => {
+            const res = await request(app.getHttpServer())
+                .get(`/api/v1/cards/${TEST_CARD_SET_CODE}/${TEST_CARD_NUMBER}/printings`)
+                .expect(200);
+
+            expect(res.body.success).toBe(true);
+            expect(res.body.data).toHaveLength(1);
+            expect(res.body.data[0]).toHaveProperty('id', TEST_CARD_ID);
+            // The set join is what lets a printings row name its set.
+            expect(res.body.data[0]).toHaveProperty('setName', 'Test Set');
+            expect(res.body.meta).toMatchObject({ page: 1, total: 1, totalPages: 1 });
+        });
+
+        it('honours page and limit', async () => {
+            const res = await request(app.getHttpServer())
+                .get(
+                    `/api/v1/cards/${TEST_CARD_SET_CODE}/${TEST_CARD_NUMBER}/printings?page=2&limit=1`
+                )
+                .expect(200);
+
+            expect(res.body.data).toEqual([]);
+            expect(res.body.meta).toMatchObject({ page: 2, limit: 1, total: 1 });
+        });
+
+        it('returns 404 for nonexistent card', async () => {
+            const res = await request(app.getHttpServer())
+                .get('/api/v1/cards/FAKE/999/printings')
+                .expect(404);
+
+            expect(res.body.success).toBe(false);
+            expect(res.body.error).toBeDefined();
+        });
+    });
 });

--- a/test/integration/mcp.e2e-spec.ts
+++ b/test/integration/mcp.e2e-spec.ts
@@ -79,7 +79,7 @@ describe('MCP endpoint (e2e)', () => {
     });
 
     describe('tools/list', () => {
-        it('returns the full 33-tool surface with snake_case names and descriptions', async () => {
+        it('returns the full 34-tool surface with snake_case names and descriptions', async () => {
             const res = await mcp({
                 jsonrpc: '2.0',
                 id: 1,
@@ -92,7 +92,7 @@ describe('MCP endpoint (e2e)', () => {
                 inputSchema: { type: string };
             }[];
 
-            expect(tools).toHaveLength(33);
+            expect(tools).toHaveLength(34);
             for (const tool of tools) {
                 expect(tool.name).toMatch(/^[a-z][a-z0-9_]*$/);
                 expect(typeof tool.description).toBe('string');

--- a/test/mcp/mcp-tools.spec.ts
+++ b/test/mcp/mcp-tools.spec.ts
@@ -34,6 +34,7 @@ const EXPECTED_NAMES = [
     'get_card',
     'get_card_prices',
     'get_card_price_history',
+    'get_card_printings',
     'search_sets',
     'get_set',
     'list_set_cards',
@@ -75,6 +76,7 @@ const READ_ONLY = new Set([
     'get_card',
     'get_card_prices',
     'get_card_price_history',
+    'get_card_printings',
     'search_sets',
     'get_set',
     'list_set_cards',
@@ -94,8 +96,8 @@ describe('McpToolRegistry', () => {
     const registry = buildRegistry();
     const tools = registry.list();
 
-    it('exposes exactly 33 tools in the documented order', () => {
-        expect(tools).toHaveLength(33);
+    it('exposes exactly 34 tools in the documented order', () => {
+        expect(tools).toHaveLength(34);
         expect(tools.map((t) => t.name)).toEqual(EXPECTED_NAMES);
     });
 


### PR DESCRIPTION
## Why

Mobile issue [matthewdtowles/i-want-my-mtg-mobile#108](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/108) wants an "other printings" section on the card page. Today the only name-wide endpoint is `GET /api/v1/cards?q=`, which is a **substring** match — `q=Shock` returns `Aftershock`, `Shellshock`, and `Barbed Shocker` before it reaches `Shock` (row 9 of 59), so a client cannot page an exact-name list. The web card page already has the right query (`findWithName` / `totalWithName`); it just was never exposed.

## What

**`GET /api/v1/cards/{setCode}/{setNumber}/printings`**

- Resolves the card by set code + collector number (404 if absent), then pages every printing that shares its name.
- Fixed price-desc order. Only `page` and `limit` are read off the query — `sort` and `ascend` are dropped so the order is the contract, not a default a caller can flip. `ascend` is pinned to `false` explicitly: `safeBoolean` defaults it to **true**, so passing the raw query through would have returned the *cheapest* printing first (caught in review, see the resolved threads).
- The addressed printing stays in the results so `meta.total` stays honest — filtering it out is the caller's job, which is what the web page does.
- `findWithName` now joins the set, so a printings row can name its set instead of only carrying the code. The web card page ignores the extra data.

**On the public (RapidAPI) surface.** Added to `PUBLIC_PATH_ALLOWLIST` and to the endpoint table in `RAPIDAPI.md` — it's read-only catalog data, the same family as `prices` and `price-history`.

**As an MCP tool.** `get_card_printings`, mirroring the controller through the same service + presenter. Its description steers clients away from `search_cards` for this job, for the substring reason above. Output schema registered; the registry contract test goes 33 → 34 tools.

## Notes

- Route is declared above `@Get(':setCode/:setNumber')` so Nest matches the three-segment path first.

## Test

- `npm test` — 1518 passed, 127 suites. `tsc --noEmit` and `eslint` clean on the touched files.
- New `getPrintings` cases: paging/meta, the addressed printing staying in the page, and 404 on an unknown card.
- `buildPublicSpec` still asserts the exposed paths equal the allowlist exactly, now including printings.
- New integration cases hit the route over real HTTP against the seeded database — paging meta, the joined `setName`, and the 404. Unit tests mock the service, so they could not have caught the likeliest failure here: the three-segment path resolving to `:setCode/:setNumber` instead.

## Downstream

Two consumers regenerate their typed clients from the live spec, so both wait on this deploying:

- `i-want-my-mtg-mobile` — the "Other printings" section (#108).
- `iwantmymtg-mcp` — the standalone server's `get_card_printings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUyhjVfD4qq42UuKpmFkD4

