### PR TITLE
feat(sets): art tiles like the mobile app, covered by each set's best card

### DIFF
--- a/src/database/card/card.repository.ts
+++ b/src/database/card/card.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Card } from 'src/core/card/card.entity';
 import { CardRepositoryPort } from 'src/core/card/ports/card.repository.port';
+import { PriceCalculationPolicy } from 'src/core/pricing/price-calculation.policy';
 import { SafeQueryOptions } from 'src/core/query/safe-query-options.dto';
 import { SET_CARD_SORTS, SortOptions } from 'src/core/query/sort-options.enum';
 import { latestPriceCondition } from 'src/database/query/latest-price.sql';
@@ -337,9 +338,14 @@ export class CardRepository implements CardRepositoryPort {
         if (setCodes.length === 0) return new Map();
         this.LOGGER.debug(`Finding cover images for ${setCodes.length} sets.`);
         // One query for the whole page of sets, not one per set. DISTINCT ON
-        // takes the first row per set under the ORDER BY, which is the same card
-        // `findBySet` returns first (default sort: sortNumber ascending) — so the
-        // cover matches the set's opening card.
+        // takes the first row per set under the ORDER BY, so the cover is the
+        // set's most valuable card (#628) — the chase card people recognize,
+        // rather than whatever happens to be numbered 001.
+        //
+        // Value is the same expression the rest of the app calls a card's value
+        // (normal, falling back to foil); cards with no price row COALESCE to 0
+        // and lose to any priced card. sortNumber breaks ties, which keeps the
+        // old behavior for a set that has no prices at all.
         //
         // Built through the query builder rather than raw SQL so the column names
         // come from the entity metadata. There is no `img_src` column to select:
@@ -348,10 +354,12 @@ export class CardRepository implements CardRepositoryPort {
         const rows = await this.repository
             .createQueryBuilder(this.TABLE)
             .select([`${this.TABLE}.setCode`, `${this.TABLE}.scryfallId`])
+            .leftJoin(`${this.TABLE}.prices`, 'p', latestPriceCondition('p', this.TABLE))
             .distinctOn([`${this.TABLE}.setCode`])
             .where(`${this.TABLE}.setCode IN (:...setCodes)`, { setCodes })
             .andWhere(`${this.TABLE}.scryfallId IS NOT NULL`)
             .orderBy(`${this.TABLE}.setCode`, 'ASC')
+            .addOrderBy(PriceCalculationPolicy.cardValueExpression(false), 'DESC')
             .addOrderBy(`${this.TABLE}.sortNumber`, 'ASC')
             .getMany();
         this.LOGGER.debug(`Found ${rows.length} cover images.`);

--- a/src/http/api/set/dto/set-response.dto.ts
+++ b/src/http/api/set/dto/set-response.dto.ts
@@ -44,9 +44,9 @@ export class SetApiResponseDto {
 
     @ApiPropertyOptional({
         description:
-            "Cover art tail for the set's opening card, in the same form as a card's `imgSrc`. " +
-            'Lets a client render set artwork from the list response instead of fetching a ' +
-            'card per set. Absent when the set has no card image.',
+            "Cover art tail for the set's most valuable card, in the same form as a card's " +
+            '`imgSrc`. Lets a client render set artwork from the list response instead of ' +
+            'fetching a card per set. Absent when the set has no card image.',
     })
     readonly coverImgSrc?: string;
 

--- a/src/http/hbs/home/home.controller.ts
+++ b/src/http/hbs/home/home.controller.ts
@@ -49,6 +49,9 @@ export class HomeController {
         );
         return Object.assign(setListView, {
             latestBlogPosts: allPosts.slice(0, HOME_BLOG_POSTS_LIMIT),
+            // Art tiles only here: home loads no list JS, so a toggle could only
+            // bounce the visitor to /sets.
+            showViewToggle: false,
         });
     }
 

--- a/src/http/hbs/list/sortable-header.view.ts
+++ b/src/http/hbs/list/sortable-header.view.ts
@@ -14,6 +14,10 @@ export class SortableHeaderView extends TableHeaderView {
     readonly href: string;
     readonly ascend?: boolean;
 
+    /** Whether the list is currently sorted by this column. Drives the chip row
+     *  in grid view, where there is no header to highlight. */
+    readonly active: boolean;
+
     constructor(
         options: SafeQueryOptions,
         sortOption: SortOptions,
@@ -21,7 +25,8 @@ export class SortableHeaderView extends TableHeaderView {
         subtitle?: string
     ) {
         super(SortOptionLabels[sortOption], classes, subtitle);
-        this.ascend = options.sort === sortOption ? !options.ascend : true;
+        this.active = options.sort === sortOption;
+        this.ascend = this.active ? !options.ascend : true;
         this.href = buildQueryString({ ...options, sort: sortOption, ascend: this.ascend });
     }
 }

--- a/src/http/hbs/set/dto/set-list.view.dto.ts
+++ b/src/http/hbs/set/dto/set-list.view.dto.ts
@@ -6,9 +6,27 @@ export class SetListViewDto extends ListView {
     readonly setList: SetMetaResponseDto[];
     readonly blockGroups: SetBlockGroup[];
 
+    /**
+     * Art tiles ('grid', the default) or the sortable table ('table'). Rendered
+     * server-side so the choice survives a hard load and works without JS;
+     * setListAjax.js keeps it in sync from `?view=` afterwards.
+     */
+    readonly view: 'grid' | 'table';
+    readonly isTableView: boolean;
+
+    /**
+     * Whether to offer the layout toggle. False on the home page, whose set list
+     * is a shop window rather than a browsing tool - and whose toggle would have
+     * to navigate to /sets to do anything, since home loads no list JS.
+     */
+    readonly showViewToggle: boolean;
+
     constructor(init: Partial<SetListViewDto>) {
         super(init);
         this.setList = init.setList || [];
         this.blockGroups = init.blockGroups || [];
+        this.view = init.view === 'table' ? 'table' : 'grid';
+        this.isTableView = this.view === 'table';
+        this.showViewToggle = init.showViewToggle ?? true;
     }
 }

--- a/src/http/hbs/set/dto/set-list.view.dto.ts
+++ b/src/http/hbs/set/dto/set-list.view.dto.ts
@@ -2,6 +2,16 @@ import { ListView } from 'src/http/hbs/list/list.view';
 import { SetBlockGroup } from './set-block-group.dto';
 import { SetMetaResponseDto } from './set-meta.response.dto';
 
+/**
+ * Where each layout button points. Only followed when the click is not
+ * intercepted - a middle-click, an open-in-new-tab, or JS off - so both hrefs
+ * carry the current filter, sort and paging rather than resetting the list.
+ */
+export interface SetViewToggleView {
+    readonly gridUrl: string;
+    readonly tableUrl: string;
+}
+
 export class SetListViewDto extends ListView {
     readonly setList: SetMetaResponseDto[];
     readonly blockGroups: SetBlockGroup[];
@@ -21,6 +31,8 @@ export class SetListViewDto extends ListView {
      */
     readonly showViewToggle: boolean;
 
+    readonly viewToggle: SetViewToggleView;
+
     constructor(init: Partial<SetListViewDto>) {
         super(init);
         this.setList = init.setList || [];
@@ -28,5 +40,6 @@ export class SetListViewDto extends ListView {
         this.view = init.view === 'table' ? 'table' : 'grid';
         this.isTableView = this.view === 'table';
         this.showViewToggle = init.showViewToggle ?? true;
+        this.viewToggle = init.viewToggle ?? { gridUrl: '/sets', tableUrl: '/sets?view=table' };
     }
 }

--- a/src/http/hbs/set/dto/set-meta.response.dto.ts
+++ b/src/http/hbs/set/dto/set-meta.response.dto.ts
@@ -4,8 +4,20 @@ import { BaseSetResponseDto } from './base-set.response.dto';
 export class SetMetaResponseDto extends BaseSetResponseDto {
     readonly isBlockChild: boolean;
 
+    /**
+     * Full art_crop URL of the set's most valuable card, the background of its
+     * tile in grid view. Undefined for a set whose cards have no images.
+     */
+    readonly coverImgSrc?: string;
+
+    /** Release year alone — the tile's subline reads "2024 · 261 cards". */
+    readonly releaseYear: string;
+
     constructor(init: Partial<SetMetaResponseDto>) {
         super(init);
         this.isBlockChild = init.isBlockChild ?? false;
+        this.coverImgSrc = init.coverImgSrc;
+        // `releaseDate` is a `date` column, so it is always 'YYYY-MM-DD'.
+        this.releaseYear = this.releaseDate.slice(0, 4);
     }
 }

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -18,7 +18,7 @@ import { Set } from 'src/core/set/set.entity';
 import { SetService } from 'src/core/set/set.service';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { Breadcrumb } from 'src/http/base/breadcrumb';
-import { completionRate, isAuthenticated, toDollar } from 'src/http/base/http.util';
+import { BASE_IMAGE_URL, completionRate, isAuthenticated, toDollar } from 'src/http/base/http.util';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { ImportResultDto } from 'src/http/hbs/import/import-result.dto';
@@ -131,6 +131,7 @@ export class SetOrchestrator {
             pagination: new PaginationView(options, baseUrl, currentCount),
             filter: new FilterView(options, baseUrl),
             tableHeadersRow: this.buildSetListTableHeaders(options, isAuthenticated(req)),
+            view: this.selectedView(req),
         });
     }
 
@@ -172,7 +173,17 @@ export class SetOrchestrator {
             pagination: new PaginationView(options, baseUrl, totalGroups),
             filter: new FilterView(options, baseUrl),
             tableHeadersRow: this.buildSetListTableHeaders(options, isAuthenticated(req)),
+            view: this.selectedView(req),
         });
+    }
+
+    /**
+     * Which set-list layout to render. Art tiles unless the visitor asked for
+     * the table with `?view=table` — the toggle writes that param, so a shared
+     * or reloaded URL comes back in the same layout.
+     */
+    private selectedView(req: AuthenticatedRequest): 'grid' | 'table' {
+        return req.query?.view === 'table' ? 'table' : 'grid';
     }
 
     async findSpoilersList(
@@ -530,19 +541,29 @@ export class SetOrchestrator {
         const setCodes = sets.map((s) => s.code);
         let totalsMap = new Map<string, number>();
         let valuesMap = new Map<string, number>();
+        let coverMap = new Map<string, string>();
 
+        // Covers are public, so they load for anonymous visitors too — one
+        // batched query for the whole page, the same call the API makes.
         if (userId) {
-            [totalsMap, valuesMap] = await Promise.all([
+            [coverMap, totalsMap, valuesMap] = await Promise.all([
+                this.cardService.coverImagesForSets(setCodes),
                 this.inventoryService.inventoryTotalsForSets(userId, setCodes),
                 this.inventoryService.ownedValuesForSets(userId, setCodes),
             ]);
+        } else {
+            coverMap = await this.cardService.coverImagesForSets(setCodes);
         }
 
         return sets.map((set) => {
             const ownedTotal = totalsMap.get(set.code) ?? 0;
             const ownedValue = valuesMap.get(set.code) ?? 0;
+            const cover = coverMap.get(set.code);
 
             return new SetMetaResponseDto({
+                coverImgSrc: cover
+                    ? `${BASE_IMAGE_URL}/${CardImgType.ART_CROP}/front/${cover}`
+                    : undefined,
                 baseSize: set.baseSize,
                 block: set.block ?? set.name,
                 code: set.code,

--- a/src/http/hbs/set/set.orchestrator.ts
+++ b/src/http/hbs/set/set.orchestrator.ts
@@ -18,7 +18,13 @@ import { Set } from 'src/core/set/set.entity';
 import { SetService } from 'src/core/set/set.service';
 import { AuthenticatedRequest } from 'src/http/base/authenticated.request';
 import { Breadcrumb } from 'src/http/base/breadcrumb';
-import { BASE_IMAGE_URL, completionRate, isAuthenticated, toDollar } from 'src/http/base/http.util';
+import {
+    BASE_IMAGE_URL,
+    buildQueryString,
+    completionRate,
+    isAuthenticated,
+    toDollar,
+} from 'src/http/base/http.util';
 import { CardPresenter } from 'src/http/hbs/card/card.presenter';
 import { HttpErrorHandler } from 'src/http/http.error.handler';
 import { ImportResultDto } from 'src/http/hbs/import/import-result.dto';
@@ -38,7 +44,7 @@ import {
     SetPriceHistoryPointDto,
     SetPriceHistoryResponseDto,
 } from './dto/set-price-history-response.dto';
-import { SetListViewDto } from './dto/set-list.view.dto';
+import { SetListViewDto, SetViewToggleView } from './dto/set-list.view.dto';
 import { SetMetaResponseDto } from './dto/set-meta.response.dto';
 import { SetPriceDto } from './dto/set-price.dto';
 import { SetPresenter } from './set.presenter';
@@ -132,6 +138,7 @@ export class SetOrchestrator {
             filter: new FilterView(options, baseUrl),
             tableHeadersRow: this.buildSetListTableHeaders(options, isAuthenticated(req)),
             view: this.selectedView(req),
+            viewToggle: this.buildViewToggle(options, baseUrl),
         });
     }
 
@@ -174,6 +181,7 @@ export class SetOrchestrator {
             filter: new FilterView(options, baseUrl),
             tableHeadersRow: this.buildSetListTableHeaders(options, isAuthenticated(req)),
             view: this.selectedView(req),
+            viewToggle: this.buildViewToggle(options, baseUrl),
         });
     }
 
@@ -184,6 +192,20 @@ export class SetOrchestrator {
      */
     private selectedView(req: AuthenticatedRequest): 'grid' | 'table' {
         return req.query?.view === 'table' ? 'table' : 'grid';
+    }
+
+    /**
+     * Hrefs for the two layout buttons. setListAjax.js intercepts the click, so
+     * these only get followed on a middle-click, an open-in-new-tab or with JS
+     * off - all cases where landing on an unfiltered page 1 would lose the
+     * visitor's place. Grid is the default layout, so it needs no `view` param.
+     */
+    private buildViewToggle(options: SafeQueryOptions, baseUrl: string): SetViewToggleView {
+        const query = buildQueryString(options);
+        return {
+            gridUrl: `${baseUrl}${query}`,
+            tableUrl: `${baseUrl}${query}${query ? '&' : '?'}view=table`,
+        };
     }
 
     async findSpoilersList(

--- a/src/http/public/css/tailwind.css
+++ b/src/http/public/css/tailwind.css
@@ -6049,6 +6049,373 @@ img,
   border-bottom: 1px solid rgba(192, 132, 252, 0.5);
 }
 
+/* ===== Sort Chips (grid view's stand-in for table headers) ===== */
+
+:where(.sort-chips, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+.sort-chips {
+  margin-bottom: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+:where(.flex,.sort-chip, .grid) > * {
+  min-width: 0;
+}
+
+.sort-chip {
+  display: inline-flex;
+  cursor: pointer;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255 / var(--tw-bg-opacity, 1));
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .sort-chip:hover {
+    --tw-border-opacity: 1;
+    border-color: rgb(69 221 214 / var(--tw-border-opacity, 1));
+    --tw-text-opacity: 1;
+    color: rgb(26 122 120 / var(--tw-text-opacity, 1));
+  }
+}
+
+.sort-chip:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(46 39 88 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(26 21 51 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .sort-chip:hover:is(.dark *) {
+    --tw-border-opacity: 1;
+    border-color: rgb(44 200 202 / var(--tw-border-opacity, 1));
+    --tw-text-opacity: 1;
+    color: rgb(69 221 214 / var(--tw-text-opacity, 1));
+  }
+}
+
+.sort-chip-active {
+  --tw-border-opacity: 1;
+  border-color: rgb(32 153 143 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(26 122 120 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .sort-chip-active:hover {
+    --tw-border-opacity: 1;
+    border-color: rgb(32 153 143 / var(--tw-border-opacity, 1));
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  }
+}
+
+.sort-chip-active:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(44 200 202 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(44 200 202 / var(--tw-bg-opacity, 1));
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .sort-chip-active:hover:is(.dark *) {
+    --tw-text-opacity: 1;
+    color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  }
+}
+
+/* ===== Set Grid (art tiles) ===== */
+
+:where(.flex, .inline-flex,.set-grid) > * {
+  min-width: 0;
+}
+
+.set-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .set-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1280px) {
+  .set-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+/* Full-width so a block name always starts its own row. */
+
+.set-grid-label {
+  grid-column: 1 / -1;
+  margin-top: 0.5rem;
+  font-size: 0.6rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  --tw-text-opacity: 1;
+  color: rgb(114 51 164 / var(--tw-text-opacity, 1));
+}
+
+.set-grid-label:first-child {
+  margin-top: 0px;
+}
+
+.set-grid-label:is(.dark *) {
+  --tw-text-opacity: 1;
+  color: rgb(219 181 245 / var(--tw-text-opacity, 1));
+}
+
+.set-grid-label {
+  text-shadow: 0 0 6px rgba(168, 85, 247, 0.5), 0 0 12px rgba(168, 85, 247, 0.25);
+}
+
+.dark .set-grid-label {
+  text-shadow: 0 0 8px rgba(192, 132, 252, 0.6), 0 0 20px rgba(168, 85, 247, 0.35), 0 0 30px rgba(168, 85, 247, 0.15);
+}
+
+/* Same proportions as the mobile app's hero tile. */
+
+.set-tile {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  border-width: 1px;
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(229 231 235 / var(--tw-bg-opacity, 1));
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .set-tile:hover {
+    --tw-border-opacity: 1;
+    border-color: rgb(69 221 214 / var(--tw-border-opacity, 1));
+  }
+}
+
+.set-tile:is(.dark *) {
+  --tw-border-opacity: 1;
+  border-color: rgb(36 30 69 / var(--tw-border-opacity, 1));
+  --tw-bg-opacity: 1;
+  background-color: rgb(36 30 69 / var(--tw-bg-opacity, 1));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .set-tile:hover:is(.dark *) {
+    --tw-border-opacity: 1;
+    border-color: rgb(44 200 202 / var(--tw-border-opacity, 1));
+  }
+}
+
+.set-tile {
+  aspect-ratio: 1.9;
+}
+
+.set-tile-art {
+  position: absolute;
+  inset: 0px;
+  height: 100%;
+  width: 100%;
+  -o-object-fit: cover;
+     object-fit: cover;
+  transition-property: transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 300ms;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .group:hover .set-tile-art {
+    --tw-scale-x: 1.05;
+    --tw-scale-y: 1.05;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+}
+
+:where(.set-tile-scrim, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+.set-tile-scrim {
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-image: linear-gradient(to top, var(--tw-gradient-stops));
+  --tw-gradient-from: rgb(0 0 0 / 0.85) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(0 0 0 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+  --tw-gradient-to: rgb(0 0 0 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), rgb(0 0 0 / 0.6) var(--tw-gradient-via-position), var(--tw-gradient-to);
+  --tw-gradient-to: transparent var(--tw-gradient-to-position);
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 2.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.set-tile-symbol {
+  flex-shrink: 0;
+  font-size: 1.5rem;
+  line-height: 2rem;
+  color: rgb(255 255 255 / 0.9);
+  --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.set-tile-body {
+  min-width: 0px;
+  flex: 1 1 0%;
+}
+
+.set-tile-name {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  font-weight: 600;
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.set-tile-sub {
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  color: rgb(255 255 255 / 0.75);
+}
+
+.set-tile-price {
+  flex-shrink: 0;
+  text-align: right;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+  --tw-drop-shadow: drop-shadow(0 1px 2px rgb(0 0 0 / 0.1)) drop-shadow(0 1px 1px rgb(0 0 0 / 0.06));
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+/* The scrim is dark in both themes, so these are lighter than .price-change. */
+
+.set-tile-change {
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+}
+
+.set-tile-change-positive {
+  --tw-text-opacity: 1;
+  color: rgb(110 231 183 / var(--tw-text-opacity, 1));
+}
+
+.set-tile-change-negative {
+  --tw-text-opacity: 1;
+  color: rgb(253 164 175 / var(--tw-text-opacity, 1));
+}
+
+.set-tile-change-neutral {
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity, 1));
+}
+
+.set-tile-owned {
+  position: absolute;
+  right: 0.5rem;
+  top: 0.5rem;
+  border-radius: 9999px;
+  background-color: rgb(0 0 0 / 0.65);
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity, 1));
+}
+
+:where(.set-tile-tags, .inline-flex, .grid) > * {
+  min-width: 0;
+}
+
+.set-tile-tags {
+  position: absolute;
+  left: 0.5rem;
+  top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.125rem;
+}
+
+.set-tile-progress {
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  display: block;
+  height: 0.25rem;
+  background-color: rgb(0 0 0 / 0.4);
+}
+
+.set-tile-progress-fill {
+  display: block;
+  height: 100%;
+  --tw-bg-opacity: 1;
+  background-color: rgb(69 221 214 / var(--tw-bg-opacity, 1));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .set-tile-art {
+    transition: none;
+  }
+}
+
 /* ===== Tags ===== */
 
 .tag {

--- a/src/http/public/js/ajaxUtils.js
+++ b/src/http/public/js/ajaxUtils.js
@@ -5,6 +5,10 @@
 var AjaxUtils = (function () {
     var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
 
+    // Layouts a page can ask for by `?view=`. 'grid' is the set list's default,
+    // so it is written into state but kept out of the URL.
+    var NAMED_VIEWS = ['binder', 'grid', 'table'];
+
     function smoothScroll(el, block) {
         el.scrollIntoView({
             behavior: prefersReducedMotion.matches ? 'auto' : 'smooth',
@@ -440,8 +444,12 @@ var AjaxUtils = (function () {
      * @param {object} opts.state - State object with .view, .page
      * @param {function} opts.fetchFn - Function to call: fetchFn(historyMethod)
      * @param {function} [opts.onToggle] - Called after state.view changes with new view value
+     * @param {string} [opts.storageKey] - localStorage key for the remembered view.
+     *   Defaults to the set page's key; pass your own so two toggles don't overwrite
+     *   each other's preference.
      */
     function setupViewToggleInterceptor(opts) {
+        var storageKey = opts.storageKey || 'setViewPreference';
         opts.container.addEventListener('click', function (e) {
             var btn = e.target.closest('.view-toggle-btn');
             if (!btn) return;
@@ -450,7 +458,7 @@ var AjaxUtils = (function () {
             if (!newView || newView === opts.state.view) return;
             opts.state.view = newView;
             opts.state.page = 1;
-            localStorage.setItem('setViewPreference', newView);
+            localStorage.setItem(storageKey, newView);
             if (opts.onToggle) opts.onToggle(newView);
             opts.fetchFn('pushState');
         });
@@ -485,7 +493,9 @@ var AjaxUtils = (function () {
             ascend: params.get('ascend') === 'true',
             filter: params.get('filter') || '',
             baseOnly: params.has('baseOnly') ? params.get('baseOnly') !== 'false' : true,
-            view: params.get('view') === 'binder' ? 'binder' : 'list',
+            // 'binder' belongs to the set page, 'grid'/'table' to the set list.
+            // Anything else is the plain list every other page renders.
+            view: NAMED_VIEWS.indexOf(params.get('view')) !== -1 ? params.get('view') : 'list',
         };
         if (extraKeys) {
             for (var i = 0; i < extraKeys.length; i++) {
@@ -528,7 +538,9 @@ var AjaxUtils = (function () {
         }
         if (state.filter) params.set('filter', state.filter);
         if (state.baseOnly === false) params.set('baseOnly', 'false');
-        if (state.view && state.view !== 'list') params.set('view', state.view);
+        if (state.view && state.view !== 'list' && state.view !== 'grid') {
+            params.set('view', state.view);
+        }
         var qs = params.toString();
         return basePath + (qs ? '?' + qs : '');
     }
@@ -955,8 +967,10 @@ var AjaxUtils = (function () {
             setupFilterInterceptor({ state: state, fetchFn: fetchAndRender });
         }
 
+        // Any sort control inside the container, not just table headers: the set
+        // grid sorts through a chip row instead of a <thead>.
         setupSortInterceptor({
-            selector: '#' + containerId + ' thead a.sort-btn',
+            selector: '#' + containerId + ' a.sort-btn',
             state: state,
             fetchFn: fetchAndRender,
         });

--- a/src/http/public/js/setListAjax.js
+++ b/src/http/public/js/setListAjax.js
@@ -3,12 +3,13 @@ document.addEventListener('DOMContentLoaded', function () {
     if (!container) return;
 
     var authenticated = container.dataset.authenticated === 'true';
+    var ART_CROP_BASE = 'https://cards.scryfall.io/art_crop/front/';
 
     var page = AjaxUtils.initListPage({
         container: container,
         apiPath: '/api/v1/sets',
         basePath: '/sets',
-        renderContent: renderTable,
+        renderContent: renderList,
         errorMessage: 'Failed to load sets',
         extraApiParams: function (state) {
             return state.sort ? '' : 'group=block';
@@ -16,15 +17,179 @@ document.addEventListener('DOMContentLoaded', function () {
     });
     if (!page) return;
 
-    function renderTable(resultsEl, sets, meta) {
+    // Art tiles unless the visitor asked for the table. Anything else - including
+    // the 'list' the URL parser falls back to - is the grid.
+    function isTableView() {
+        return page.state.view === 'table';
+    }
+
+    var toggleContainer = document.getElementById('set-view-toggle');
+    if (toggleContainer) {
+        AjaxUtils.setupViewToggleInterceptor({
+            container: toggleContainer,
+            state: page.state,
+            fetchFn: page.fetchAndRender,
+            // Distinct from the set page's list/binder toggle, which would
+            // otherwise overwrite this preference.
+            storageKey: 'setListViewPreference',
+        });
+    }
+
+    function renderList(resultsEl, sets, meta) {
         if (!sets || sets.length === 0) {
             AjaxUtils.renderEmptyState(resultsEl, {
                 message: 'No sets match your search',
                 clearHref: '/sets',
             });
+            syncToggle();
             return;
         }
 
+        if (isTableView()) {
+            renderTable(resultsEl, sets, meta);
+        } else {
+            renderGrid(resultsEl, sets, meta);
+        }
+        syncToggle();
+    }
+
+    function syncToggle() {
+        if (toggleContainer) {
+            AjaxUtils.updateViewToggle(toggleContainer, isTableView() ? 'table' : 'grid');
+        }
+    }
+
+    /** Groups the page the same way the table does, so both layouts agree. */
+    function groupsFor(sets, meta) {
+        if (!meta || !meta.multiSetBlockKeys) return null;
+        var multiSetKeys = {};
+        for (var m = 0; m < meta.multiSetBlockKeys.length; m++) {
+            multiSetKeys[meta.multiSetBlockKeys[m]] = true;
+        }
+        return SetListUtils.groupByBlock(sets, multiSetKeys);
+    }
+
+    /* ===== Grid view - mirrors partials/setGrid.hbs + partials/setTile.hbs ===== */
+
+    // Same sorts the table offers as column headers, minus the static ones.
+    var SORT_CHIPS = [
+        { key: 'set.name', label: 'Set' },
+        { key: 'setPrice.basePrice', label: 'Set Value' },
+        { key: 'set.releaseDate', label: 'Release Date' },
+    ];
+
+    /**
+     * Sort controls for the grid - mirrors partials/sortChips.hbs. Rendered with
+     * the results because the AJAX re-render replaces the whole container, and
+     * carries `sort-btn` so the shared sort interceptor picks the clicks up.
+     */
+    function renderSortChips() {
+        var state = page.state;
+        var html = '<div class="sort-chips" role="group" aria-label="Sort sets">';
+        for (var i = 0; i < SORT_CHIPS.length; i++) {
+            var chip = SORT_CHIPS[i];
+            var isActive = state.sort === chip.key;
+            // The arrow shows the direction the next click applies, matching the
+            // server-rendered chips and the table headers.
+            var nextAscend = isActive ? !state.ascend : true;
+            var params = new URLSearchParams();
+            params.set('page', '1');
+            params.set('limit', String(state.limit));
+            params.set('sort', chip.key);
+            params.set('ascend', String(nextAscend));
+            if (state.filter) params.set('filter', state.filter);
+            if (state.baseOnly === false) params.set('baseOnly', 'false');
+
+            html += '<a href="?' + params.toString() + '" class="sort-chip sort-btn';
+            html += isActive ? ' sort-chip-active">' : '">';
+            html += AjaxUtils.escapeHtml(chip.label);
+            if (isActive) {
+                html +=
+                    ' <span class="sort-icon">' + (nextAscend ? '&#9650;' : '&#9660;') + '</span>';
+            }
+            html += '</a>';
+        }
+        return html + '</div>';
+    }
+
+    function renderGrid(resultsEl, sets, meta) {
+        var html = renderSortChips() + '<div class="set-grid">';
+        var groups = groupsFor(sets, meta);
+
+        if (groups) {
+            for (var g = 0; g < groups.length; g++) {
+                if (groups[g].isMultiSet) {
+                    html +=
+                        '<h3 class="set-grid-label">' +
+                        AjaxUtils.escapeHtml(groups[g].blockName) +
+                        '</h3>';
+                }
+                for (var s = 0; s < groups[g].sets.length; s++) {
+                    html += renderSetTile(groups[g].sets[s]);
+                }
+            }
+        } else {
+            for (var i = 0; i < sets.length; i++) {
+                html += renderSetTile(sets[i]);
+            }
+        }
+
+        html += '</div>';
+        resultsEl.innerHTML = html;
+    }
+
+    function renderSetTile(set) {
+        var url = '/sets/' + encodeURIComponent(set.code.toLowerCase());
+        var name = AjaxUtils.escapeHtml(set.name);
+        var keyruneCode = AjaxUtils.escapeHtml(set.keyruneCode || set.code);
+        var cardCount = set.baseSize || set.totalSize || 0;
+        var year = (set.releaseDate || '').slice(0, 4);
+
+        var html = '<a href="' + url + '" class="set-tile group">';
+        if (set.coverImgSrc) {
+            html +=
+                '<img src="' +
+                ART_CROP_BASE +
+                AjaxUtils.escapeHtml(set.coverImgSrc) +
+                '" alt="" aria-hidden="true" loading="lazy" decoding="async" ' +
+                'width="626" height="457" class="set-tile-art" />';
+        }
+        if (set.tags && set.tags.length) {
+            html += '<span class="set-tile-tags">' + AjaxUtils.renderTags(set.tags) + '</span>';
+        }
+        if (authenticated && set.ownedTotal) {
+            html +=
+                '<span class="set-tile-owned">' +
+                AjaxUtils.toDollar(set.ownedValue) +
+                ' owned</span>';
+        }
+
+        html += '<span class="set-tile-scrim">';
+        html += '<i class="ss ss-' + keyruneCode + ' set-tile-symbol" aria-hidden="true"></i>';
+        html += '<span class="set-tile-body">';
+        html += '<span class="set-tile-name">' + name + '</span>';
+        html += '<span class="set-tile-sub">' + year + ' &middot; ' + cardCount + ' cards</span>';
+        html += '</span>';
+        html += '<span class="set-tile-price">' + formatPrice(set.prices);
+        html += formatTileChange(set.prices);
+        html += '</span>';
+        html += '</span>';
+
+        if (AjaxUtils.isSubscribed() && set.completionRate) {
+            html +=
+                '<span class="set-tile-progress" aria-hidden="true">' +
+                '<span class="set-tile-progress-fill" style="width: ' +
+                Number(set.completionRate) +
+                '%"></span></span>';
+        }
+
+        html += '</a>';
+        return html;
+    }
+
+    /* ===== Table view - mirrors the table branch of partials/setList.hbs ===== */
+
+    function renderTable(resultsEl, sets, meta) {
         var headers = [
             { key: 'set.name', label: 'Set' },
             { key: 'setPrice.basePrice', label: 'Set Value', subtitle: '7d', classes: 'xxs-hide' },
@@ -38,12 +203,8 @@ document.addEventListener('DOMContentLoaded', function () {
         html += '<thead>' + AjaxUtils.renderTableHeaderRow(headers, page.state) + '</thead>';
         html += '<tbody>';
 
-        if (meta && meta.multiSetBlockKeys) {
-            var multiSetKeys = {};
-            for (var m = 0; m < meta.multiSetBlockKeys.length; m++) {
-                multiSetKeys[meta.multiSetBlockKeys[m]] = true;
-            }
-            var groups = SetListUtils.groupByBlock(sets, multiSetKeys);
+        var groups = groupsFor(sets, meta);
+        if (groups) {
             for (var g = 0; g < groups.length; g++) {
                 var group = groups[g];
                 if (group.isMultiSet) {
@@ -119,11 +280,35 @@ document.addEventListener('DOMContentLoaded', function () {
         return AjaxUtils.toDollar(val);
     }
 
-    function formatWeeklyChange(prices) {
-        if (!prices) return '';
+    function weeklyChange(prices) {
+        if (!prices) return null;
         var change = prices.basePriceChangeWeekly;
         if (change == null || change === 0) change = prices.totalPriceChangeWeekly;
-        if (change == null || change === 0) return '';
-        return AjaxUtils.renderPriceChange(change);
+        return change == null || change === 0 ? null : change;
+    }
+
+    function formatWeeklyChange(prices) {
+        var change = weeklyChange(prices);
+        return change == null ? '' : AjaxUtils.renderPriceChange(change);
+    }
+
+    /**
+     * The tile's badge sits on a dark scrim, so it uses the lighter
+     * `set-tile-change-*` colors instead of the table's `price-change-*`.
+     */
+    function formatTileChange(prices) {
+        var change = weeklyChange(prices);
+        if (change == null) return '';
+        var abs = AjaxUtils.toDollar(Math.abs(Math.round(change * 100) / 100));
+        var sign = change > 0 ? '+' : '-';
+        var direction = change > 0 ? 'positive' : 'negative';
+        return (
+            '<span class="set-tile-change set-tile-change-' +
+            direction +
+            '">' +
+            sign +
+            abs +
+            '</span>'
+        );
     }
 });

--- a/src/http/styles/tailwind.css
+++ b/src/http/styles/tailwind.css
@@ -1220,6 +1220,123 @@
     border-bottom: 1px solid rgba(192, 132, 252, 0.5);
 }
 
+/* ===== Sort Chips (grid view's stand-in for table headers) ===== */
+
+.sort-chips {
+    @apply mb-3 flex flex-wrap items-center gap-2;
+}
+
+.sort-chip {
+    @apply inline-flex items-center gap-1 rounded-full border px-3 py-1 text-xs font-medium
+           border-gray-300 bg-white text-gray-600
+           hover:border-teal-400 hover:text-teal-700
+           dark:border-midnight-600 dark:bg-midnight-800 dark:text-gray-300
+           dark:hover:border-teal-500 dark:hover:text-teal-400
+           transition-colors cursor-pointer;
+}
+
+.sort-chip-active {
+    @apply border-teal-600 bg-teal-700 text-white
+           hover:border-teal-600 hover:text-white
+           dark:border-teal-500 dark:bg-teal-500 dark:text-white dark:hover:text-white;
+}
+
+/* ===== Set Grid (art tiles) ===== */
+
+.set-grid {
+    @apply grid gap-3 sm:grid-cols-2 xl:grid-cols-3;
+}
+
+/* Full-width so a block name always starts its own row. */
+.set-grid-label {
+    @apply col-span-full mt-2 first:mt-0 text-[0.6rem] font-semibold uppercase tracking-widest
+           text-purple-700 dark:text-purple-300;
+    text-shadow: 0 0 6px rgba(168, 85, 247, 0.5), 0 0 12px rgba(168, 85, 247, 0.25);
+}
+
+.dark .set-grid-label {
+    text-shadow: 0 0 8px rgba(192, 132, 252, 0.6), 0 0 20px rgba(168, 85, 247, 0.35), 0 0 30px rgba(168, 85, 247, 0.15);
+}
+
+/* Same proportions as the mobile app's hero tile. */
+.set-tile {
+    @apply relative block overflow-hidden rounded-xl
+           bg-gray-200 dark:bg-midnight-700
+           border border-gray-200 dark:border-midnight-700
+           hover:border-teal-400 dark:hover:border-teal-500 transition-colors;
+    aspect-ratio: 1.9;
+}
+
+.set-tile-art {
+    @apply absolute inset-0 h-full w-full object-cover
+           transition-transform duration-300 group-hover:scale-105;
+}
+
+.set-tile-scrim {
+    @apply absolute inset-x-0 bottom-0 flex items-center gap-2 px-3 pt-10 pb-2
+           bg-gradient-to-t from-black/85 via-black/60 to-transparent;
+}
+
+.set-tile-symbol {
+    @apply shrink-0 text-2xl text-white/90 drop-shadow;
+}
+
+.set-tile-body {
+    @apply min-w-0 flex-1;
+}
+
+.set-tile-name {
+    @apply block truncate font-display font-semibold text-white drop-shadow;
+}
+
+.set-tile-sub {
+    @apply block text-xs text-white/75;
+}
+
+.set-tile-price {
+    @apply shrink-0 text-right font-mono text-sm text-white drop-shadow;
+}
+
+/* The scrim is dark in both themes, so these are lighter than .price-change. */
+.set-tile-change {
+    @apply block text-xs font-medium;
+}
+
+.set-tile-change-positive {
+    @apply text-emerald-300;
+}
+
+.set-tile-change-negative {
+    @apply text-rose-300;
+}
+
+.set-tile-change-neutral {
+    @apply text-gray-300;
+}
+
+.set-tile-owned {
+    @apply absolute right-2 top-2 rounded-full bg-black/65 px-2 py-0.5
+           text-xs font-medium text-white;
+}
+
+.set-tile-tags {
+    @apply absolute left-2 top-2 flex flex-wrap gap-0.5;
+}
+
+.set-tile-progress {
+    @apply absolute inset-x-0 bottom-0 block h-1 bg-black/40;
+}
+
+.set-tile-progress-fill {
+    @apply block h-full bg-teal-400;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .set-tile-art {
+        transition: none;
+    }
+}
+
 /* ===== Tags ===== */
 
 .tag {

--- a/src/http/views/partials/setGrid.hbs
+++ b/src/http/views/partials/setGrid.hbs
@@ -1,0 +1,18 @@
+{{~!--
+  Grid of set art tiles - the default view of every set list. One continuous
+  grid: block names span the full width and so start a new row, which keeps a
+  block's sets together without breaking the column rhythm.
+
+  Parameters:
+    blockGroups - array of { blockName, isMultiSet, sets: array }
+--~}}
+<div class="set-grid">
+    {{#each blockGroups}}
+        {{#if this.isMultiSet}}
+            <h3 class="set-grid-label">{{this.blockName}}</h3>
+        {{/if}}
+        {{#each this.sets}}
+            {{>setTile}}
+        {{/each}}
+    {{/each}}
+</div>

--- a/src/http/views/partials/setList.hbs
+++ b/src/http/views/partials/setList.hbs
@@ -1,11 +1,17 @@
 {{~!--
-  Set list page content - filter, base-only toggle, and block-grouped set table.
+  Set list page content - filter, base-only toggle, grid/table view toggle, and
+  the block-grouped set list itself.
+
+  Two layouts share this partial: art tiles (default, mirrors the mobile app)
+  and the sortable table. `isTableView` picks one; setListAjax.js renders the
+  matching layout for AJAX-loaded pages.
 
   Parameters:
     filter          - filter partial params (baseUrl, searchTerm, etc.)
     baseOnlyToggle  - { visible, url, isBaseOnly, text }
     blockGroups     - array of { blockName, isMultiSet, sets: array }
     authenticated   - boolean, controls owned-column visibility
+    isTableView     - boolean, false renders the art-tile grid
     assetVersion    - cache-busting version
 --~}}
 <div class="content-wrapper">
@@ -21,9 +27,29 @@
             {{baseOnlyToggle.text}}
         </a>
         {{/if}}
+        {{#if showViewToggle}}
+        <div class="flex items-center gap-1 flex-shrink-0 mb-4" id="set-view-toggle">
+            <a href="{{filter.baseUrl}}" class="view-toggle-btn {{#if isTableView}}view-toggle-inactive{{else}}view-toggle-active{{/if}}"
+               data-view="grid" aria-label="Grid view">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <rect x="3" y="4" width="8" height="7" rx="1" />
+                    <rect x="13" y="4" width="8" height="7" rx="1" />
+                    <rect x="3" y="13" width="8" height="7" rx="1" />
+                    <rect x="13" y="13" width="8" height="7" rx="1" />
+                </svg>
+            </a>
+            <a href="{{filter.baseUrl}}?view=table" class="view-toggle-btn {{#if isTableView}}view-toggle-active{{else}}view-toggle-inactive{{/if}}"
+               data-view="table" aria-label="Table view">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+            </a>
+        </div>
+        {{/if}}
     </div>
     <div id="filter-results">
         {{#if blockGroups.length}}
+        {{#if isTableView}}
         <div class="table-wrapper">
         <table class="min-w-full table-container">
             <thead>{{>tableHeadersRow}}</thead>
@@ -60,6 +86,10 @@
             </tbody>
         </table>
         </div>
+        {{else}}
+        {{>sortChips}}
+        {{>setGrid}}
+        {{/if}}
         {{else}}
         {{>emptyState icon="search" message="No sets match your search" hint="Try a different search term or clear your filter." buttonHref="/sets" buttonText="Show All Sets"}}
         {{/if}}

--- a/src/http/views/partials/setList.hbs
+++ b/src/http/views/partials/setList.hbs
@@ -12,6 +12,7 @@
     blockGroups     - array of { blockName, isMultiSet, sets: array }
     authenticated   - boolean, controls owned-column visibility
     isTableView     - boolean, false renders the art-tile grid
+    viewToggle      - { gridUrl, tableUrl } hrefs that keep the current list state
     assetVersion    - cache-busting version
 --~}}
 <div class="content-wrapper">
@@ -29,7 +30,7 @@
         {{/if}}
         {{#if showViewToggle}}
         <div class="flex items-center gap-1 flex-shrink-0 mb-4" id="set-view-toggle">
-            <a href="{{filter.baseUrl}}" class="view-toggle-btn {{#if isTableView}}view-toggle-inactive{{else}}view-toggle-active{{/if}}"
+            <a href="{{viewToggle.gridUrl}}" class="view-toggle-btn {{#if isTableView}}view-toggle-inactive{{else}}view-toggle-active{{/if}}"
                data-view="grid" aria-label="Grid view">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                     <rect x="3" y="4" width="8" height="7" rx="1" />
@@ -38,7 +39,7 @@
                     <rect x="13" y="13" width="8" height="7" rx="1" />
                 </svg>
             </a>
-            <a href="{{filter.baseUrl}}?view=table" class="view-toggle-btn {{#if isTableView}}view-toggle-active{{else}}view-toggle-inactive{{/if}}"
+            <a href="{{viewToggle.tableUrl}}" class="view-toggle-btn {{#if isTableView}}view-toggle-active{{else}}view-toggle-inactive{{/if}}"
                data-view="table" aria-label="Table view">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />

--- a/src/http/views/partials/setTile.hbs
+++ b/src/http/views/partials/setTile.hbs
@@ -1,0 +1,45 @@
+{{~!--
+  One set as an art tile: the art crop of the set's most valuable card as the
+  background, with the expansion symbol, name and set value over a bottom scrim.
+  Mirrors the mobile app's SetTile (i-want-my-mtg-mobile/components/SetTile.tsx).
+
+  The art is decorative - the set name sits right beside it - so it carries an
+  empty alt.
+
+  Parameters: a SetMetaResponseDto (url, name, keyruneCode, coverImgSrc,
+  releaseYear, effectiveSize, prices, ownedValue, ownedTotal, completionRate,
+  tags). setListAjax.js mirrors this markup for AJAX-loaded pages - keep the two
+  in sync.
+--~}}
+<a href="{{url}}" class="set-tile group">
+    {{#if coverImgSrc}}
+        <img src="{{coverImgSrc}}" alt="" aria-hidden="true" loading="lazy" decoding="async"
+            width="626" height="457" class="set-tile-art" />
+    {{/if}}
+    {{#if tags.length}}
+        <span class="set-tile-tags">{{>tags item=this}}</span>
+    {{/if}}
+    {{#if @root.authenticated}}{{#if ownedTotal}}
+        <span class="set-tile-owned">{{ownedValue}} owned</span>
+    {{/if}}{{/if}}
+    <span class="set-tile-scrim">
+        <i class="ss ss-{{keyruneCode}} set-tile-symbol" aria-hidden="true"></i>
+        <span class="set-tile-body">
+            <span class="set-tile-name">{{name}}</span>
+            <span class="set-tile-sub">{{releaseYear}} &middot; {{effectiveSize}} cards</span>
+        </span>
+        <span class="set-tile-price">
+            {{prices.defaultPrice}}
+            {{#if prices.defaultPriceChangeWeekly}}
+                <span class="set-tile-change set-tile-change-{{prices.defaultPriceChangeWeeklySign}}">{{prices.defaultPriceChangeWeekly}}</span>
+            {{/if}}
+        </span>
+    </span>
+    {{~!-- Completion is a Premium view everywhere else, so the tile only draws
+           the bar for subscribers rather than putting a lock over the art. --~}}
+    {{#if @root.subscribed}}{{#if completionRate}}
+        <span class="set-tile-progress" aria-hidden="true">
+            <span class="set-tile-progress-fill" style="width: {{completionRate}}%"></span>
+        </span>
+    {{/if}}{{/if}}
+</a>

--- a/src/http/views/partials/sortChips.hbs
+++ b/src/http/views/partials/sortChips.hbs
@@ -1,0 +1,25 @@
+{{~!--
+  Sort controls for a list with no table headers to click - the set grid. Built
+  from the same TableHeadersRowView the table renders, so both layouts offer and
+  highlight exactly the same sorts. Static headers (no href) are skipped.
+
+  Carries `sort-btn` so the AJAX sort interceptor picks these up like a header.
+
+  Parameters:
+    tableHeadersRow.headers - array of { text, href?, active?, ascend? }
+--~}}
+<div class="sort-chips" role="group" aria-label="Sort sets">
+    {{#each tableHeadersRow.headers as |header|}}
+    {{#if header.href}}
+    <a href="{{header.href}}" class="sort-chip sort-btn{{#if header.active}} sort-chip-active{{/if}}">
+        {{header.text}}
+        {{#if header.active}}
+        {{~!-- Same arrow the table header shows: the direction the next click applies. --~}}
+        <span class="sort-icon">
+            {{#if header.ascend}}{{>uparrow}}{{else}}{{>downarrow}}{{/if}}
+        </span>
+        {{/if}}
+    </a>
+    {{/if}}
+    {{/each}}
+</div>

--- a/test/e2e/authenticated.e2e.ts
+++ b/test/e2e/authenticated.e2e.ts
@@ -3,7 +3,7 @@ import { test, expect } from './fixtures/auth.fixture';
 test.describe('Set detail (authenticated)', () => {
     test('shows collection action card', async ({ authedPage: page }) => {
         await page.goto('/sets');
-        const setHref = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const setHref = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         await page.goto(setHref);
         await expect(page.locator('h1')).toBeVisible();
         // Authenticated users see the "Add All Cards" form
@@ -13,7 +13,7 @@ test.describe('Set detail (authenticated)', () => {
 
     test('shows My Binder link', async ({ authedPage: page }) => {
         await page.goto('/sets');
-        const setHref = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const setHref = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         const setCode = setHref.split('/').pop()!;
         await page.goto(setHref);
         await expect(page.locator(`a[href="/inventory/sets/${setCode}"]`)).toBeVisible();
@@ -48,7 +48,7 @@ test.describe('Inventory page (authenticated)', () => {
 test.describe('Inventory binder (authenticated)', () => {
     test('renders binder for first set', async ({ authedPage: page }) => {
         await page.goto('/sets');
-        const setHref = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const setHref = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         const setCode = setHref.split('/').pop()!;
         await page.goto(`/inventory/sets/${setCode}`);
         await expect(page.locator('h1')).toContainText('Binder');
@@ -57,7 +57,7 @@ test.describe('Inventory binder (authenticated)', () => {
 
     test('shows owned-only toggle', async ({ authedPage: page }) => {
         await page.goto('/sets');
-        const setHref = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const setHref = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         const setCode = setHref.split('/').pop()!;
         await page.goto(`/inventory/sets/${setCode}`);
         await expect(page.locator('#owned-only-toggle')).toBeAttached();

--- a/test/e2e/public.e2e.ts
+++ b/test/e2e/public.e2e.ts
@@ -9,8 +9,8 @@ test.describe('Home page', () => {
 
     test('shows set list on home page', async ({ page }) => {
         await page.goto('/');
-        await expect(page.locator('.table-container')).toBeVisible();
-        await expect(page.locator('.table-row').first()).toBeVisible();
+        await expect(page.locator('.set-grid')).toBeVisible();
+        await expect(page.locator('a.set-tile').first()).toBeVisible();
     });
 });
 
@@ -18,22 +18,40 @@ test.describe('Sets page', () => {
     test('lists sets with filter input', async ({ page }) => {
         await page.goto('/sets');
         await expect(page.locator('input#filter')).toBeVisible();
-        await expect(page.locator('.table-container')).toBeVisible();
+        await expect(page.locator('.set-grid')).toBeVisible();
     });
 
-    test('set rows link to set detail', async ({ page }) => {
+    test('set tiles link to set detail', async ({ page }) => {
         await page.goto('/sets');
-        const firstSetLink = page.locator('.table-row a').first();
+        const firstSetLink = page.locator('a.set-tile').first();
         await expect(firstSetLink).toBeVisible();
         const href = await firstSetLink.getAttribute('href');
         expect(href).toMatch(/^\/sets\/[A-Za-z0-9]+$/);
+    });
+
+    // The toggle is a real link, so the layout survives a reload and works
+    // without JS.
+    test('table view renders the sortable table', async ({ page }) => {
+        await page.goto('/sets?view=table');
+        await expect(page.locator('.table-container')).toBeVisible();
+        await expect(page.locator('.table-row').first()).toBeVisible();
+        await expect(page.locator('.set-grid')).toHaveCount(0);
+    });
+
+    test('grid view sorts through the chip row', async ({ page }) => {
+        await page.goto('/sets');
+        const valueChip = page.locator('.sort-chip', { hasText: 'Set Value' });
+        await valueChip.click();
+        await expect(page.locator('.sort-chip-active')).toContainText('Set Value');
+        await expect(page).toHaveURL(/sort=setPrice\.basePrice/);
+        await expect(page.locator('a.set-tile').first()).toBeVisible();
     });
 });
 
 test.describe('Set detail page', () => {
     test('renders set name and stat cards', async ({ page }) => {
         await page.goto('/sets');
-        const href = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const href = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         await page.goto(href);
         await expect(page.locator('h1')).toBeVisible();
         await expect(page.locator('.stat-card').first()).toBeVisible();
@@ -41,7 +59,7 @@ test.describe('Set detail page', () => {
 
     test('shows price info popover on button click', async ({ page }) => {
         await page.goto('/sets');
-        const href = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const href = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         await page.goto(href);
         await expect(page.locator('#price-info-toggle')).toBeVisible();
         await page.locator('#price-info-toggle').click();
@@ -50,7 +68,7 @@ test.describe('Set detail page', () => {
 
     test('renders card list', async ({ page }) => {
         await page.goto('/sets');
-        const href = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const href = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         await page.goto(href);
         await expect(page.locator('#set-card-list-ajax')).toBeVisible();
     });
@@ -61,7 +79,7 @@ test.describe('Set detail page', () => {
         // until a hard refresh.
         await page.setViewportSize({ width: 390, height: 844 });
         await page.goto('/sets');
-        const href = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const href = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         await page.goto(href);
 
         const cardCalls: string[] = [];
@@ -89,7 +107,7 @@ test.describe('Set detail page', () => {
 test.describe('Card detail page', () => {
     test('renders card name and price', async ({ page }) => {
         await page.goto('/sets');
-        const setHref = (await page.locator('.table-row a').first().getAttribute('href'))!;
+        const setHref = (await page.locator('a.set-tile').first().getAttribute('href'))!;
         await page.goto(setHref);
         // Card list is AJAX-loaded - wait for first card link to appear
         const cardLink = page.locator('#set-card-list-ajax a[href^="/card/"]').first();

--- a/test/e2e/responsive-overflow.e2e.ts
+++ b/test/e2e/responsive-overflow.e2e.ts
@@ -85,7 +85,7 @@ async function assertNoHorizontalOverflow(page: Page, label: string): Promise<vo
 
 async function resolveSetHref(page: Page): Promise<string> {
     await page.goto('/sets');
-    return (await page.locator('.table-row a').first().getAttribute('href'))!;
+    return (await page.locator('a.set-tile').first().getAttribute('href'))!;
 }
 
 async function resolveCardHref(page: Page, setHref: string): Promise<string> {

--- a/test/frontend/setListAjax.spec.js
+++ b/test/frontend/setListAjax.spec.js
@@ -10,13 +10,17 @@ if (!window.matchMedia) {
 
 // Captured renderContent callback from initListPage
 var capturedConfig = null;
+// The page's state object, so a test can pick the layout under test
+var capturedState = null;
 
 // Minimal AjaxUtils mock
 window.AjaxUtils = {
     initListPage: function (config) {
         capturedConfig = config;
-        return { container: config.container, state: { page: 1, limit: 25 }, fetchAndRender: function () {} };
+        return { container: config.container, state: capturedState, fetchAndRender: function () {} };
     },
+    setupViewToggleInterceptor: function () {},
+    updateViewToggle: function () {},
     renderEmptyState: function (el, opts) {
         el.innerHTML = '<div class="empty-state">' + opts.message + '</div>';
     },
@@ -38,6 +42,9 @@ window.AjaxUtils = {
     renderCompletionBar: function (rate) {
         return '<div class="completion-bar">' + rate + '%</div>';
     },
+    isSubscribed: function () {
+        return document.body.getAttribute('data-subscribed') === 'true';
+    },
     renderPriceChange: function (change) {
         var sign = change > 0 ? '+' : '';
         return '<span class="price-change">' + sign + '$' + Math.abs(change).toFixed(2) + '</span>';
@@ -49,11 +56,13 @@ require('../../src/http/public/js/setListUtils.js');
 
 beforeEach(function () {
     capturedConfig = null;
+    capturedState = { page: 1, limit: 25, view: 'grid' };
     document.body.innerHTML = '<div id="set-list-ajax" data-authenticated="false"><div id="filter-results"></div></div>';
 });
 
-function loadSetListAjax() {
+function loadSetListAjax(view) {
     jest.resetModules();
+    capturedState.view = view || 'grid';
     // Re-trigger DOMContentLoaded to run the script's init
     require('../../src/http/public/js/setListAjax.js');
     document.dispatchEvent(new Event('DOMContentLoaded'));
@@ -66,7 +75,7 @@ function getResultsEl() {
 
 describe('setListAjax renderTable', function () {
     it('should render empty state when sets array is empty', function () {
-        var config = loadSetListAjax();
+        var config = loadSetListAjax('table');
         var resultsEl = getResultsEl();
         config.renderContent(resultsEl, [], null);
 
@@ -75,7 +84,7 @@ describe('setListAjax renderTable', function () {
     });
 
     it('should render flat rows when meta has no multiSetBlockKeys', function () {
-        var config = loadSetListAjax();
+        var config = loadSetListAjax('table');
         var resultsEl = getResultsEl();
         var sets = [
             { code: 'mid', name: 'Midnight Hunt', keyruneCode: 'mid', tags: [], prices: { basePrice: 50 }, releaseDate: '2021-09-24' },
@@ -91,7 +100,7 @@ describe('setListAjax renderTable', function () {
     });
 
     it('should render block label rows and child indentation with multiSetBlockKeys', function () {
-        var config = loadSetListAjax();
+        var config = loadSetListAjax('table');
         var resultsEl = getResultsEl();
         var sets = [
             { code: 'mid', name: 'Midnight Hunt', block: 'Innistrad', parentCode: null, isMain: true, keyruneCode: 'mid', tags: [], prices: { basePrice: 50 }, releaseDate: '2021-09-24' },
@@ -121,7 +130,7 @@ describe('setListAjax renderTable', function () {
     });
 
     it('should not render block label for single-set groups not in multiSetBlockKeys', function () {
-        var config = loadSetListAjax();
+        var config = loadSetListAjax('table');
         var resultsEl = getResultsEl();
         var sets = [
             { code: 'neo', name: 'Neon Dynasty', block: 'Kamigawa', parentCode: null, isMain: true, keyruneCode: 'neo', tags: [], prices: { basePrice: 40 }, releaseDate: '2022-02-18' },
@@ -139,7 +148,7 @@ describe('setListAjax renderTable', function () {
     });
 
     it('should render multiple block groups with labels', function () {
-        var config = loadSetListAjax();
+        var config = loadSetListAjax('table');
         var resultsEl = getResultsEl();
         var sets = [
             { code: 'mid', name: 'Midnight Hunt', block: 'Innistrad', parentCode: null, isMain: true, keyruneCode: 'mid', tags: [], prices: { basePrice: 50 }, releaseDate: '2021-09-24' },
@@ -160,7 +169,7 @@ describe('setListAjax renderTable', function () {
 
     it('should include owned value column when authenticated', function () {
         document.body.innerHTML = '<div id="set-list-ajax" data-authenticated="true"><div id="filter-results"></div></div>';
-        var config = loadSetListAjax();
+        var config = loadSetListAjax('table');
         var resultsEl = getResultsEl();
         var sets = [
             { code: 'mid', name: 'Midnight Hunt', keyruneCode: 'mid', tags: [], prices: { basePrice: 50 }, releaseDate: '2021-09-24', ownedValue: 25.5, completionRate: 40 },
@@ -170,5 +179,113 @@ describe('setListAjax renderTable', function () {
 
         expect(resultsEl.innerHTML).toContain('$25.50');
         expect(resultsEl.innerHTML).toContain('completion-bar');
+    });
+});
+
+// The grid is the default layout, and must match partials/setTile.hbs.
+describe('setListAjax renderGrid', function () {
+    var GRID_SET = {
+        code: 'mid',
+        name: 'Midnight Hunt',
+        keyruneCode: 'mid',
+        tags: [],
+        prices: { basePrice: 50, basePriceChangeWeekly: 1.25 },
+        releaseDate: '2021-09-24',
+        baseSize: 277,
+        totalSize: 391,
+        coverImgSrc: 'a/b/cover.jpg',
+    };
+
+    it('renders one tile per set, linking to the set page', function () {
+        var config = loadSetListAjax();
+        var resultsEl = getResultsEl();
+
+        config.renderContent(resultsEl, [GRID_SET], { page: 1, limit: 25, total: 1, totalPages: 1 });
+
+        var tiles = resultsEl.querySelectorAll('a.set-tile');
+        expect(tiles.length).toBe(1);
+        expect(tiles[0].getAttribute('href')).toBe('/sets/mid');
+        expect(tiles[0].textContent).toContain('Midnight Hunt');
+    });
+
+    it('builds the art_crop URL from the cover tail', function () {
+        var config = loadSetListAjax();
+        var resultsEl = getResultsEl();
+
+        config.renderContent(resultsEl, [GRID_SET], { page: 1, limit: 25, total: 1, totalPages: 1 });
+
+        var img = resultsEl.querySelector('.set-tile-art');
+        expect(img.getAttribute('src')).toBe(
+            'https://cards.scryfall.io/art_crop/front/a/b/cover.jpg'
+        );
+    });
+
+    it('renders a tile without art when the set has no cover', function () {
+        var config = loadSetListAjax();
+        var resultsEl = getResultsEl();
+        var noCover = Object.assign({}, GRID_SET, { coverImgSrc: undefined });
+
+        config.renderContent(resultsEl, [noCover], { page: 1, limit: 25, total: 1, totalPages: 1 });
+
+        expect(resultsEl.querySelectorAll('a.set-tile').length).toBe(1);
+        expect(resultsEl.querySelector('.set-tile-art')).toBeNull();
+    });
+
+    it('shows release year and card count under the name', function () {
+        var config = loadSetListAjax();
+        var resultsEl = getResultsEl();
+
+        config.renderContent(resultsEl, [GRID_SET], { page: 1, limit: 25, total: 1, totalPages: 1 });
+
+        expect(resultsEl.querySelector('.set-tile-sub').textContent).toContain('2021');
+        expect(resultsEl.querySelector('.set-tile-sub').textContent).toContain('277');
+    });
+
+    it('labels block groups instead of indenting rows', function () {
+        var config = loadSetListAjax();
+        var resultsEl = getResultsEl();
+        var sets = [
+            Object.assign({}, GRID_SET, { block: 'Innistrad', parentCode: null, isMain: true }),
+            Object.assign({}, GRID_SET, {
+                code: 'mic',
+                name: 'MH Commander',
+                block: 'Innistrad',
+                parentCode: 'mid',
+                isMain: false,
+            }),
+        ];
+        var meta = { page: 1, limit: 25, total: 1, totalPages: 1, multiSetBlockKeys: ['mid'] };
+
+        config.renderContent(resultsEl, sets, meta);
+
+        var labels = resultsEl.querySelectorAll('.set-grid-label');
+        expect(labels.length).toBe(1);
+        expect(labels[0].textContent).toContain('Innistrad');
+        expect(resultsEl.querySelectorAll('a.set-tile').length).toBe(2);
+    });
+
+    it('badges owned value only when authenticated and the set is owned', function () {
+        document.body.innerHTML = '<div id="set-list-ajax" data-authenticated="true"><div id="filter-results"></div></div>';
+        var config = loadSetListAjax();
+        var resultsEl = getResultsEl();
+        var sets = [
+            Object.assign({}, GRID_SET, { ownedTotal: 12, ownedValue: 25.5 }),
+            Object.assign({}, GRID_SET, { code: 'neo', name: 'Neon Dynasty', ownedTotal: 0 }),
+        ];
+
+        config.renderContent(resultsEl, sets, { page: 1, limit: 25, total: 2, totalPages: 1 });
+
+        var badges = resultsEl.querySelectorAll('.set-tile-owned');
+        expect(badges.length).toBe(1);
+        expect(badges[0].textContent).toContain('$25.50');
+    });
+
+    it('renders the empty state in grid view too', function () {
+        var config = loadSetListAjax();
+        var resultsEl = getResultsEl();
+
+        config.renderContent(resultsEl, [], null);
+
+        expect(resultsEl.innerHTML).toContain('No sets match your search');
     });
 });

--- a/test/http/set.orchestrator.spec.ts
+++ b/test/http/set.orchestrator.spec.ts
@@ -291,6 +291,36 @@ describe('SetOrchestrator', () => {
             expect(table.isTableView).toBe(true);
         });
 
+        // The toggle hrefs are what a middle-click or a JS-off visitor actually
+        // follows, so they have to carry the list you were looking at (#629).
+        it('keeps filter, sort and paging in both view-toggle hrefs', async () => {
+            const options = new SafeQueryOptions({
+                page: '3',
+                limit: '50',
+                filter: 'ravnica',
+                sort: 'set.name',
+                ascend: 'true',
+                baseOnly: 'false',
+            });
+            setService.findSets.mockResolvedValue([mockSet]);
+            setService.totalSetsCount.mockResolvedValue(1);
+            inventoryService.inventoryTotalsForSets.mockResolvedValue(new Map());
+            inventoryService.ownedValuesForSets.mockResolvedValue(new Map());
+
+            const result = await orchestrator.findSetList(mockAuthenticatedRequest, [], options);
+
+            for (const url of [result.viewToggle.gridUrl, result.viewToggle.tableUrl]) {
+                expect(url).toContain('page=3');
+                expect(url).toContain('limit=50');
+                expect(url).toContain('filter=ravnica');
+                expect(url).toContain('sort=set.name');
+                expect(url).toContain('baseOnly=false');
+            }
+            expect(result.viewToggle.gridUrl.startsWith('/sets?')).toBe(true);
+            expect(result.viewToggle.gridUrl).not.toContain('view=');
+            expect(result.viewToggle.tableUrl).toContain('view=table');
+        });
+
         it('uses flat set pagination when sort is specified', async () => {
             const sortedOptions = new SafeQueryOptions({
                 page: '1',

--- a/test/http/set.orchestrator.spec.ts
+++ b/test/http/set.orchestrator.spec.ts
@@ -103,6 +103,7 @@ describe('SetOrchestrator', () => {
                     useValue: {
                         findBySet: jest.fn(),
                         totalInSet: jest.fn(),
+                        coverImagesForSets: jest.fn(),
                     },
                 },
                 {
@@ -143,6 +144,7 @@ describe('SetOrchestrator', () => {
         // Default: sealed product service returns nothing so existing tests are unaffected
         sealedProductService.findBySetCode.mockResolvedValue([]);
         sealedProductService.findInventoryQuantitiesForUser.mockResolvedValue(new Map());
+        cardService.coverImagesForSets.mockResolvedValue(new Map());
     });
 
     describe('findSetList', () => {
@@ -194,6 +196,99 @@ describe('SetOrchestrator', () => {
             expect(result.blockGroups.length).toBe(0);
             expect(result.setList.length).toBe(0);
             expect(result.toast).toBeUndefined();
+        });
+
+        // The art tiles need a full art_crop URL, not the `a/b/id.jpg` tail the
+        // repository returns (#628).
+        it('puts each set’s cover art on its DTO', async () => {
+            setService.totalBlockGroups.mockResolvedValue(1);
+            setService.findBlockGroupKeys.mockResolvedValue(['TST']);
+            setService.findSetsByBlockKeys.mockResolvedValue([mockSet]);
+            setService.findMultiSetBlockKeys.mockResolvedValue([]);
+            inventoryService.inventoryTotalsForSets.mockResolvedValue(new Map());
+            inventoryService.ownedValuesForSets.mockResolvedValue(new Map());
+            cardService.coverImagesForSets.mockResolvedValue(new Map([['TST', 'a/b/cover.jpg']]));
+
+            const result = await orchestrator.findSetList(
+                mockAuthenticatedRequest,
+                [],
+                mockQueryOptions
+            );
+
+            expect(cardService.coverImagesForSets).toHaveBeenCalledWith(['TST']);
+            expect(result.setList[0].coverImgSrc).toBe(
+                'https://cards.scryfall.io/art_crop/front/a/b/cover.jpg'
+            );
+        });
+
+        // A set with no priced cards (or no cards at all) still renders — the
+        // tile just falls back to a plain background.
+        it('leaves coverImgSrc undefined when a set has no cover', async () => {
+            setService.totalBlockGroups.mockResolvedValue(1);
+            setService.findBlockGroupKeys.mockResolvedValue(['TST']);
+            setService.findSetsByBlockKeys.mockResolvedValue([mockSet]);
+            setService.findMultiSetBlockKeys.mockResolvedValue([]);
+            inventoryService.inventoryTotalsForSets.mockResolvedValue(new Map());
+            inventoryService.ownedValuesForSets.mockResolvedValue(new Map());
+
+            const result = await orchestrator.findSetList(
+                mockAuthenticatedRequest,
+                [],
+                mockQueryOptions
+            );
+
+            expect(result.setList[0].coverImgSrc).toBeUndefined();
+        });
+
+        // Covers are public: an anonymous visitor sees art too, even though
+        // every inventory read is skipped for them.
+        it('fetches covers for anonymous visitors', async () => {
+            setService.totalBlockGroups.mockResolvedValue(1);
+            setService.findBlockGroupKeys.mockResolvedValue(['TST']);
+            setService.findSetsByBlockKeys.mockResolvedValue([mockSet]);
+            setService.findMultiSetBlockKeys.mockResolvedValue([]);
+            cardService.coverImagesForSets.mockResolvedValue(new Map([['TST', 'a/b/cover.jpg']]));
+
+            const result = await orchestrator.findSetList(
+                { isAuthenticated: () => false } as AuthenticatedRequest,
+                [],
+                mockQueryOptions
+            );
+
+            expect(result.setList[0].coverImgSrc).toBe(
+                'https://cards.scryfall.io/art_crop/front/a/b/cover.jpg'
+            );
+            expect(inventoryService.inventoryTotalsForSets).not.toHaveBeenCalled();
+        });
+
+        // Art tiles are the default layout; the table is opt-in and server-rendered
+        // so it survives a reload (#628).
+        it('renders art tiles unless ?view=table asks for the table', async () => {
+            setService.totalBlockGroups.mockResolvedValue(1);
+            setService.findBlockGroupKeys.mockResolvedValue(['TST']);
+            setService.findSetsByBlockKeys.mockResolvedValue([mockSet]);
+            setService.findMultiSetBlockKeys.mockResolvedValue([]);
+            inventoryService.inventoryTotalsForSets.mockResolvedValue(new Map());
+            inventoryService.ownedValuesForSets.mockResolvedValue(new Map());
+
+            const grid = await orchestrator.findSetList(
+                mockAuthenticatedRequest,
+                [],
+                mockQueryOptions
+            );
+            const table = await orchestrator.findSetList(
+                {
+                    ...mockAuthenticatedRequest,
+                    query: { view: 'table' },
+                } as unknown as AuthenticatedRequest,
+                [],
+                mockQueryOptions
+            );
+
+            expect(grid.view).toBe('grid');
+            expect(grid.isTableView).toBe(false);
+            expect(table.view).toBe('table');
+            expect(table.isTableView).toBe(true);
         });
 
         it('uses flat set pagination when sort is specified', async () => {

--- a/test/integration/api-sets.e2e-spec.ts
+++ b/test/integration/api-sets.e2e-spec.ts
@@ -43,6 +43,15 @@ describe('Sets API (e2e)', () => {
             expect(res.body.success).toBe(true);
             expect(Array.isArray(res.body.data)).toBe(true);
         });
+
+        // Same cover rule as the detail route, resolved for a whole page of sets
+        // in one query.
+        it('covers each listed set with its most valuable card', async () => {
+            const res = await request(app.getHttpServer()).get('/api/v1/sets?q=Test').expect(200);
+
+            const testSet = res.body.data.find((s) => s.code === TEST_SET_CODE);
+            expect(testSet.coverImgSrc).toBe('4/4/44444444-4444-4444-a444-444444444444.jpg');
+        });
     });
 
     describe('GET /api/v1/sets/:code', () => {
@@ -69,6 +78,19 @@ describe('Sets API (e2e)', () => {
                 expect(res.body.data.prices).toHaveProperty('basePrice');
                 expect(res.body.data.prices).toHaveProperty('totalPrice');
             }
+        });
+
+        // The cover is the set's most valuable card, not its opening card (#628):
+        // the seed's Test Dragon is $20.00 against Test Angel's $5.00, and Angel
+        // is the one that sorts first.
+        it('covers the set with its most valuable card', async () => {
+            const res = await request(app.getHttpServer())
+                .get(`/api/v1/sets/${TEST_SET_CODE}`)
+                .expect(200);
+
+            expect(res.body.data.coverImgSrc).toBe(
+                '4/4/44444444-4444-4444-a444-444444444444.jpg'
+            );
         });
 
         it('returns 404 for nonexistent set', async () => {


### PR DESCRIPTION
Closes #628.

## What this does

The set list — `/sets`, the home page, and `/spoilers` — is now a responsive grid of art tiles instead of a table, matching the mobile app's `SetTile`. Columns are added as the screen grows (1 / 2 / 3) rather than showing one full-width banner per set, so a desktop browser still shows ~12 sets per screen.

A set's cover art is now **the art crop of its most valuable card**, not whatever card happens to be numbered 001.

| | |
|---|---|
| Tile anatomy (from mobile) | art crop background, bottom scrim, keyrune symbol, name, `2021 · 303 cards` |
| Web-only additions | set value with 7d change, owned-value badge, completion bar (subscribers) |

## The cover change affects mobile too

`findCoverImagesForSets` is what feeds `/api/v1/sets`, so the app's tiles switch to best-card covers **in this deploy, with no mobile release**. There is an uncommitted doc-comment edit in `i-want-my-mtg-mobile/components/SetTile.tsx` that already describes this behavior; it becomes true when this merges.

Value is `COALESCE(p.normal, p.foil, 0)` — the same expression `PriceCalculationPolicy` uses everywhere else. Cards with no price row lose to any priced card, and `sortNumber` breaks ties, so a set with no prices at all keeps the old behavior.

## Table view is still there

`/sets` defaults to the grid; the toggle links to `?view=table`, which renders today's table markup **server-side**. That means the layout survives a reload and works with JS off. Grid view sorts through a chip row built from the same `TableHeadersRowView` the table headers use, so both layouts offer and highlight exactly the same sorts, and flipping views keeps your sort.

Home is grid-only (`showViewToggle: false`): it loads no list JS, so a toggle there could only navigate away to `/sets`.

## Shared code touched

- `setupSortInterceptor`'s selector widened from `#container thead a.sort-btn` to `#container a.sort-btn` — the grid sorts through chips, not a `<thead>`. No page has a `.sort-btn` outside a `<thead>` other than these chips.
- `parseStateFromUrl` accepts `grid`/`table` alongside `binder`; `buildBrowserUrl` keeps `grid` out of the URL since it is the default.
- `setupViewToggleInterceptor` takes an optional `storageKey`, so this toggle no longer overwrites the set page's list/binder preference.
- `SortableHeaderView` gained `active` — the chips need to know which sort is on; nothing about the table's rendering changed.

## Testing

| Suite | Result |
|---|---|
| Unit | 1524 passing |
| Frontend (jsdom) | 132 passing |
| Integration | 300 passing |
| Playwright | 33 passing, incl. 320px/375px overflow guard on `/sets` |

New coverage: two integration tests pinning the best-card cover on both `/api/v1/sets` and `/api/v1/sets/:code`; orchestrator tests for cover URL building, the no-cover fallback, anonymous visitors, and grid-vs-table selection; seven frontend tests for the AJAX grid renderer.

## Reviewer notes

1. **Worth an `EXPLAIN ANALYZE` on production-size data.** The cover query now joins the latest price row per card across a whole page of sets (worst case ~12k card rows). I could not measure it — no local database has real data. If it is slow, swap the correlated `MAX(date)` subquery for a LATERAL join; the query is isolated in `findCoverImagesForSets`.
2. **Tile art has empty `alt`.** Getting the cover card's name would mean widening the repository port and the API DTO; the set name sits directly beside the image, so the art is decorative.
3. **No completion percentage on tiles for free users.** The table shows a "Premium" lock in that column; a lock badge over the art looked wrong, so the bar simply does not draw. The table is unchanged.