### PR TITLE
fix: stop integration suites fighting over a test user, stop baseOnly defaulting invisibly, and resequence the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,6 +5,9 @@ per section under **Done**; small leftovers from shipped sections live under
 **Catch-up**; unstarted future work is under Phases 8 and 9. Verbose history lives
 in git.
 
+**Markers:** 🔴 = **manual, AWS console or an external service — cannot be done in a
+PR, and only you can do it.** ✅ = shipped.
+
 ---
 
 ## Now
@@ -18,67 +21,118 @@ internal track.
 
 The live production problem is **[#612](https://github.com/matthewdtowles/i-want-my-mtg/issues/612):
 the API intermittently 503s under load**, badly enough that the mobile app often
-can't load Browse. #612 is now an **umbrella**; the three fixes under it are filed
-separately and are listed below in the order they should be done. Close #612 when
-the 503s actually stop, not when the children merge.
+can't load Browse. #612 is now an **umbrella**; its fixes are filed separately and
+sequenced below. Close #612 when the 503s actually stop, not when the children merge.
+
+### 🔴 Blocked on you — AWS console, no code in any repo
+
+These cannot be done from a PR. There is **no IaC for the CloudFront distribution
+anywhere in this repo**, so nothing in the ordered list below can substitute for
+them. They are also the highest-leverage items on the board, which is the awkward
+part: the two remaining 503 fixes are one console session, not a coding task.
+
+| | Item | Console work | Blocks |
+|---|---|---|---|
+| 🔴 | **[#621](https://github.com/matthewdtowles/i-want-my-mtg/issues/621)** — CloudFront caches nothing on `/api/*` | CloudFront → cache behavior for `/api/v1/sets*`, `/api/v1/cards*` | #616, and the edge half of #625 |
+| 🔴 | **[#625](https://github.com/matthewdtowles/i-want-my-mtg/issues/625)** — no health-check monitoring on the web tier | UptimeRobot/Better Stack signup, *or* a CloudWatch 5xx alarm | nothing, but nothing surfaces the next outage without it |
+
+**#621 detail.** Six identical `/api/v1/sets` requests all returned `Miss`, so every
+catalog request reaches the single Lightsail container — that is the load that makes
+the origin buckle. Recipe and its cache-key hazard are in the issue; the hazard is
+that `GET /api/v1/sets` returns per-user `ownedTotal`, so a naive public cache leaks
+one user's owned counts to everyone. → verify: `x-cache: Hit from cloudfront` on a
+repeat, and a signed-in caller still gets its own `ownedTotal`.
+
+**#625 detail.** #612 was found by *using the app*, not by an alert. The asymmetry to
+close: scry's cron already mails on failure, so the data pipeline is monitored and
+the tier serving that data is not. Option 1 (external uptime service) needs no code
+and no second host. Option 3 (CloudWatch alarm on the distribution's 5xx rate) is
+worth pairing with it once #621 makes the distribution something we manage
+deliberately. → verify: break it on purpose, confirm the alert arrives *and* clears.
+
+### Dependency flow
+
+```
+✅ #620 + #631 (PR #632) ──► trustworthy CI under every PR below
+
+🔴 #621 CloudFront cache ──┬──► #616 CORS (headers must survive the distribution)
+                           └──► #625 edge alarm (option 3 only)
+   #622 trust proxy ───────── independent code; verify hop count against prod first
+   #623 browser review ─────► #624 deck detail thumbnail
+```
+
+Nothing else is gated. #622, #623/#624 and the mobile Browse items can proceed in
+any order at any time.
 
 ### Order of work
 
 Web = this repo, Mobile = `i-want-my-mtg-mobile`. Each line has its own verification.
 
-1. **Mobile [#101](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/101)
-   — adopt `coverImgSrc`.** *(client-only, ~1h)* `SetTile.tsx` still runs a
-   `useQuery` per tile against `/sets/{code}/cards?limit=1`, so one Browse screen
-   costs **51 requests**. The server half ([#615](https://github.com/matthewdtowles/i-want-my-mtg/issues/615))
-   is already live. Biggest load reduction available and it needs no infra work.
-   → verify: cold Browse load issues **1** catalog request.
-2. **Web [#621](https://github.com/matthewdtowles/i-want-my-mtg/issues/621) —
-   CloudFront caches nothing on `/api/*`.** *(infra only, ~1–2h in the AWS console)*
-   Six identical `/api/v1/sets` requests all returned `Miss`, so every catalog
-   request reaches the single Lightsail container. There is **no IaC for the
-   distribution anywhere in this repo** — the recipe and its cache-key hazard live
-   in the issue. → verify: `x-cache: Hit from cloudfront` on a repeat request, and a
-   signed-in caller still gets its own `ownedTotal`.
-3. **Web [#622](https://github.com/matthewdtowles/i-want-my-mtg/issues/622) — set
+1. ~~**Mobile [#101](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/101)
+   — adopt `coverImgSrc`.**~~ ✅ **Closed 2026-07-30.** `SetTile.tsx` no longer runs a
+   `useQuery` per tile, so a Browse screen costs 1 catalog request instead of 51.
+   This was the largest client-side load reduction available; the remaining 503 work
+   is all server/edge side.
+2. ~~**Web [#620](https://github.com/matthewdtowles/i-want-my-mtg/issues/620) +
+   [#631](https://github.com/matthewdtowles/i-want-my-mtg/issues/631) — CI green and
+   `baseOnly` honest.**~~ ✅ **[PR #632](https://github.com/matthewdtowles/i-want-my-mtg/pull/632)**
+   (which also carries this roadmap update).
+   `api-user` rewrote `mutation@test.com`'s password, so integration runs passed or
+   failed on Jest's suite order; fixed with a dedicated `pwchange@test.com`.
+   *Correction to #620's own diagnosis:* the self-repairing seed it proposed would
+   **not** have fixed this — `test-integ.sh` does `down -v` on entry, so the seed
+   always runs against an empty table and cannot repair a mid-run mutation. Verified
+   by forcing the failing order: 14 failures on `main`, 300/300 on the branch. #631
+   rides along — `safeBoolean` defaulted to `true`, so `baseOnly` silently filtered;
+   the default moved to the call site and the Swagger text now says so. Everything
+   below now lands on a suite whose result means something.
+3. 🔴 **Web [#621](https://github.com/matthewdtowles/i-want-my-mtg/issues/621) —
+   CloudFront caching.** *(AWS console, ~1–2h — see the red table above.)* The single
+   highest-leverage 503 fix.
+4. **Web [#622](https://github.com/matthewdtowles/i-want-my-mtg/issues/622) — set
    `trust proxy`.** *(small diff, security-sensitive, ~2h)* `request.ip` is a
    CloudFront edge IP, so the 60/min anonymous bucket is shared per POP. Scope note:
    signed-in callers are keyed on `user.id` at 200/min, so this only affects
    **anonymous** traffic — which is exactly what public Browse uses. Do not use
-   `trust proxy: true` (spoofable). → verify: two client IPs get independent
+   `trust proxy: true` (spoofable). **Needs one live prod request first** to count
+   the proxy hops — Lightsail may add one in front of CloudFront, and guessing wrong
+   is a live bug in either direction. → verify: two client IPs get independent
    budgets; a forged `X-Forwarded-For` does not.
-4. **Web [#620](https://github.com/matthewdtowles/i-want-my-mtg/issues/620) — CI
-   green.** *(~1h)* `api-user` rewrites `mutation@test.com`'s password and the seed's
-   `ON CONFLICT DO NOTHING` cannot repair it, so integration runs pass or fail on
-   Jest's suite order. Do this before or alongside the above so their PRs land on a
-   trustworthy suite. → verify: `./scripts/test-integ.sh` green twice in a row, and
-   green with `--runInBand`.
 5. **Web [#623](https://github.com/matthewdtowles/i-want-my-mtg/issues/623) — look
-   at the deck pages in a browser.** *(~1h review, plus work if it finds any)* #618
-   and #619 shipped on tests alone. The decision it surfaced — deck *detail* pages
-   have no cover art — is split out as
-   [#624](https://github.com/matthewdtowles/i-want-my-mtg/issues/624) (thumbnail
-   beside the `<h1>`, not a hero band), so this closes on the review alone.
+   at the deck pages in a browser** *(~1h review)*, then
+   **[#624](https://github.com/matthewdtowles/i-want-my-mtg/issues/624) — deck detail
+   cover thumbnail** *(~2h)*. #618/#619/#629 shipped on tests alone, so no deck or
+   set page has been opened in a browser. #624 is already decided — a thumbnail beside
+   the `<h1>`, not a hero band, reusing `DeckCoverPolicy.pick` for no extra query — so
+   #623 closes on the review alone.
 6. **Web [#616](https://github.com/matthewdtowles/i-want-my-mtg/issues/616) — CORS
-   on `/api/v1`.** *(~3h)* Preflight 404s, so no browser-based third-party client
-   can use the paid API tiers. Not a 503 contributor — sequenced after them because
-   it unblocks a paid product, not a live outage. Must be `credentials: false`;
-   `/api/v1` also accepts the session cookie, so credentialed CORS would be a CSRF
-   hole. Do it after #621 so the new `OPTIONS` behavior is added against the final
-   cache config.
-7. **Mobile Browse polish** — [#96](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/96)
+   on `/api/v1`.** *(~3h, **do after #621**)* Preflight 404s, so no browser-based
+   third-party client can use the paid API tiers. Not a 503 contributor — sequenced
+   here because it unblocks a paid product, not a live outage. Must be
+   `credentials: false`; `/api/v1` also accepts the session cookie, so credentialed
+   CORS would be a CSRF hole across every authenticated route. Sequenced after #621
+   so the new `OPTIONS` behavior is added against the final cache config rather than
+   one that is about to change.
+7. 🔴 **Web [#625](https://github.com/matthewdtowles/i-want-my-mtg/issues/625) —
+   health-check monitoring.** *(AWS console / external service — see the red table.)*
+   Last because the fixes above reduce the load that caused the 503s; but do not skip
+   it, because none of them make the *next* occurrence visible.
+8. **Mobile Browse polish** — [#96](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/96)
    sort by set value *(~1h, no backend work: `SET_SORTS` already has
    `SortOptions.SET_BASE_PRICE`)*, then [#95](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/95)
    group by block *(~half a day, `?group=block` already exists)*. **They interact:**
    the API disables block grouping whenever `sort` is set, so the UI has to treat
    grouping and sorting as mutually exclusive.
 
-**Also open, unsequenced:**
-[#625](https://github.com/matthewdtowles/i-want-my-mtg/issues/625) — there is no
-health-check monitoring on the web tier, which is why #612 was found by using the
-app rather than by an alert. It was the one checkbox in #612 no child covers. The
-data pipeline is already monitored (scry's cron `MAILTO` + `health` exit code); the
-tier serving that data is not. Do it whenever, but not never — the fixes above
-reduce the load that caused the 503s without making the next occurrence visible.
+**Newly filed on mobile, unsequenced:**
+[#104](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/104) (no
+component test harness — ~7,600 lines of UI with no coverage, and where every shipped
+bug has been) is the one worth pulling forward; it is the mobile analogue of item 2.
+Then [#108](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/108) (links
+to other printings — the web half shipped in #627),
+[#110](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/110) (mana symbol
+images), [#112](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/112)
+(binder view with unowned cards).
 
 **Deferred, deliberately:** mobile
 [#97](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/97) (filter
@@ -102,6 +156,14 @@ remaining gap in the catalog API.
 ---
 
 ## Done
+
+### Post-launch shipped, not yet folded into a phase
+
+Work merged since the store releases, listed because the **Now** board references it.
+
+- **Cover art across the catalog** — set DTOs carry `coverImgSrc` ([#615](https://github.com/matthewdtowles/i-want-my-mtg/pull/615)), deck list ([#618](https://github.com/matthewdtowles/i-want-my-mtg/pull/618)) and published-deck grids ([#619](https://github.com/matthewdtowles/i-want-my-mtg/pull/619)) show art-backed tiles, and `/sets` got mobile-style art tiles picked by each set's best card ([#629](https://github.com/matthewdtowles/i-want-my-mtg/pull/629), corrected in [#630](https://github.com/matthewdtowles/i-want-my-mtg/pull/630) to prefer a main-set card). **None of it has been opened in a browser** — that is [#623](https://github.com/matthewdtowles/i-want-my-mtg/issues/623). Deck *detail* pages were never covered: [#624](https://github.com/matthewdtowles/i-want-my-mtg/issues/624).
+- **Card printings endpoint** — list a card's printings by set code and number ([#627](https://github.com/matthewdtowles/i-want-my-mtg/pull/627)). Mobile's half is [#108](https://github.com/matthewdtowles/i-want-my-mtg-mobile/issues/108).
+- **Inventory finish filter** — normal/foil on the inventory list ([#611](https://github.com/matthewdtowles/i-want-my-mtg/pull/611)).
 
 ### Phase 1: Foundation & Infrastructure
 

--- a/src/core/query/query.util.ts
+++ b/src/core/query/query.util.ts
@@ -50,7 +50,12 @@ export function resolveSort(
     return sort && allowedSorts.includes(sort) ? sort : undefined;
 }
 
-export function safeBoolean(value: unknown, defaultValue: boolean = true): boolean {
+/**
+ * Parses a query param into a boolean. Defaults to `false` — a flag is off unless
+ * asked for. Callers that want the opposite must say so explicitly, so an
+ * on-by-default param is visible at its call site instead of hidden in here.
+ */
+export function safeBoolean(value: unknown, defaultValue: boolean = false): boolean {
     if (typeof value === 'boolean') return value;
     if (typeof value !== 'string') return defaultValue;
     const lower = value.toLowerCase();

--- a/src/core/query/safe-query-options.dto.ts
+++ b/src/core/query/safe-query-options.dto.ts
@@ -107,8 +107,8 @@ export class SafeQueryOptions implements QueryOptionsData {
 
     constructor(init?: RawQueryOptions, extra?: { includedSetTypes?: string[] | null }) {
         init = init || {};
-        this.ascend = safeBoolean(init.ascend);
-        this.baseOnly = safeBoolean(init.baseOnly);
+        this.ascend = safeBoolean(init.ascend, true);
+        this.baseOnly = safeBoolean(init.baseOnly, true);
         this.filter = safeSearchTerm(init.filter);
         this.finish = safeFinish(init.finish);
         this.format = safeFormat(init.format);

--- a/src/http/api/set/set-api.controller.ts
+++ b/src/http/api/set/set-api.controller.ts
@@ -62,7 +62,7 @@ export class SetApiController {
         name: 'baseOnly',
         required: false,
         type: Boolean,
-        description: 'Show only base/main sets',
+        description: 'Show only base/main sets. Defaults to true — pass false to include all sets.',
     })
     @ApiQuery({ name: 'q', required: false, type: String, description: 'Search query' })
     @ApiQuery({
@@ -192,7 +192,8 @@ export class SetApiController {
         name: 'baseOnly',
         required: false,
         type: Boolean,
-        description: 'Show only base set cards',
+        description:
+            'Show only base set cards. Defaults to true — pass false to include variant printings.',
     })
     @ApiQuery({
         name: 'rarity',

--- a/test/core/query/query.util.spec.ts
+++ b/test/core/query/query.util.spec.ts
@@ -1,4 +1,4 @@
-import { resolveSort, sanitizeInt } from 'src/core/query/query.util';
+import { resolveSort, safeBoolean, sanitizeInt } from 'src/core/query/query.util';
 import { SortOptions, TRANSACTION_SORTS } from 'src/core/query/sort-options.enum';
 
 describe('sanitizeInt', () => {
@@ -45,5 +45,32 @@ describe('resolveSort', () => {
 
     it('returns undefined when no sort is requested', () => {
         expect(resolveSort(undefined, TRANSACTION_SORTS)).toBeUndefined();
+    });
+});
+
+describe('safeBoolean', () => {
+    it('parses the string and boolean forms of true and false', () => {
+        expect(safeBoolean('true')).toBe(true);
+        expect(safeBoolean('TRUE')).toBe(true);
+        expect(safeBoolean('1')).toBe(true);
+        expect(safeBoolean(true)).toBe(true);
+        expect(safeBoolean('false')).toBe(false);
+        expect(safeBoolean('False')).toBe(false);
+        expect(safeBoolean('0')).toBe(false);
+        expect(safeBoolean(false)).toBe(false);
+    });
+
+    it('defaults to false when the value is missing or unparseable', () => {
+        expect(safeBoolean(undefined)).toBe(false);
+        expect(safeBoolean(null)).toBe(false);
+        expect(safeBoolean('yes')).toBe(false);
+        expect(safeBoolean(['true'] as never)).toBe(false);
+    });
+
+    it('uses an explicit default when one is given', () => {
+        expect(safeBoolean(undefined, true)).toBe(true);
+        expect(safeBoolean('nonsense', true)).toBe(true);
+        // an explicit default never overrides a parseable value
+        expect(safeBoolean('false', true)).toBe(false);
     });
 });

--- a/test/core/query/safe-query-options.spec.ts
+++ b/test/core/query/safe-query-options.spec.ts
@@ -31,6 +31,22 @@ describe('SafeQueryOptions — public catalog filters', () => {
         });
     });
 
+    describe('boolean defaults', () => {
+        // Both defaults live at the call site rather than inside safeBoolean, so a
+        // future boolean param defaults to off unless it deliberately opts in.
+        it('defaults ascend and baseOnly to true when omitted', () => {
+            const opts = new SafeQueryOptions({});
+            expect(opts.ascend).toBe(true);
+            expect(opts.baseOnly).toBe(true);
+        });
+
+        it('honors an explicit false for either', () => {
+            const opts = new SafeQueryOptions({ ascend: 'false', baseOnly: 'false' });
+            expect(opts.ascend).toBe(false);
+            expect(opts.baseOnly).toBe(false);
+        });
+    });
+
     describe('setCode', () => {
         it('lowercases set codes to match DB storage convention', () => {
             const opts = new SafeQueryOptions({ setCode: 'LEA' });

--- a/test/integration/api-user.e2e-spec.ts
+++ b/test/integration/api-user.e2e-spec.ts
@@ -7,10 +7,20 @@ const MUTATION_USER = {
     password: 'TestPass1!',
 };
 
+// Owned solely by the password test below. Rewriting a password is not reversible
+// within a run — the seed runs once, before any suite — so it must happen on a user
+// no other suite logs in as. Using MUTATION_USER here made freemium-gates fail with
+// 401s whenever Jest scheduled it after this file (issue #620).
+const PW_CHANGE_USER = {
+    email: 'pwchange@test.com',
+    password: 'TestPass1!',
+};
+
 describe('User API (e2e)', () => {
     let app: INestApplication;
     let bearerToken: string;
     let mutationBearerToken: string;
+    let pwChangeBearerToken: string;
 
     async function loginApi(
         testApp: INestApplication,
@@ -32,6 +42,7 @@ describe('User API (e2e)', () => {
         app = await createTestApp();
         bearerToken = await loginApi(app, TEST_USER);
         mutationBearerToken = await loginApi(app, MUTATION_USER);
+        pwChangeBearerToken = await loginApi(app, PW_CHANGE_USER);
     }, 30000);
 
     afterAll(async () => {
@@ -83,7 +94,7 @@ describe('User API (e2e)', () => {
         it('updates password', async () => {
             const res = await request(app.getHttpServer())
                 .patch('/api/v1/user/password')
-                .set('Authorization', mutationBearerToken)
+                .set('Authorization', pwChangeBearerToken)
                 .send({ password: 'NewTestPass1!' })
                 .expect(200);
 

--- a/test/integration/seed.sql
+++ b/test/integration/seed.sql
@@ -68,17 +68,34 @@ VALUES
     ('tst', 6.75, 6.75, 19.75, 19.75, CURRENT_DATE)
 ON CONFLICT (set_code, date) DO NOTHING;
 
--- Test user (password: TestPass1!)
--- bcrypt hash generated with 10 rounds
+-- Test users (password for all three: TestPass1!)
+-- bcrypt hash generated with 10 rounds.
+--
+-- ON CONFLICT DO UPDATE, not DO NOTHING: the seed must be able to *repair* a user a
+-- previous run left mutated, not just create a missing one. test-integ.sh drops the
+-- volume on entry so this normally hits an empty table, but a run against a reused
+-- database would otherwise inherit whatever the last run wrote.
+--
+-- Credentials are still not a shared fixture: any suite that changes a password must
+-- use pwchange@test.com, because the seed runs once per run and cannot undo a mutation
+-- between suites. See the comment on that user below.
 INSERT INTO users (email, name, password, role)
-VALUES ('integ@test.com', 'IntegTestUser', '$2b$10$fNiH5A76rU5uJun2HwtdX.buge2hb2urV/cZJpOfHRz1oamXu77la', 'user')
-ON CONFLICT (email) DO NOTHING;
+VALUES
+    ('integ@test.com', 'IntegTestUser', '$2b$10$fNiH5A76rU5uJun2HwtdX.buge2hb2urV/cZJpOfHRz1oamXu77la', 'user'),
+    ('mutation@test.com', 'MutationTestUser', '$2b$10$fNiH5A76rU5uJun2HwtdX.buge2hb2urV/cZJpOfHRz1oamXu77la', 'user'),
+    ('pwchange@test.com', 'PasswordChangeTestUser', '$2b$10$fNiH5A76rU5uJun2HwtdX.buge2hb2urV/cZJpOfHRz1oamXu77la', 'user')
+ON CONFLICT (email) DO UPDATE
+    SET password = EXCLUDED.password,
+        name = EXCLUDED.name,
+        role = EXCLUDED.role;
 
--- Disposable test user for mutation tests (password: TestPass1!)
--- Same bcrypt hash; this user can be freely modified/deleted without affecting other suites
-INSERT INTO users (email, name, password, role)
-VALUES ('mutation@test.com', 'MutationTestUser', '$2b$10$fNiH5A76rU5uJun2HwtdX.buge2hb2urV/cZJpOfHRz1oamXu77la', 'user')
-ON CONFLICT (email) DO NOTHING;
+-- integ@test.com     — read-mostly user shared by most suites (setup.ts TEST_USER).
+-- mutation@test.com  — non-credential mutations (profile name, subscription rows).
+-- pwchange@test.com  — owned solely by api-user's password test. Nothing else may log
+--                      in as it: the seed runs once per run, so a password rewritten
+--                      mid-run stays rewritten for every later suite, and Jest's file
+--                      order decides who runs later. That is what broke
+--                      freemium-gates with 14 × 401 (issue #620).
 
 -- Legality entries (required FK for some queries)
 INSERT INTO legality (card_id, format, status)


### PR DESCRIPTION
Two small, independent fixes grouped because both are low-risk and locally verifiable.

Closes #620
Closes #631

## #620 — integration suites fail depending on execution order

`api-user`'s `PATCH /api/v1/user/password` rewrote `mutation@test.com`'s password
mid-run. `freemium-gates` logs in as that same user, so whichever order Jest picked
decided whether CI was green — 14 × 401 when `api-user` went first.

Fix: a dedicated `pwchange@test.com` that nothing else logs in as.

**One correction to the issue's diagnosis.** The suggested `ON CONFLICT DO UPDATE`
seed alone would *not* have fixed this: `scripts/test-integ.sh` does `down -v` on
entry, so the seed always runs against an empty table and never re-runs between
suites. It cannot repair a mutation that happens mid-run. The seed change is in
anyway — it helps a run against a reused database — but the dedicated user is what
actually fixes it.

### Verified, not assumed

A throwaway sequencer forced alphabetical order, putting `api-user` 12th and
`freemium-gates` 17th — the exact failing arrangement from the issue:

| | Result |
|---|---|
| `main`, forced order | **14 failed**, 286 passed |
| this branch, same forced order | **300 passed**, 28/28 suites |

## #631 — `safeBoolean` defaults to true

Every boolean query param was on unless explicitly disabled. `baseOnly` inherited
that, so `GET /api/v1/sets/{code}/cards` quietly filters out variant printings while
its Swagger text reads as off-unless-asked.

- `safeBoolean` now defaults to `false` — a flag is off unless it opts in.
- `SafeQueryOptions` passes `true` explicitly for `ascend` and `baseOnly`, so the
  on-by-default is visible at the call site.
- Both `baseOnly` `@ApiQuery` descriptions now state the default.

**No behavior change** — both params still default to true. Flipping `baseOnly`
itself would break the API and is deliberately not done here. New unit tests pin
both the helper's default and the DTO's.

## Checks

- `npm test` — 1530 passed, 127 suites
- `./scripts/test-integ.sh` — 300 passed, 28 suites (default order and forced order)
- `prettier --check` clean on all touched files